### PR TITLE
C:\Windows\SysWOW64\WinMetadata folder is no more

### DIFF
--- a/src/library/cmd_reader.h
+++ b/src/library/cmd_reader.h
@@ -139,7 +139,11 @@ namespace xlang::cmd
                 else if (path == "local")
                 {
                     std::array<char, MAX_PATH> local{};
+#ifdef _WIN64
                     ExpandEnvironmentStringsA("%windir%\\System32\\WinMetadata", local.data(), static_cast<DWORD>(local.size()));
+#else
+                    ExpandEnvironmentStringsA("%windir%\\SysNative\\WinMetadata", local.data(), static_cast<DWORD>(local.size()));
+#endif
                     add_directory(local.data());
                 }
 #endif


### PR DESCRIPTION
Ensure access is always to C:\Windows\System32\WinMetadata, regardless of WOW redirection.