### PR TITLE
C++/WinRT deferred destruction and safe QI during destruction

### DIFF
--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(cpp_test PUBLIC
     test/Enum.cpp
     test/Events.cpp
     test/Fast.cpp
+    test/FinalRelease.cpp
     test/Names.cpp
     test/Structs.cpp
     implementation/Component.Async.Class.cpp

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -6239,6 +6239,7 @@ namespace winrt::impl
 
         void abi_enter() const noexcept {}
         void abi_exit() const noexcept {}
+        static void final_release(std::unique_ptr<D>) noexcept {}
 
     protected:
 
@@ -6290,6 +6291,11 @@ namespace winrt::impl
 
         uint32_t WINRT_CALL NonDelegatingAddRef() noexcept
         {
+            if (!m_references)
+            {
+                return 1;
+            }
+
             if constexpr (is_weak_ref_source::value)
             {
                 uintptr_t count_or_pointer = m_references.load(std::memory_order_relaxed);
@@ -6317,12 +6323,17 @@ namespace winrt::impl
 
         uint32_t WINRT_CALL NonDelegatingRelease() noexcept
         {
+            if (!m_references)
+            {
+                return 0;
+            }
+
             uint32_t const target = subtract_reference();
 
             if (target == 0)
             {
                 std::atomic_thread_fence(std::memory_order_acquire);
-                delete this;
+                D::final_release(std::unique_ptr<D>(static_cast<D*>(this)));
             }
 
             return target;

--- a/src/test/cpp/test/FinalRelease.cpp
+++ b/src/test/cpp/test/FinalRelease.cpp
@@ -1,0 +1,58 @@
+#include "pch.h"
+#include "winrt/Windows.Foundation.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    struct Sample : implements<Sample, IStringable>
+    {
+        hstring ToString()
+        {
+            return L"Sample";
+        }
+
+        ~Sample()
+        {
+            // It's safe to QI/AddRef/Release inside destructor.
+            IStringable s;
+            check_hresult(QueryInterface(guid_of<IStringable>(), put_abi(s)));
+            REQUIRE(s.ToString() == L"Sample");
+
+            REQUIRE(released);
+            REQUIRE(!destroyed);
+            destroyed = true;
+        }
+
+        static void final_release(std::unique_ptr<Sample> ptr) noexcept
+        {
+            // It's safe to QI/AddRef/Release inside final_release.
+            IStringable s;
+            check_hresult(ptr->QueryInterface(guid_of<IStringable>(), put_abi(s)));
+            REQUIRE(s.ToString() == L"Sample");
+
+            // References must be released prior to destroying the unique_ptr.
+            s = nullptr;
+
+            REQUIRE(!released);
+            REQUIRE(!destroyed);
+            released = true;
+            ptr = nullptr;
+            REQUIRE(destroyed);
+        }
+
+        static inline bool released;
+        static inline bool destroyed;
+    };
+}
+
+TEST_CASE("FinalRelease")
+{
+    auto s = make<Sample>();
+    REQUIRE(!Sample::released);
+    REQUIRE(!Sample::destroyed);
+    s = nullptr;
+    REQUIRE(Sample::released);
+    REQUIRE(Sample::destroyed);
+}


### PR DESCRIPTION
Xaml apps can get themselves into knots because they need to perform a QI in a destructor to call some cleanup implementation up or down the hierarchy. This call involves a QI after the object's reference count has already reached zero. This update adds support for [debouncing](https://en.wikipedia.org/wiki/Switch#Contact_bounce) the reference count, ensuring that once it reaches zero it can never be resurrected but still allows QI for temporaries required during destruction. This all seems rather messy but is unavoidable in certain Xaml apps/controls and C++/WinRT should be resilient to this. The downside of debouncing is that it makes AddRef and Release a bit more expensive. The up side is that C++/WinRT is hardened and far more resilient to such abuses.

Destruction may be deferred by providing a static final_release function and moving ownership of the unique_ptr to some other context.

```
struct Sample : implements<Sample, IStringable>
{
    hstring ToString()
    {
        return L"Sample";
    }

    ~Sample()
    {
        // Called when the unique_ptr below is reset.
    }

    static void final_release(std::unique_ptr<Sample> ptr) noexcept
    {
        // Move 'ptr' as needed to delay destruction.
    }
};
```

In the example below once the MainPage is released (for the final time), final_release is called, which spends 5s waiting (on the thread pool) then resumes using the page’s Dispatcher (which requires QI/AddRef/Release to work). It then clears the unique_ptr, which causes the MainPage destructor to actually get called. Even here DataContext is called, which requires a QI for IFrameworkElement. 

Obviously you don’t have to implement your final_release as a coroutine but that does work and makes it very simple to move destruction to a different thread.

```
struct MainPage : PageT<MainPage>
{
    MainPage()
    {
    }

    ~MainPage()
    {
        DataContext(nullptr);
    }

    static IAsyncAction final_release(std::unique_ptr<MainPage> ptr)
    {
        co_await 5s;

        co_await resume_foreground(ptr->Dispatcher());

        ptr = nullptr;
    }
};
```
