### PR TITLE
LSN01 Design note udpates

### DIFF
--- a/DesignNotes/LDN00 - Design Note Process.md
+++ b/DesignNotes/LDN00 - Design Note Process.md
@@ -13,9 +13,6 @@ status: draft
 
 This Design Note describes the process for making and disseminating architecturally important design decisions through Design Notes in Project Langworthy (cross-platform Windows Runtime). 
 
-## Revisions
- * 2018-06-13, First Draft created from 1ES design note docs by Harry Pierson
-
 ## 1. The Purpose
 In any project, the process for making and documenting decisions defines the character of the endeavor.  Project Langworthy is small now, but is likely to grow and become a collaborative effort across multiple divisions of Microsoft as well as the open source community.
 

--- a/DesignNotes/LDN01 - A Strategy for Language Interoperability.md
+++ b/DesignNotes/LDN01 - A Strategy for Language Interoperability.md
@@ -15,12 +15,6 @@ Abstract
 
 This design note describes the goals and guiding principles of the Langworthy project. This document is aspirational: It describes the project and its features as it has been envisioned, and may include references to features or characteristics that have not yet been implemented.
 
-Revisions
----------
-
--   2018-07-05, First Draft by Harry Pierson
--   2018-09-11, Clarifications and additional text by Ben Kuhn
-
 Overview
 --------
 

--- a/DesignNotes/LDN03 - Type System Specification.md
+++ b/DesignNotes/LDN03 - Type System Specification.md
@@ -15,9 +15,6 @@ This Design Note describes the Langworthy type system.
 
 > Note, this document is 1/2 of the original WinRT Consolidated Reference and has not yet been updated to use cross-platfrom terminology 
 
-## Revisions
- * 2018-07-03, First Draft created from WinRT Consolidated Reference by Harry Pierson
-
 General Notes
 -------------
 

--- a/DesignNotes/LDN04 - Metadata Representation.md
+++ b/DesignNotes/LDN04 - Metadata Representation.md
@@ -15,9 +15,6 @@ This Design Note describes how Langworthy types are encoded in metadata files.
 
 > Note, this document is 1/2 of the original WinRT Consolidated Reference and has not yet been updated to use cross-platfrom terminology
 
-## Revisions
- * 2018-07-03, First Draft created from WinRT Consolidated Reference by Harry Pierson
-
 Overview
 --------
 

--- a/DesignNotes/LDN05 - Platform Abstraction Layer.md
+++ b/DesignNotes/LDN05 - Platform Abstraction Layer.md
@@ -13,10 +13,6 @@ status: draft
 
 This design note documents the platform abstraction layer (or PAL) for Langworthy.
 
-## Revisions
- * 2018-09-06, First Draft created by Ryan Shepherd
-
-
 Overview
 --------
 Langworthy language projections depend on language-agnostic functionality that is provided by the underlying platform. Activating types, allocating shared cross-module memory and strings all require some built in functionality that's provided for app code and/or language projections.

--- a/DesignNotes/design note template.md
+++ b/DesignNotes/design note template.md
@@ -13,9 +13,6 @@ status: template
 
 This document is a template for Project Langworthy Design Notes. All major features and behaviors of project Langworthy are documented in a Design Note submitted to the repository.
 
-## Revisions
- * 2018-06-13, First Draft by Harry Pierson
-
 ## Specification Section 1
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vehicula lorem vitae leo lobortis, et fermentum nulla semper. Sed auctor elementum ligula quis tristique. Vestibulum id metus a sapien eleifend mollis at a diam. Vivamus pharetra elit non fringilla aliquet. Suspendisse et rutrum urna, nec rutrum nisl. Praesent eu ligula eu tellus blandit commodo. Etiam odio est, pharetra ac tincidunt eget, imperdiet a diam. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Curabitur commodo dui in egestas vehicula. Donec nec odio diam. Quisque ac consectetur nulla. Nunc non urna vitae nisl iaculis varius. Pellentesque sit amet ante et justo gravida consectetur. Nulla ipsum sapien, volutpat sit amet aliquet a, dignissim eget enim. Quisque ex risus, euismod vel sapien id, sagittis scelerisque sem. 


### PR DESCRIPTION
I've made a few changes to reduce the number of references to the project code name. I've also added clarification on some of the wording: defined acronyms, expanded the background, and reduced reliance on references to Windows concepts. It's enough to say that it borrows heavily from the Windows Runtime. Beyond that, the documentation should largely stand on its own.
