### PR TITLE
The capture helper now supports projected types as well (Bug 18741232)

### DIFF
--- a/src/library/impl/base.h
+++ b/src/library/impl/base.h
@@ -24,6 +24,7 @@
 #include <list>
 #include <map>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <variant>
 #include <vector>

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -45,7 +45,11 @@ endif()
 if (CMAKE_CXX_COMPILER MATCHES "clang-cl")
     target_sources(cpp_test PUBLIC main.cpp)
 else()
-    target_sources(cpp_test PUBLIC main.cpp test/Interop.cpp)
+    target_sources(cpp_test PUBLIC
+        main.cpp
+        test/Interop.cpp
+        test/Capture.cpp
+    )
 endif()
 
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../tool/cpp/cppwinrt/cppwinrt.exe cpp_exe)

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -2487,16 +2487,15 @@ WINRT_EXPORT namespace winrt
     template <typename T, typename F, typename...Args>
     auto capture(F function, Args&&...args)
     {
-        com_ptr<T> result;
-        check_hresult(function(args..., guid_of<T>(), result.put_void()));
+        impl::com_ref<T> result{ nullptr };
+        check_hresult(function(args..., guid_of<T>(), reinterpret_cast<void**>(put_abi(result))));
         return result;
     }
-
     template <typename T, typename O, typename M, typename...Args>
     auto capture(com_ptr<O> const& object, M method, Args&&...args)
     {
-        com_ptr<T> result;
-        check_hresult((object.get()->*(method))(args..., guid_of<T>(), result.put_void()));
+        impl::com_ref<T> result{ nullptr };
+        check_hresult((object.get()->*(method))(args..., guid_of<T>(), reinterpret_cast<void**>(put_abi(result))));
         return result;
     }
 

--- a/src/test/cpp/test/Capture.cpp
+++ b/src/test/cpp/test/Capture.cpp
@@ -1,0 +1,73 @@
+#include "catch.hpp"
+#include <inspectable.h>
+#include "winrt/Windows.Foundation.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+struct __declspec(uuid("5fb96f8d-409c-42a9-99a7-8a95c1459dbd")) ICapture : ::IUnknown
+{
+    virtual int32_t WINRT_CALL GetValue() noexcept = 0;
+    virtual int32_t WINRT_CALL CreateMemberCapture(int32_t value, GUID const& iid, void** object) noexcept = 0;
+};
+
+struct Capture : implements<Capture, ICapture, IStringable>
+{
+    int32_t const m_value{};
+
+    Capture(int32_t value) :
+        m_value{ value }
+    {
+    }
+
+    hstring ToString()
+    {
+        return hstring{ std::to_wstring(m_value) };
+    }
+
+    int32_t WINRT_CALL GetValue() noexcept override
+    {
+        return m_value;
+    }
+
+    int32_t WINRT_CALL CreateMemberCapture(int32_t value, GUID const& iid, void** object) noexcept override
+    {
+        auto capture = make<Capture>(value);
+        return capture->QueryInterface(iid, object);
+    }
+};
+
+HRESULT __stdcall CreateNonMemberCapture(int value, GUID const& iid, void** object) noexcept
+{
+    auto capture = make<Capture>(value);
+    return capture->QueryInterface(iid, object);
+}
+
+TEST_CASE("capture")
+{
+    com_ptr<ICapture> a = capture<ICapture>(CreateNonMemberCapture, 10);
+    REQUIRE(a->GetValue() == 10);
+    a = nullptr;
+    a.capture(CreateNonMemberCapture, 20);
+    REQUIRE(a->GetValue() == 20);
+
+    com_ptr<ICapture> b = capture<ICapture>(a, &ICapture::CreateMemberCapture, 30);
+    REQUIRE(b->GetValue() == 30);
+    b = nullptr;
+    b.capture(a, &ICapture::CreateMemberCapture, 40);
+    REQUIRE(b->GetValue() == 40);
+
+    IStringable c = capture<IStringable>(CreateNonMemberCapture, 50);
+    REQUIRE(c.ToString() == L"50");
+    c = capture<IStringable>(a, &ICapture::CreateMemberCapture, 60);
+    REQUIRE(c.ToString() == L"60");
+
+    com_ptr<IDispatch> d;
+
+    REQUIRE_THROWS_AS(capture<IDispatch>(CreateNonMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(capture<IClosable>(CreateNonMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(d.capture(CreateNonMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(capture<IDispatch>(a, &ICapture::CreateMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(capture<IClosable>(a, &ICapture::CreateMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(d.capture(a, &ICapture::CreateMemberCapture, 0), hresult_no_interface);
+}

--- a/src/tool/cpp/cppwinrt/main.cpp
+++ b/src/tool/cpp/cppwinrt/main.cpp
@@ -252,5 +252,4 @@ namespace xlang
 int main(int const argc, char** argv)
 {
     xlang::run(argc, argv);
-
 }

--- a/src/tool/cpp/cppwinrt/strings/base_com_ptr.h
+++ b/src/tool/cpp/cppwinrt/strings/base_com_ptr.h
@@ -207,16 +207,15 @@ WINRT_EXPORT namespace winrt
     template <typename T, typename F, typename...Args>
     auto capture(F function, Args&&...args)
     {
-        com_ptr<T> result;
-        check_hresult(function(args..., guid_of<T>(), result.put_void()));
+        impl::com_ref<T> result{ nullptr };
+        check_hresult(function(args..., guid_of<T>(), reinterpret_cast<void**>(put_abi(result))));
         return result;
     }
-
     template <typename T, typename O, typename M, typename...Args>
     auto capture(com_ptr<O> const& object, M method, Args&&...args)
     {
-        com_ptr<T> result;
-        check_hresult((object.get()->*(method))(args..., guid_of<T>(), result.put_void()));
+        impl::com_ref<T> result{ nullptr };
+        check_hresult((object.get()->*(method))(args..., guid_of<T>(), reinterpret_cast<void**>(put_abi(result))));
         return result;
     }
 

--- a/src/tool/cpp/cppx/main.cpp
+++ b/src/tool/cpp/cppx/main.cpp
@@ -1,5 +1,5 @@
 #include "pch.h"
 
-int main(int const argc, char** argv)
+int main()
 {
 }


### PR DESCRIPTION
This update fixes the limitation with the capture helpers by supporting projected types as well. The comes up now and then with the WinRT interop APIs when they return a projected type. 

I have also ported the original capture tests from cppwinrt and fixed some minor issues building xlang with VS 2019.