### PR TITLE
Python/WinRT: Python Iterator support and _from function

### DIFF
--- a/src/test/python/CMakeLists.txt
+++ b/src/test/python/CMakeLists.txt
@@ -20,12 +20,8 @@ set(included_namespaces
 )
 
 set(excluded_namespaces
-    Windows.Foundation.Deferral
     Windows.Foundation.Diagnostics
-    Windows.Foundation.IPropertyValue
-    Windows.Foundation.IRef
     Windows.Foundation.Metadata
-    Windows.Foundation.PropertyValue
 )
 
 set(cmdline "-output ${output_dir}")
@@ -50,7 +46,6 @@ endforeach()
 get_filename_component(output_dir ${CMAKE_CURRENT_SOURCE_DIR}/output REALPATH)
 set(pybase_h ${output_dir}/pybase.h)
 
-message(${pybase_h})
 add_custom_command(
   OUTPUT ${pybase_h} 
   DEPENDS ${pywinrt_exe}

--- a/src/test/python/CMakeLists.txt
+++ b/src/test/python/CMakeLists.txt
@@ -7,9 +7,7 @@ file(TO_NATIVE_PATH "$ENV{WindowsSdkDir}References/$ENV{WindowsSDKVersion}" REFE
 
 set(winmd_files
     Windows.Foundation.FoundationContract
-    Windows.Devices.DevicesLowLevelContract
     Windows.Foundation.UniversalApiContract
-    Windows.AI.MachineLearning.MachineLearningContract
 )
 
 set(included_namespaces

--- a/src/test/python/testasfunction.py
+++ b/src/test/python/testasfunction.py
@@ -1,0 +1,17 @@
+import find_projection
+import _pyrt
+import unittest
+
+class TestQueryInterface(unittest.TestCase):
+    def test_as_function(self):
+        propset = _pyrt.PropertySet()
+        propset.Insert("strmap", _pyrt.StringMap())
+        self.assertTrue(propset.HasKey("strmap"))
+        o = propset.Lookup("strmap")
+        strmap = _pyrt.StringMap._as(o)
+        self.assertEqual(type(strmap), _pyrt.StringMap)
+
+if __name__ == '__main__':
+    _pyrt.init_apartment()
+    unittest.main()
+    _pyrt.uninit_apartment()

--- a/src/test/python/testfromfunction.py
+++ b/src/test/python/testfromfunction.py
@@ -8,7 +8,7 @@ class TestQueryInterface(unittest.TestCase):
         propset.Insert("strmap", _pyrt.StringMap())
         self.assertTrue(propset.HasKey("strmap"))
         o = propset.Lookup("strmap")
-        strmap = _pyrt.StringMap._as(o)
+        strmap = _pyrt.StringMap._from(o)
         self.assertEqual(type(strmap), _pyrt.StringMap)
 
 if __name__ == '__main__':

--- a/src/test/python/testgeoloc.py
+++ b/src/test/python/testgeoloc.py
@@ -35,6 +35,20 @@ class TestGeolocation(unittest.TestCase):
         for x in ["Latitude", "Longitude", "Altitude"]:
             self.assertEqual(basic_pos[x], getattr(center, x))
 
+    
+    def test_iiterable_wraping(self):
+        basic_pos1 = _pyrt.BasicGeoposition(47.1, -122.1, 0.0)
+        basic_pos2 = _pyrt.BasicGeoposition(47.2, -122.2, 0.0)
+
+        box = _pyrt.GeoboundingBox.TryCompute([basic_pos1, basic_pos2])
+        nw = box.get_NorthwestCorner()
+        se = box.get_SoutheastCorner()
+
+        self.assertAlmostEqual(nw.Latitude, basic_pos2.Latitude)
+        self.assertAlmostEqual(nw.Longitude, basic_pos2.Longitude)
+        self.assertAlmostEqual(se.Latitude, basic_pos1.Latitude)
+        self.assertAlmostEqual(se.Longitude, basic_pos1.Longitude)
+
     def test_GetGeopositionAsync(self):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)

--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -518,18 +518,20 @@ static PyType_Spec @_Type_spec =
 
     void write_type_query_interface(writer& w, TypeDef const& type)
     {
-        if (is_ptype(type))
+        if (is_ptype(type) || type.Flags().Abstract())
         {
             return;
         }
 
         auto format = R"(
-static PyObject* %__query_interface(PyObject* /*unused*/, PyObject* args)
+static PyObject* %__query_interface(PyObject* /*unused*/, PyObject* arg)
 {
-    return nullptr;
+    auto instance = py::converter<winrt::Windows::Foundation::IInspectable>::convert_to(arg);
+    return py::converter<%>::convert(instance.as<%>());
 }
 )";
-        w.write(format, type.TypeName());
+
+        w.write(format, type.TypeName(), type, type);
     }
     
     void write_type_method_decl_self_type(writer& w, TypeDef const& type, MethodDef const& method)

--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -1088,10 +1088,10 @@ static void @_dealloc(%* self)
             case ElementType::R8:
                 w.write("d");
                 break;
-            // TODO: string struct support 
-            //case ElementType::String:
-            //    w.write("winrt::hstring");
-            //    break;
+            // TODO: 'u' format string was deprecated in Python 3.3. Need to move to a supported construct
+            case ElementType::String:
+               w.write("u");
+               break;
             case ElementType::Object:
                 throw_invalid("structs cannot contain ElementType::Object");
             default:

--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -175,7 +175,7 @@ namespace xlang
 
         if (!(is_ptype(type) || is_static_class(type)))
         {
-            w.write("    { \"_as\", (PyCFunction)@__as, METH_O | METH_STATIC, nullptr },\n", type.TypeName());
+            w.write("    { \"_from\", (PyCFunction)@__from, METH_O | METH_STATIC, nullptr },\n", type.TypeName());
         }
 
         w.write("    { nullptr }\n};\n");
@@ -524,7 +524,7 @@ static PyType_Spec @_Type_spec =
         }
 
         auto format = R"(
-static PyObject* %__as(PyObject* /*unused*/, PyObject* arg)
+static PyObject* %__from(PyObject* /*unused*/, PyObject* arg)
 {
     try
     {

--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -1019,7 +1019,7 @@ static void @_dealloc(%* self)
         w.write_indented("PyObject* py::converter<%>::convert(% instance) noexcept\n{\n", type, type);
         {
             writer::indent_guard g{ w };
-            w.write_indented("return py::wrap_struct<%>(instance, py::winrt_type<%>::get_python_type());\n", type, type);
+            w.write_indented("return py::wrap_struct<%>(instance, py::get_python_type<%>());\n", type, type);
         }
         w.write_indented("}\n\n");
 
@@ -1027,7 +1027,7 @@ static void @_dealloc(%* self)
         {
             writer::indent_guard g{ w };
             w.write_indented("throw_if_pyobj_null(obj);\n");
-            w.write_indented(R"(if (Py_TYPE(obj) == py::winrt_type<%>::get_python_type())
+            w.write_indented(R"(if (Py_TYPE(obj) == py::get_python_type<%>())
 {
     return reinterpret_cast<py::winrt_struct_wrapper<%>*>(obj)->obj;
 }

--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -173,6 +173,11 @@ namespace xlang
                 name, type.TypeName(), name, bind<write_method_table_flags>(overloads));
         }
 
+        if (!is_ptype(type))
+        {
+            w.write("    { \"_query_interface\", (PyCFunction)@__query_interface, METH_O | METH_STATIC, nullptr },\n", type.TypeName());
+        }
+
         w.write("    { nullptr }\n};\n");
     }
 
@@ -510,6 +515,22 @@ static PyType_Spec @_Type_spec =
             write_method_overload<F>(w, type, overloads);
         }
     }
+
+    void write_type_query_interface(writer& w, TypeDef const& type)
+    {
+        if (is_ptype(type))
+        {
+            return;
+        }
+
+        auto format = R"(
+static PyObject* %__query_interface(PyObject* /*unused*/, PyObject* args)
+{
+    return nullptr;
+}
+)";
+        w.write(format, type.TypeName());
+    }
     
     void write_type_method_decl_self_type(writer& w, TypeDef const& type, MethodDef const& method)
     {
@@ -690,6 +711,7 @@ static void @_dealloc(%* self)
         write_winrt_type_specialization_storage(w, type);
         write_class_constructor(w, type);
         write_class_dealloc(w, type);
+        write_type_query_interface(w, type);
         write_type_functions(w, type);
         write_method_table(w, type);
         write_type_slot_table(w, type);
@@ -875,6 +897,7 @@ static void @_dealloc(%* self)
         write_winrt_type_specialization_storage(w, type);
         write_interface_constructor(w, type);
         write_interface_dealloc(w, type);
+        write_type_query_interface(w, type);
         write_type_functions(w, type);
         write_method_table(w, type);
         write_type_slot_table(w, type);

--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -279,10 +279,13 @@ static PyType_Spec @_Type_spec =
             w.write("            % param% { % };\n", param.second->Type(), sequence, bind<write_out_param_init>(param));
             break;
         case param_category::pass_array:
-            w.write("            /*p*/ winrt::array_view<% const> param% {}; //= py::convert_to<winrt::array_view<% const>>(args, %);\n", param.second->Type(), sequence, param.second->Type(), sequence);
+            w.write("            /*p*/ winrt::array_view<% const> param% { };\n // TODO: Convert incoming python parameter", param.second->Type(), sequence);
+            break;
+        case param_category::fill_array:
+            w.write("            /*f*/ winrt::array_view<%> param% { };\n // TODO: Convert incoming python parameter", param.second->Type(), sequence);
             break;
         case param_category::receive_array:
-            w.write("            /*r*/ winrt::array_view<%> param% { };\n", param.second->Type(), sequence);
+            w.write("            /*r*/ winrt::com_array<%> param% { };\n", param.second->Type(), sequence);
             break;
         default:
             throw_invalid("write_param_conversion not impl");

--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -279,10 +279,10 @@ static PyType_Spec @_Type_spec =
             w.write("            % param% { % };\n", param.second->Type(), sequence, bind<write_out_param_init>(param));
             break;
         case param_category::pass_array:
-            w.write("            /*p*/ winrt::array_view<% const> param% { };\n // TODO: Convert incoming python parameter", param.second->Type(), sequence);
+            w.write("            /*p*/ winrt::array_view<% const> param% { }; // TODO: Convert incoming python parameter\n", param.second->Type(), sequence);
             break;
         case param_category::fill_array:
-            w.write("            /*f*/ winrt::array_view<%> param% { };\n // TODO: Convert incoming python parameter", param.second->Type(), sequence);
+            w.write("            /*f*/ winrt::array_view<%> param% { }; // TODO: Convert incoming python parameter\n", param.second->Type(), sequence);
             break;
         case param_category::receive_array:
             w.write("            /*r*/ winrt::com_array<%> param% { };\n", param.second->Type(), sequence);

--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -350,6 +350,14 @@ static PyType_Spec @_Type_spec =
     {
         auto guard{ w.push_generic_params(info.type_arguments) };
 
+        if (get_param_category(signature.return_signature()) == param_category::receive_array)
+        {
+            w.write(R"(        // returning a ReceiveArray not impl
+        return nullptr;
+)");
+            return;
+        }
+
         w.write("        try\n        {\n");
         for (auto&& param : signature.params())
         {

--- a/src/tool/python/file_writers.h
+++ b/src/tool/python/file_writers.h
@@ -29,6 +29,9 @@ namespace xlang
         w.write("\nnamespace py\n{\n");
         {
             writer::indent_guard g{ w };
+            f.bind_each<write_winrt_type_specialization>(members.classes)(w);
+            f.bind_each<write_winrt_type_specialization>(members.interfaces)(w);
+            f.bind_each<write_winrt_type_specialization>(members.structs)(w);
             f.bind_each<write_struct_converter_decl>(members.structs)(w);
             f.bind_each<write_pinterface_type_mapper>(members.interfaces)(w);
             f.bind_each<write_delegate_type_mapper>(members.delegates)(w);

--- a/src/tool/python/helpers.h
+++ b/src/tool/python/helpers.h
@@ -547,6 +547,18 @@ namespace xlang
         }
     }
 
+    auto get_param_category(RetTypeSig const& sig)
+    {
+        if (sig.Type().is_szarray())
+        {
+            return param_category::receive_array;
+        }
+        else
+        {
+            return param_category::out;
+        }
+    }
+
     bool is_in_param(method_signature::param_t const& param)
     {
         auto category = get_param_category(param);

--- a/src/tool/python/helpers.h
+++ b/src/tool/python/helpers.h
@@ -400,6 +400,11 @@ namespace xlang
         return distance(type.GenericParam()) > 0;
     }
 
+    bool is_static_class(TypeDef const& type)
+    {
+        return get_category(type) == category::class_type && type.Flags().Abstract();
+    }
+
     bool is_constructor(MethodDef const& method)
     {
         return method.Flags().RTSpecialName() && method.Name() == ".ctor";

--- a/src/tool/python/helpers.h
+++ b/src/tool/python/helpers.h
@@ -524,12 +524,12 @@ namespace xlang
             else if (param.second->ByRef())
             {
                 XLANG_ASSERT(param.first.Flags().Out());
-                return param_category::fill_array;
+                return param_category::receive_array;
             }
             else
             {
                 XLANG_ASSERT(param.first.Flags().Out());
-                return param_category::receive_array;
+                return param_category::fill_array;
             }
         }
         else
@@ -551,12 +551,16 @@ namespace xlang
     {
         auto category = get_param_category(param);
 
-        if (category == param_category::fill_array)
-        {
-            throw_invalid("fill aray param not impl");
-        }
+        return (category == param_category::in 
+             || category == param_category::pass_array 
+             || category == param_category::fill_array);
+    }
 
-        return (category == param_category::in || category == param_category::pass_array);
+    bool is_out_param(method_signature::param_t const& param)
+    {
+        auto category = get_param_category(param);
+
+        return (category == param_category::out || category == param_category::receive_array);
     }
 
     int count_in_param(std::vector<method_signature::param_t> const& params)
@@ -580,7 +584,7 @@ namespace xlang
 
         for (auto&& param : params)
         {
-            if (!is_in_param(param))
+            if (is_out_param(param))
             {
                 count++;
             }

--- a/src/tool/python/strings/pybase.h
+++ b/src/tool/python/strings/pybase.h
@@ -653,8 +653,8 @@ namespace py
                         return {};
                     }
                 }
-                
-                return std::move(converter<T>::convert_to(next));
+
+                return std::move(std::optional<T>{ converter<T>::convert_to(next) });
             }
 
             iterator(PyObject* i) : _iterator(i)
@@ -693,7 +693,7 @@ namespace py
 
     // TODO: specalization for Python Sequence Protocol -> IVector[View]
     // TODO: specalization for Python Mapping Protocol -> IMap[View]
-    
+
     template <typename T>
     std::optional<T> convert_interface_to(PyObject* obj)
     {

--- a/src/tool/python/strings/pybase.h
+++ b/src/tool/python/strings/pybase.h
@@ -691,9 +691,6 @@ namespace py
         };
     };
 
-    // TODO: specalization for Python Sequence Protocol -> IVector[View]
-    // TODO: specalization for Python Mapping Protocol -> IMap[View]
-
     template <typename T>
     std::optional<T> convert_interface_to(PyObject* obj)
     {
@@ -712,6 +709,9 @@ namespace py
 
         return {};
     }
+
+    // TODO: specalization for Python Sequence Protocol -> IVector[View]
+    // TODO: specalization for Python Mapping Protocol -> IMap[View]
 
     template <typename TItem>
     struct converter<winrt::Windows::Foundation::Collections::IIterable<TItem>>

--- a/src/tool/python/strings/pybase.h
+++ b/src/tool/python/strings/pybase.h
@@ -442,6 +442,26 @@ namespace py
         }
     };
 
+    template <>
+    struct converter<winrt::Windows::Foundation::IInspectable>
+    {
+        static PyObject* convert(winrt::Windows::Foundation::IInspectable value) noexcept
+        {
+            return wrap<winrt::Windows::Foundation::IInspectable>(value, winrt_type<winrt_base>::python_type);
+        }
+
+        static winrt::Windows::Foundation::IInspectable convert_to(PyObject* obj)
+        {
+            if (PyObject_IsInstance(obj, reinterpret_cast<PyObject*>(winrt_type<winrt_base>::python_type)) == 0)
+            {
+                throw winrt::hresult_invalid_argument();
+            }
+
+            auto wrapper = reinterpret_cast<winrt_wrapper_base*>(obj);
+            return as<winrt::Windows::Foundation::IInspectable>(wrapper);
+        }
+    };
+
     struct pystring
     {
         wchar_t* buffer{ nullptr };

--- a/src/tool/python/strings/pybase.h
+++ b/src/tool/python/strings/pybase.h
@@ -122,7 +122,24 @@ namespace py
     struct winrt_base;
 
     template<typename T>
-    struct winrt_type { static PyTypeObject* python_type; };
+    struct winrt_type 
+    { 
+        static PyTypeObject* get_python_type()
+        {
+            return nullptr;
+        }
+    };
+
+    template<>
+    struct winrt_type<winrt_base>
+    {
+        static PyTypeObject* python_type;
+
+        static PyTypeObject* get_python_type()
+        {
+            return python_type;
+        }
+    };
 
     inline __declspec(noinline) PyObject* to_PyErr() noexcept
     {
@@ -217,7 +234,7 @@ namespace py
     {
         using ptype = pinterface_python_type<T>;
 
-        PyTypeObject* type_object = winrt_type<ptype::abstract>::python_type;
+        PyTypeObject* type_object = winrt_type<ptype::abstract>::get_python_type();
 
         if (type_object == nullptr)
         {
@@ -247,7 +264,7 @@ namespace py
     {
         if constexpr (is_class_category_v<T> || is_interface_category_v<T>)
         {
-            return wrap<T>(instance, winrt_type<T>::python_type);
+            return wrap<T>(instance, winrt_type<T>::get_python_type());
         }
         else
         {
@@ -513,7 +530,7 @@ namespace py
         }
         else if constexpr (is_struct_category_v<T>)
         {
-            return wrap_struct<T>(instance, winrt_type<T>::python_type);
+            return wrap_struct<T>(instance, winrt_type<T>::get_python_type());
         }
         else if constexpr (is_basic_category_v<T>)
         {
@@ -536,7 +553,7 @@ namespace py
 
         if constexpr (is_class_category_v<T>)
         {
-            if (Py_TYPE(arg) != winrt_type<T>::python_type)
+            if (Py_TYPE(arg) != winrt_type<T>::get_python_type())
             {
                 throw winrt::hresult_invalid_argument();
             }
@@ -545,12 +562,12 @@ namespace py
         }
         else if constexpr (is_interface_category_v<T>)
         {
-            if (Py_TYPE(arg) == winrt_type<T>::python_type)
+            if (Py_TYPE(arg) == winrt_type<T>::get_python_type())
             {
                 return reinterpret_cast<winrt_wrapper<T>*>(arg)->obj;
             }
 
-            if (PyObject_IsInstance(arg, reinterpret_cast<PyObject*>(winrt_type<winrt_base>::python_type)) == 0)
+            if (PyObject_IsInstance(arg, reinterpret_cast<PyObject*>(winrt_type<winrt_base>::get_python_type())) == 0)
             {
                 throw winrt::hresult_invalid_argument();
             }
@@ -582,7 +599,7 @@ namespace py
         }
         else if constexpr (is_struct_category_v<T>)
         {
-            if (Py_TYPE(arg) == winrt_type<T>::python_type)
+            if (Py_TYPE(arg) == winrt_type<T>::get_python_type())
             {
                 return reinterpret_cast<winrt_struct_wrapper<T>*>(arg)->obj;
             }

--- a/src/tool/python/type_writers.h
+++ b/src/tool/python/type_writers.h
@@ -394,7 +394,7 @@ namespace xlang
                 write("bool");
                 break;
             case ElementType::Char:
-                write("wchar_t");
+                write("char16_t");
                 break;
             case ElementType::I1:
                 write("int8_t");


### PR DESCRIPTION
This PR adds two major projection features:

* the ability to pass [Python Iterator types](https://docs.python.org/3/library/stdtypes.html#iterator-types) for WinRT IIterable<T> parameters 
   * Passing [Python Sequence Types](https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range)as WinRT IVector and [Python Mapping Types](https://docs.python.org/3/library/stdtypes.html#mapping-types-dict) as WinRT IMap will come in a later update
* Exposes a static ~~_as~~ _from method on projected classes and concrete interfaces to enable type casting (i.e. QueryInterface)

Other changes
* reworked python type mapping to eliminate linker errors when a projected type has parameters of an unprojected type
   * UniversalApiContract is large, so for projection developer inner loop it is often preferable to only project a small subset of the overall contract. This feature enables more of UniversalApiContract to be projected piecemeal *during projection development*
* refactored WinRT <--> Python converter code in pybase.h to enable specializations (used to enable projecting Python iterators as IIterable<T>)
* fixed array parameter categorization and updated generation of array parameters to actually compile.
   * Note, methods with array parameters still don't work, but at least they compile so you can generate code for a type that has array parameters and all the non-array parametered methods will still work as expected 

Sample projected code (with diff vs. previous Python PR!) is available here: https://github.com/devhawk/pywinrt-output/tree/iterables