### PR TITLE
update windows build container

### DIFF
--- a/src/scripts/windows/Dockerfile
+++ b/src/scripts/windows/Dockerfile
@@ -5,7 +5,6 @@
 FROM microsoft/dotnet-framework:4.7.2-runtime-windowsservercore-1803
 
 ADD https://aka.ms/vs/15/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
-ADD https://go.microsoft.com/fwlink/p/?LinkID=2023014 c:\TEMP\winsdksetup.exe
 
 # https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2017
 RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
@@ -15,5 +14,3 @@ RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
     --add Microsoft.VisualStudio.Component.VC.ATL `
     --add Microsoft.Net.Component.4.6.1.SDK `
     --installPath C:\BuildTools
-
-RUN C:\TEMP\winsdksetup.exe /quiet /norestart /features OptionId.DesktopCPPx86 OptionId.DesktopCPPx64

--- a/src/scripts/windows/Dockerfile
+++ b/src/scripts/windows/Dockerfile
@@ -9,6 +9,7 @@ ADD https://aka.ms/vs/15/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 # https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2017
 RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
     --add Microsoft.VisualStudio.Workload.VCTools `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.17763 `
     --add Microsoft.VisualStudio.Component.VC.CMake.Project `
     --add Microsoft.VisualStudio.Component.VSSDKBuildTools `
     --add Microsoft.VisualStudio.Component.VC.ATL `

--- a/src/scripts/windows/azure-pipelines.yml
+++ b/src/scripts/windows/azure-pipelines.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: build_container
-    image:   msftxlang.azurecr.io/xlang-windows-build-test
+    image:   msftxlang.azurecr.io/xlang-windows-build
     endpoint: msftxlang_acr
 
 pool:

--- a/src/scripts/windows/azure-pipelines.yml
+++ b/src/scripts/windows/azure-pipelines.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: build_container
-    image:   msftxlang.azurecr.io/xlang-windows-build
+    image:   msftxlang.azurecr.io/xlang-windows-build-test
     endpoint: msftxlang_acr
 
 pool:


### PR DESCRIPTION
Removing seperate install of Windows 10 SDK. As of 15.9.1, VS Build Tools includes Windows 10 SDK v17763 (aka RS5 SDK). [Verified manually](https://dev.azure.com/msft-xlang/public/_build/results?buildId=135) that this new image works with our existing build infrastrucutre 

~~Note, the WIndows SDK is a required depenency of the cmake tooling (aka Microsoft.VisualStudio.Component.VC.CMake.Project). I think we should be specifying the Windows SDK on the build tools command line, but the docs are unclear on the topic. Waiting on feedback from VS team before committing.~~

VS team verified Windows 10 SDK v17763 component ID is same between VS and VS Build Tools, though it's not listed on the [VS Build tool component ID list page](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2017) (currently). Manually added to dockerfile to ensure correct installation in case vs build tool dependency tree changes in the future