### PR TITLE
C++/WinRT: Hardened and optimized relationship between final_release and weak references

### DIFF
--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -6259,6 +6259,8 @@ namespace winrt::impl
 
         virtual ~root_implements() noexcept
         {
+            subtract_reference();
+
             if constexpr (use_module_lock::value)
             {
                 --get_module_lock();
@@ -6297,11 +6299,6 @@ namespace winrt::impl
 
         uint32_t WINRT_CALL NonDelegatingAddRef() noexcept
         {
-            if (!m_references)
-            {
-                return 1;
-            }
-
             if constexpr (is_weak_ref_source::value)
             {
                 uintptr_t count_or_pointer = m_references.load(std::memory_order_relaxed);
@@ -6329,16 +6326,11 @@ namespace winrt::impl
 
         uint32_t WINRT_CALL NonDelegatingRelease() noexcept
         {
-            if (!m_references)
-            {
-                return 0;
-            }
-
             uint32_t const target = subtract_reference();
 
             if (target == 0)
             {
-                std::atomic_thread_fence(std::memory_order_acquire);
+                m_references = 1;
                 D::final_release(std::unique_ptr<D>(static_cast<D*>(this)));
             }
 

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -6259,6 +6259,7 @@ namespace winrt::impl
 
         virtual ~root_implements() noexcept
         {
+            // If a weak reference is created during destruction, this ensures that it is also destroyed.
             subtract_reference();
 
             if constexpr (use_module_lock::value)
@@ -6330,7 +6331,10 @@ namespace winrt::impl
 
             if (target == 0)
             {
+                // If a weak reference was previously created, the m_references value will not be stable value (won't be zero).
+                // This ensures destruction has a stable value during destruction.
                 m_references = 1;
+
                 D::final_release(std::unique_ptr<D>(static_cast<D*>(this)));
             }
 

--- a/src/test/cpp/test/FinalRelease.cpp
+++ b/src/test/cpp/test/FinalRelease.cpp
@@ -20,6 +20,9 @@ namespace
             check_hresult(QueryInterface(guid_of<IStringable>(), put_abi(s)));
             REQUIRE(s.ToString() == L"Sample");
 
+            // Weak references are also supported during destruction.
+            weak_ref<IStringable>{ s };
+
             REQUIRE(released);
             REQUIRE(!destroyed);
             destroyed = true;
@@ -50,6 +53,10 @@ namespace
 TEST_CASE("FinalRelease")
 {
     auto s = make<Sample>();
+
+    // Weak references are supported prior to destruction
+    weak_ref<IStringable>{ s };
+
     REQUIRE(!Sample::released);
     REQUIRE(!Sample::destroyed);
     s = nullptr;

--- a/src/test/cpp/test/FinalRelease.cpp
+++ b/src/test/cpp/test/FinalRelease.cpp
@@ -21,7 +21,7 @@ namespace
             REQUIRE(s.ToString() == L"Sample");
 
             // Weak references are also supported during destruction.
-            weak_ref<IStringable>{ s };
+            REQUIRE(weak_ref<IStringable>{ s }.get());
 
             REQUIRE(released);
             REQUIRE(!destroyed);
@@ -54,8 +54,8 @@ TEST_CASE("FinalRelease")
 {
     auto s = make<Sample>();
 
-    // Weak references are supported prior to destruction
-    weak_ref<IStringable>{ s };
+    // Weak references are supported prior to destruction.
+    REQUIRE(weak_ref<IStringable>{ s }.get());
 
     REQUIRE(!Sample::released);
     REQUIRE(!Sample::destroyed);

--- a/src/tool/cpp/cppwinrt/strings/base_implements.h
+++ b/src/tool/cpp/cppwinrt/strings/base_implements.h
@@ -779,6 +779,7 @@ namespace winrt::impl
 
         virtual ~root_implements() noexcept
         {
+            // If a weak reference is created during destruction, this ensures that it is also destroyed.
             subtract_reference();
 
             if constexpr (use_module_lock::value)
@@ -850,7 +851,10 @@ namespace winrt::impl
 
             if (target == 0)
             {
+                // If a weak reference was previously created, the m_references value will not be stable value (won't be zero).
+                // This ensures destruction has a stable value during destruction.
                 m_references = 1;
+
                 D::final_release(std::unique_ptr<D>(static_cast<D*>(this)));
             }
 


### PR DESCRIPTION
The final_release feature pessimized AddRef and Release in all cases and didn't actually play very nicely with weak references. While it supported QIs during destruction, a query for IWeakReferenceSource caused trouble. This minor tweak fixes both by removing the need for the extra memory barriers in AddRef and Release and by supporting queries for weak references during destruction. 