### PR TITLE
Fix ubuntu build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# explicitly mark shell scripts as having LF line endings
+*.sh text eol=lf

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,4 +98,8 @@ endif()
 
 add_subdirectory(tool)
 add_subdirectory(test)
+
+# TODO: enable platform compiling on Ubuntu
+if (WIN32)
 add_subdirectory(platform)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,8 +98,4 @@ endif()
 
 add_subdirectory(tool)
 add_subdirectory(test)
-
-# TODO: enable platform compiling on Ubuntu
-if (WIN32)
 add_subdirectory(platform)
-endif()

--- a/src/library/cmd_reader.h
+++ b/src/library/cmd_reader.h
@@ -13,6 +13,23 @@ namespace xlang::cmd
 
     struct reader
     {
+    private:
+        auto find(std::vector<option> const& options, std::string_view const& arg)
+        {
+            for (auto current = options.begin(); current != options.end(); ++current)
+            {
+                if (starts_with(current->name, arg))
+                {
+                    return current;
+                }
+            }
+
+            return options.end();
+        }
+
+        std::map<std::string_view, std::vector<std::string>> m_options;
+        
+    public:
         template <typename C, typename V>
         reader(C const argc, V argv, std::vector<option> const& options)
         {
@@ -155,22 +172,5 @@ namespace xlang::cmd
 
             return files;
         }
-
-    private:
-
-        auto find(std::vector<option> const& options, std::string_view const& arg)
-        {
-            for (auto current = options.begin(); current != options.end(); ++current)
-            {
-                if (starts_with(current->name, arg))
-                {
-                    return current;
-                }
-            }
-
-            return options.end();
-        }
-
-        std::map<std::string_view, std::vector<std::string>> m_options;
     };
 }

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -10,7 +10,7 @@ set(sources string_abi.cpp string_base.cpp)
 if (WIN32)
     set(sources ${sources} win32_memory.cpp win32_string_convert.cpp)
 else()
-    set(sources ${sources} common_memory.cpp)
+    set(sources ${sources} common_memory.cpp common_string_convert.cpp)
 endif()
 
 add_definitions(-DXLANG_PAL_EXPORTS)

--- a/src/platform/cache_string.h
+++ b/src/platform/cache_string.h
@@ -3,9 +3,9 @@
 #include <memory>
 #include "pal_internal.h"
 #include "atomic_ref_count.h"
-#include "string_base.h"
 #include "string_allocate.h"
 #include "string_convert.h"
+#include "string_traits.h"
 
 namespace xlang::impl
 {
@@ -54,7 +54,7 @@ namespace xlang::impl
     }
 
     template <typename char_type>
-    static std::unique_ptr<cache_string, xlang_mem_deleter> cache_string::create(char_type const* source_string, uint32_t length)
+    std::unique_ptr<cache_string, xlang_mem_deleter> cache_string::create(char_type const* source_string, uint32_t length)
     {
         static_assert(std::disjunction_v<std::is_same<char_type, xlang_char8>, std::is_same<char_type, char16_t>>, "char_t must be either xlang_char8 or char16_t");
         using alternate_char_type = typename alternate_type<char_type>::result_type;

--- a/src/platform/common_memory.cpp
+++ b/src/platform/common_memory.cpp
@@ -7,7 +7,7 @@
 
 extern "C"
 {
-    void* XLANG_CALL xlang_mem_alloc(size_t count)
+    void* XLANG_CALL xlang_mem_alloc(size_t count) noexcept
     {
         if (count == 0)
         {
@@ -16,7 +16,7 @@ extern "C"
         return ::malloc(count);
     }
 
-    void XLANG_CALL xlang_mem_free(void* ptr)
+    void XLANG_CALL xlang_mem_free(void* ptr) noexcept
     {
         ::free(ptr);
     }

--- a/src/platform/common_string_convert.cpp
+++ b/src/platform/common_string_convert.cpp
@@ -1,0 +1,39 @@
+#include "pal_internal.h"
+#include "string_convert.h"
+
+namespace xlang::impl
+{
+    uint32_t get_converted_length(char16_t const* input_str, uint32_t input_length)
+    {
+        return convert_string(input_str, input_length, nullptr, 0);
+    }
+
+    uint32_t get_converted_length(xlang_char8 const* input_str, uint32_t input_length)
+    {
+        return convert_string(input_str, input_length, nullptr, 0);
+    }
+
+    uint32_t convert_string(
+        char16_t const* input_str,
+        uint32_t input_length,
+        xlang_char8* output_buffer,
+        uint32_t buffer_length)
+    {
+        static_assert(sizeof(xlang_char8) == sizeof(char));
+ 
+        // TODO: implement convert_string for non-windows platforms (#47)
+        throw_result(xlang_error_sadness);
+    }
+    
+    uint32_t convert_string(
+        xlang_char8 const* input_str,
+        uint32_t input_length,
+        char16_t* output_buffer,
+        uint32_t buffer_length)
+    {
+        static_assert(sizeof(xlang_char8) == sizeof(char));
+
+        // TODO: implement convert_string for non-windows platforms (#47)
+        throw_result(xlang_error_sadness);
+    }
+}

--- a/src/platform/heap_string.h
+++ b/src/platform/heap_string.h
@@ -67,7 +67,7 @@ namespace xlang::impl
     };
 
     template <typename char_type>
-    static heap_string* heap_string::create(
+    heap_string* heap_string::create(
         char_type const* source_string,
         uint32_t length)
     {
@@ -79,7 +79,7 @@ namespace xlang::impl
     }
 
     template <typename char_type>
-    static heap_string* heap_string::create(
+    heap_string* heap_string::create(
         char_type const* source_string,
         uint32_t length,
         cache_string* alternate)
@@ -92,7 +92,7 @@ namespace xlang::impl
     }
 
     template <typename char_type>
-    static heap_string* heap_string::create_preallocated(uint32_t length)
+    heap_string* heap_string::create_preallocated(uint32_t length)
     {
         heap_string* result = heap_string::create_impl<char_type>(nullptr, length, nullptr);
         result->mutable_buffer<char_type>()[length] = 0;

--- a/src/platform/pal_internal.h
+++ b/src/platform/pal_internal.h
@@ -5,7 +5,12 @@
 
 #ifdef _DEBUG
 
+#if XLANG_COMPILER_MSVC
 #define XLANG_ASSERT _ASSERTE
+#else
+#include <cassert>
+#define XLANG_ASSERT assert
+#endif
 #define XLANG_VERIFY XLANG_ASSERT
 #define XLANG_VERIFY_(result, expression) XLANG_ASSERT(result == expression)
 
@@ -30,6 +35,12 @@ namespace xlang
         throw xlang_error{ result };
     }
 
+// TODO: rework to_result to avoid exceptions warning on clang
+#if XLANG_COMPILER_CLANG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexceptions"
+#endif
+
     inline xlang_result to_result() noexcept
     {
         try
@@ -45,4 +56,8 @@ namespace xlang
             return xlang_error_out_of_memory;
         }
     }
+
+#if XLANG_COMPILER_CLANG
+#pragma clang diagnostic pop
+#endif
 }

--- a/src/platform/published/pal.h
+++ b/src/platform/published/pal.h
@@ -19,7 +19,7 @@
 #ifdef _MSC_VER
 #define XLANG_COMPILER_CLANG 0
 #define XLANG_COMPILER_MSVC 1
-#elif
+#elif defined(__clang__)
 #define XLANG_COMPILER_CLANG 1
 #define XLANG_COMPILER_MSVC 0
 #else
@@ -118,6 +118,12 @@ extern "C"
         return static_cast<xlang_string_encoding>(static_cast<int_t>(lhs) & static_cast<int_t>(rhs));
     }
 
+// TODO: rework operator |= and &= to avoid return-type-c-linkage linkage warning on clang
+#if XLANG_COMPILER_CLANG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#endif
+
     inline constexpr xlang_string_encoding& operator|=(xlang_string_encoding& lhs, xlang_string_encoding rhs) noexcept
     {
         lhs = lhs | rhs;
@@ -129,6 +135,11 @@ extern "C"
         lhs = lhs & rhs;
         return lhs;
     }
+
+#if XLANG_COMPILER_CLANG
+#pragma clang diagnostic pop
+#endif
+
 #else
     enum xlang_string_encoding
     {

--- a/src/platform/string_abi.cpp
+++ b/src/platform/string_abi.cpp
@@ -55,8 +55,8 @@ namespace xlang::impl
 
         if (length != 0)
         {
-            static_assert(sizeof(string_storage_base) == sizeof(xlang_string_header), "xlang_string_header must be same size as string_storage_base");
-            return to_handle(string_reference::create(source_string, length, reinterpret_cast<string_storage_base*>(header)));
+            static_assert(sizeof(string_reference) == sizeof(xlang_string_header), "xlang_string_header must be same size as string_storage_base");
+            return to_handle(string_reference::create(source_string, length, reinterpret_cast<string_reference*>(header)));
         }
 
         return nullptr;

--- a/src/platform/string_base.h
+++ b/src/platform/string_base.h
@@ -2,7 +2,10 @@
 
 #include <atomic>
 #include <type_traits>
+#include <algorithm>
 #include "pal_internal.h"
+#include "cache_string.h"
+#include "string_traits.h"
 
 namespace xlang::impl
 {
@@ -78,30 +81,6 @@ namespace xlang::impl
             // Points to a UTF-16 or UTF-8 string buffer
             void const* string_ref{ nullptr };
         };
-    };
-
-    struct cache_string;
-
-    template <typename char_type>
-    struct alternate_type;
-
-    template <>
-    struct alternate_type<xlang_char8>
-    {
-        using result_type = char16_t;
-    };
-
-    template <>
-    struct alternate_type<char16_t>
-    {
-        using result_type = xlang_char8;
-    };
-
-    template <typename char_type>
-    struct buffer_info
-    {
-        char_type const* buffer;
-        uint32_t length;
     };
 
     // String objects are represented by a set of classes that all derive from string_base. The

--- a/src/platform/string_reference.h
+++ b/src/platform/string_reference.h
@@ -13,7 +13,7 @@ namespace xlang::impl
         static string_reference* create(
             char_type const* source_string,
             uint32_t length,
-            string_storage_base* header
+            string_reference* header
         ) noexcept;
 
         // Read the ptr, but don't create it. May be null.
@@ -38,12 +38,13 @@ namespace xlang::impl
 
     // string references initialize in the space allocated by xlang_string_header. Size must match.
     static_assert(sizeof(string_reference) == sizeof(xlang_string_header), "size mismatch");
+    static_assert(sizeof(string_reference) == sizeof(string_storage_base), "size mismatch");
 
     template <typename char_type>
     inline string_reference* string_reference::create(
         char_type const* source_string,
         uint32_t length,
-        string_storage_base* header
+        string_reference* header
     ) noexcept
     {
         return (new (header) string_reference{ source_string, length });

--- a/src/platform/string_traits.h
+++ b/src/platform/string_traits.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdint.h>
+
+template <typename char_type>
+struct alternate_type;
+
+template <>
+struct alternate_type<xlang_char8>
+{
+    using result_type = char16_t;
+};
+
+template <>
+struct alternate_type<char16_t>
+{
+    using result_type = xlang_char8;
+};
+
+template <typename char_type>
+struct buffer_info
+{
+    char_type const* buffer;
+    uint32_t length;
+};

--- a/src/scripts/wslConfigureBionic.sh
+++ b/src/scripts/wslConfigureBionic.sh
@@ -1,6 +1,12 @@
 # run this in script in Ubuntu 18.04 for WSL
 #   sudo bash wslConfigBionic.sh 
 
+# Note, in order to run in WSL, this file *MUST* have Unix-style LF line endings.
+#       If you get errors like "'\r': command not found", this file has been mistakenly
+#       updated to have Windows-style CRLF line endings.
+#       .gitattributes file in this repo has been updated to ensure all .sh files 
+#       have LF only line endings.
+
 # update APT packages
 sudo apt update 
 sudo apt upgrade -y

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 3.9)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/inc")
 
-add_subdirectory(il)
-add_subdirectory(cpp)
-add_subdirectory(platform)
-add_subdirectory(python)
+if (WIN32)
+    add_subdirectory(il)
+    add_subdirectory(cpp)
+    # TODO: enable platform tests compiling on Ubuntu
+    add_subdirectory(platform)
+    add_subdirectory(python)
+endif()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.9)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/inc")
 
+add_subdirectory(platform)
+
 if (WIN32)
     add_subdirectory(il)
     add_subdirectory(cpp)
-    # TODO: enable platform tests compiling on Ubuntu
-    add_subdirectory(platform)
     add_subdirectory(python)
 endif()

--- a/src/tool/CMakeLists.txt
+++ b/src/tool/CMakeLists.txt
@@ -2,5 +2,8 @@ cmake_minimum_required(VERSION 3.9)
 
 add_subdirectory(cpp)
 add_subdirectory(idl)
-add_subdirectory(natvis)
 add_subdirectory(python)
+
+if (WIN32)
+    add_subdirectory(natvis)
+endif()

--- a/src/tool/cpp/code_writers.h
+++ b/src/tool/cpp/code_writers.h
@@ -706,7 +706,7 @@ template <> struct consume<@::%> { template <typename D> using type = consume_%<
         bool clear{};
         bool optional{};
 
-        visit(signature.Type(),
+        xlang::visit(signature.Type(),
             [&](ElementType type)
         {
             if (out && type == ElementType::Object)

--- a/src/tool/cpp/helpers.h
+++ b/src/tool/cpp/helpers.h
@@ -172,7 +172,7 @@ namespace xlang
 
         bool async{};
 
-        visit(method_signature.return_signature().Type().Type(),
+        xlang::visit(method_signature.return_signature().Type().Type(),
             [&](GenericTypeInstSig const& type)
         {
             auto generic_type = type.GenericType().TypeRef();
@@ -372,7 +372,7 @@ namespace xlang
     {
         bool wrap{};
 
-        visit(signature.Type(),
+        xlang::visit(signature.Type(),
             [&](ElementType type)
         {
             wrap = type == ElementType::String || type == ElementType::Object;
@@ -389,7 +389,7 @@ namespace xlang
     {
         bool object{};
 
-        visit(signature.Type(),
+        xlang::visit(signature.Type(),
             [&](ElementType type)
         {
             if (type == ElementType::Object)

--- a/src/tool/cpp/main.cpp
+++ b/src/tool/cpp/main.cpp
@@ -152,9 +152,9 @@ namespace xlang
             w.flush_to_console();
             task_group group;
 
-            for (auto&&[ns, members] : c.namespaces())
+            for (auto&& ns : c.namespaces())
             {
-                group.add([&]
+                group.add([&, &ns = ns.first, &members = ns.second]
                 {
                     if (!f.includes(members))
                     {

--- a/src/tool/cpp/type_writers.h
+++ b/src/tool/cpp/type_writers.h
@@ -435,7 +435,7 @@ namespace xlang
 
         void write(TypeSig::value_type const& type)
         {
-            visit(type,
+            xlang::visit(type,
                 [&](ElementType type)
             {
                 if (type == ElementType::Boolean) { write("bool"); }

--- a/src/tool/python/helpers.h
+++ b/src/tool/python/helpers.h
@@ -129,7 +129,7 @@ namespace xlang
 
         void handle(TypeSig const& signature)
         {
-            visit(signature.Type(),
+            xlang::visit(signature.Type(),
                 [&](auto&& type)
             {
                 static_cast<T*>(this)->handle(type);

--- a/src/tool/python/type_writers.h
+++ b/src/tool/python/type_writers.h
@@ -444,7 +444,7 @@ namespace xlang
 
         void write(TypeSig const& signature)
         {
-            visit(signature.Type(),
+            xlang::visit(signature.Type(),
                 [&](auto&& type)
             {
                 write(type);


### PR DESCRIPTION
changes to enable xlang tools, PAL and to compile on Ubuntu 18.04 with clang 6. Tested via Windwos Susbsytem for Linux.

Note, convert_string functions in PAL remain unimplemented on non-windows platforms. As such, 4 of the PAL tests fail on Ubuntu. #47 opened to track the issue, assigned to @DefaultRyan.