### PR TITLE
Added code owners to enforce reviewer policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# See https://help.github.com/articles/about-codeowners/
+
+# * @BenJKuhn @BrentRe @DefaultRyan @devhawk @dunhor @kennykerr @loarabia @manodasanW @Scottj1s 
+
+* @BenJKuhn @DefaultRyan @devhawk @kennykerr @Scottj1s 
+
+/src/library/ @kennykerr  
+/src/test/cpp/ @kennykerr
+/src/tool/cpp/ @kennykerr
+/src/tool/idl/ @kennykerr
+
+/src/platform/ @DefaultRyan 
+/src/test/platform/ @DefaultRyan 
+
+/src/scripts/ @devhawk  
+/src/test/python/ @devhawk  
+/src/tool/python/ @devhawk  
+
+/src/tool/python/ @Scottj1s

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 /src/test/python/ @devhawk  
 /src/tool/python/ @devhawk  
 
-/src/tool/python/ @Scottj1s
+/src/tool/natvis/ @Scottj1s


### PR DESCRIPTION
Looking for general agreement on this idea, which Kenny asked for.  GitHub code owners are required reviewers for any PRs affecting files under their respective paths of ownership.  Later rules overrule earlier ones, so the one on line 5 is the default.