### PR TITLE
C++/WinRT: Improved support for COM-style single interface inheritance

### DIFF
--- a/src/library/impl/meta_reader/cache.h
+++ b/src/library/impl/meta_reader/cache.h
@@ -133,7 +133,7 @@ namespace xlang::meta::reader
             return m_namespaces;
         }
 
-        void remove_legacy_cppwinrt_foundation_types()
+        void remove_cppwinrt_foundation_types()
         {
             auto remove = [&](auto&& ns, auto&& name)
             {

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -710,6 +710,12 @@ WINRT_EXPORT namespace winrt
         return impl::guid_storage<default_interface<T>>::value;
     }
 
+    template <typename T>
+    bool is_guid_of(guid const& id) noexcept
+    {
+        return id == guid_of<T>();
+    }
+
     struct event_token;
 
     template <typename T>
@@ -726,12 +732,6 @@ namespace winrt::impl
 
     template <typename T>
     struct is_fast_interface<fast_interface<T>> : std::true_type {};
-
-    template <typename T>
-    constexpr bool is_guid_of(guid const& id) noexcept
-    {
-        return id == guid_of<T>();
-    }
 
     template <size_t Size, typename T, size_t... Index>
     constexpr std::array<T, Size> to_array(T const* value, std::index_sequence<Index...> const) noexcept
@@ -1768,7 +1768,6 @@ WINRT_EXPORT namespace winrt
 namespace winrt::impl
 {
     inline constexpr hresult error_ok{ 0 }; // S_OK
-    inline constexpr hresult error_false{ 1 }; // S_FALSE
     inline constexpr hresult error_fail{ static_cast<hresult>(0x80004005) }; // E_FAIL
     inline constexpr hresult error_access_denied{ static_cast<hresult>(0x80070005) }; // E_ACCESSDENIED
     inline constexpr hresult error_wrong_thread{ static_cast<hresult>(0x8001010E) }; // RPC_E_WRONG_THREAD

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -710,10 +710,10 @@ WINRT_EXPORT namespace winrt
         return impl::guid_storage<default_interface<T>>::value;
     }
 
-    template <typename T>
+    template <typename... T>
     bool is_guid_of(guid const& id) noexcept
     {
-        return id == guid_of<T>();
+        return ((id == guid_of<T>()) || ...);
     }
 
     struct event_token;

--- a/src/test/cpp/test/Interop.cpp
+++ b/src/test/cpp/test/Interop.cpp
@@ -18,15 +18,12 @@ namespace winrt
 {
     template<> bool is_guid_of<IDerived>(guid const& id) noexcept
     {
-        return id == guid_of<IDerived>() ||
-               id == guid_of<IBase>();
+        return is_guid_of<IDerived, IBase>(id);
     }
 
     template<> bool is_guid_of<IMoreDerived>(guid const& id) noexcept
     {
-        return id == guid_of<IMoreDerived>() ||
-               id == guid_of<IDerived>() ||
-               id == guid_of<IBase>();
+        return is_guid_of<IMoreDerived, IDerived, IBase>(id);
     }
 }
 

--- a/src/test/cpp/test/Interop.cpp
+++ b/src/test/cpp/test/Interop.cpp
@@ -2,7 +2,47 @@
 #include <inspectable.h>
 #include "winrt/Windows.Foundation.h"
 
+struct __declspec(uuid("5040a5f4-796a-42ff-9f06-be89137a518f")) IBase : IUnknown
+{
+};
+
+struct __declspec(uuid("529fed32-514f-4150-b1ba-15b47df700b7")) IDerived : IBase
+{
+};
+
+struct __declspec(uuid("b81fb2a2-eab4-488a-96a7-434873c2c20b")) IMoreDerived : IDerived
+{
+};
+
+namespace winrt
+{
+    template<> bool is_guid_of<IDerived>(guid const& id) noexcept
+    {
+        return id == guid_of<IDerived>() ||
+               id == guid_of<IBase>();
+    }
+
+    template<> bool is_guid_of<IMoreDerived>(guid const& id) noexcept
+    {
+        return id == guid_of<IMoreDerived>() ||
+               id == guid_of<IDerived>() ||
+               id == guid_of<IBase>();
+    }
+}
+
 using namespace winrt;
+
+struct MyBase : implements<MyBase, IBase>
+{
+};
+
+struct MyDerived : implements<MyDerived, IDerived>
+{
+};
+
+struct MyMoreDerived : implements<MyMoreDerived, IMoreDerived>
+{
+};
 
 Windows::Foundation::IAsyncAction Async()
 {
@@ -11,8 +51,31 @@ Windows::Foundation::IAsyncAction Async()
 
 TEST_CASE("Interop")
 {
-    Windows::Foundation::IAsyncAction a = Async();
-    com_ptr<::IInspectable> b = a.as<::IInspectable>();
-    Windows::Foundation::IAsyncAction c = b.as<Windows::Foundation::IAsyncAction>();
-    REQUIRE(a == c);
+    {
+        Windows::Foundation::IAsyncAction a = Async();
+        com_ptr<::IInspectable> b = a.as<::IInspectable>();
+        Windows::Foundation::IAsyncAction c = b.as<Windows::Foundation::IAsyncAction>();
+        REQUIRE(a == c);
+    }
+    {
+        com_ptr<IBase> a = make<MyBase>();
+        REQUIRE(a);
+        REQUIRE(a.try_as<IBase>() != nullptr);
+        REQUIRE(a.try_as<IDerived>() == nullptr);
+        REQUIRE(a.try_as<IMoreDerived>() == nullptr);
+    }
+    {
+        com_ptr<IDerived> a = make<MyDerived>();
+        REQUIRE(a);
+        REQUIRE(a.try_as<IBase>() != nullptr);
+        REQUIRE(a.try_as<IDerived>() != nullptr);
+        REQUIRE(a.try_as<IMoreDerived>() == nullptr);
+    }
+    {
+        com_ptr<IMoreDerived> a = make<MyMoreDerived>();
+        REQUIRE(a);
+        REQUIRE(a.try_as<IBase>() != nullptr);
+        REQUIRE(a.try_as<IDerived>() != nullptr);
+        REQUIRE(a.try_as<IMoreDerived>() != nullptr);
+    }
 }

--- a/src/tool/cpp/cppwinrt/main.cpp
+++ b/src/tool/cpp/cppwinrt/main.cpp
@@ -147,7 +147,7 @@ namespace xlang
             auto start = get_start_time();
             process_args(argc, argv);
             cache c{ get_files_to_cache() };
-            c.remove_legacy_cppwinrt_foundation_types();
+            c.remove_cppwinrt_foundation_types();
             supplement_includes(c);
             settings.filter = { settings.include, settings.exclude };
 

--- a/src/tool/cpp/cppwinrt/strings/base_abi.h
+++ b/src/tool/cpp/cppwinrt/strings/base_abi.h
@@ -2,7 +2,6 @@
 namespace winrt::impl
 {
     inline constexpr hresult error_ok{ 0 }; // S_OK
-    inline constexpr hresult error_false{ 1 }; // S_FALSE
     inline constexpr hresult error_fail{ static_cast<hresult>(0x80004005) }; // E_FAIL
     inline constexpr hresult error_access_denied{ static_cast<hresult>(0x80070005) }; // E_ACCESSDENIED
     inline constexpr hresult error_wrong_thread{ static_cast<hresult>(0x8001010E) }; // RPC_E_WRONG_THREAD

--- a/src/tool/cpp/cppwinrt/strings/base_identity.h
+++ b/src/tool/cpp/cppwinrt/strings/base_identity.h
@@ -10,10 +10,10 @@ WINRT_EXPORT namespace winrt
         return impl::guid_storage<default_interface<T>>::value;
     }
 
-    template <typename T>
+    template <typename... T>
     bool is_guid_of(guid const& id) noexcept
     {
-        return id == guid_of<T>();
+        return ((id == guid_of<T>()) || ...);
     }
 
     struct event_token;

--- a/src/tool/cpp/cppwinrt/strings/base_identity.h
+++ b/src/tool/cpp/cppwinrt/strings/base_identity.h
@@ -10,6 +10,12 @@ WINRT_EXPORT namespace winrt
         return impl::guid_storage<default_interface<T>>::value;
     }
 
+    template <typename T>
+    bool is_guid_of(guid const& id) noexcept
+    {
+        return id == guid_of<T>();
+    }
+
     struct event_token;
 
     template <typename T>
@@ -26,12 +32,6 @@ namespace winrt::impl
 
     template <typename T>
     struct is_fast_interface<fast_interface<T>> : std::true_type {};
-
-    template <typename T>
-    constexpr bool is_guid_of(guid const& id) noexcept
-    {
-        return id == guid_of<T>();
-    }
 
     template <size_t Size, typename T, size_t... Index>
     constexpr std::array<T, Size> to_array(T const* value, std::index_sequence<Index...> const) noexcept


### PR DESCRIPTION
As much as we like WinRT, C++/WinRT is also used for a lot of COM-only APIs. This update makes it possible to implement COM servers where their exists an interface hierarchy. This is not required for WinRT, but is required for some COM implementations and is also needed for the upcoming WinRT fast ABI.