### PR TITLE
C++/WinRT improved capture helpers and variadic delegates

### DIFF
--- a/src/library/impl/base.h
+++ b/src/library/impl/base.h
@@ -24,6 +24,7 @@
 #include <list>
 #include <map>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <variant>
 #include <vector>

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(cpp_test PUBLIC
     test/Names.cpp
     test/Structs.cpp
     test/CustomError.cpp
+    test/VariadicDelegate.cpp
     implementation/Component.Async.Class.cpp
     implementation/Component.Collections.Class.cpp
     implementation/Component.Composable.Base.cpp

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(cpp_test PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/generated/module.g.cpp"
     pch.cpp
     activation.cpp
+    test/AbiGuard.cpp
     test/Async.cpp
     test/Collections.cpp
     test/Composable.cpp

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(cpp_test PUBLIC
     pch.cpp
     activation.cpp
     test/AbiGuard.cpp
+    test/AgileRef.cpp
     test/Async.cpp
     test/Collections.cpp
     test/Composable.cpp

--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -45,7 +45,11 @@ endif()
 if (CMAKE_CXX_COMPILER MATCHES "clang-cl")
     target_sources(cpp_test PUBLIC main.cpp)
 else()
-    target_sources(cpp_test PUBLIC main.cpp test/Interop.cpp)
+    target_sources(cpp_test PUBLIC
+        main.cpp
+        test/Interop.cpp
+        test/Capture.cpp
+    )
 endif()
 
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../tool/cpp/cppwinrt/cppwinrt.exe cpp_exe)

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -2487,16 +2487,15 @@ WINRT_EXPORT namespace winrt
     template <typename T, typename F, typename...Args>
     auto capture(F function, Args&&...args)
     {
-        com_ptr<T> result;
-        check_hresult(function(args..., guid_of<T>(), result.put_void()));
+        impl::com_ref<T> result{ nullptr };
+        check_hresult(function(args..., guid_of<T>(), reinterpret_cast<void**>(put_abi(result))));
         return result;
     }
-
     template <typename T, typename O, typename M, typename...Args>
     auto capture(com_ptr<O> const& object, M method, Args&&...args)
     {
-        com_ptr<T> result;
-        check_hresult((object.get()->*(method))(args..., guid_of<T>(), result.put_void()));
+        impl::com_ref<T> result{ nullptr };
+        check_hresult((object.get()->*(method))(args..., guid_of<T>(), reinterpret_cast<void**>(put_abi(result))));
         return result;
     }
 

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -5045,6 +5045,16 @@ WINRT_EXPORT namespace winrt
             delegate([=](auto&&... args) { ((*object).*(method))(args...); })
         {}
 
+        template <typename O, typename M> delegate(com_ptr<O>&& object, M method) :
+            delegate([o = std::move(object), method](auto&&... args) { return ((*o).*(method))(args...); })
+        {
+        }
+
+        template <typename O, typename M> delegate(weak_ref<O>&& object, M method) :
+            delegate([o = std::move(object), method](auto&&... args) { if (auto s = o.get()) { ((*s).*(method))(args...); } })
+        {
+        }
+
         void operator()(T const&... args) const
         {
             (*(impl::variadic_delegate_abi<T...>**)this)->invoke(args...);

--- a/src/test/cpp/test/AbiGuard.cpp
+++ b/src/test/cpp/test/AbiGuard.cpp
@@ -1,0 +1,294 @@
+#include "pch.h"
+#include "winrt/Windows.Foundation.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    //
+    // This implemenetation uses the simplest abi_enter and abi_exit methods
+    //
+    struct Simple : implements<Simple, IClosable, IStringable>
+    {
+        void Close()
+        {
+        }
+
+        hstring ToString()
+        {
+            return L"";
+        }
+
+        void abi_enter()
+        {
+            ++m_enter;
+        }
+
+        void abi_exit()
+        {
+            ++m_exit;
+        }
+
+        int m_enter{};
+        int m_exit{};
+    };
+
+    //
+    // This implemenetation uses the abi_enter but omits the abi_exit method
+    //
+    struct OnlyEnter : implements<OnlyEnter, IClosable, IStringable>
+    {
+        void Close()
+        {
+        }
+
+        hstring ToString()
+        {
+            return L"";
+        }
+
+        void abi_enter()
+        {
+            ++m_enter;
+        }
+
+        int m_enter{};
+    };
+
+    //
+    // This implemenetation throws from the abi_enter method
+    //
+    struct Throwing : implements<Throwing, IClosable, IStringable>
+    {
+        void Close()
+        {
+        }
+
+        hstring ToString()
+        {
+            return L"";
+        }
+
+        void abi_enter()
+        {
+            throw hresult_wrong_thread();
+        }
+
+        void abi_exit()
+        {
+            ++m_exit;
+        }
+
+        int m_exit{};
+    };
+
+    //
+    // This implemenetation provides a nested abi_guard
+    //
+    struct NestedGuard : implements<NestedGuard, IClosable, IStringable>
+    {
+        void Close()
+        {
+        }
+
+        hstring ToString()
+        {
+            return L"";
+        }
+
+        int m_enter{};
+        int m_exit{};
+
+        struct abi_guard
+        {
+            abi_guard(NestedGuard& that) :
+                m_that(that)
+            {
+                ++m_that.m_enter;
+            }
+
+            ~abi_guard()
+            {
+                ++m_that.m_exit;
+            }
+
+        private:
+
+            NestedGuard& m_that;
+        };
+    };
+
+    template <typename T>
+    struct CountGuard
+    {
+        CountGuard(T& that) :
+            m_that(that)
+        {
+            ++m_that.m_enter;
+        }
+
+        ~CountGuard()
+        {
+            ++m_that.m_exit;
+        }
+
+    private:
+
+        T& m_that;
+    };
+
+    //
+    // This implemenetation use an abi_guard type alias
+    //
+    struct GuardAlias : implements<GuardAlias, IClosable, IStringable>
+    {
+        void Close()
+        {
+        }
+
+        hstring ToString()
+        {
+            return L"";
+        }
+
+        int m_enter{};
+        int m_exit{};
+
+        using abi_guard = CountGuard<GuardAlias>;
+    };
+
+    template <typename T>
+    struct ThrowGuard
+    {
+        ThrowGuard(T &)
+        {
+            throw hresult_wrong_thread();
+        }
+    };
+
+    //
+    // This implemenetation use an abi_guard type alias that thows
+    //
+    struct ThrowAlias : implements<ThrowAlias, IClosable, IStringable>
+    {
+        void Close()
+        {
+        }
+
+        hstring ToString()
+        {
+            return L"";
+        }
+
+        using abi_guard = ThrowGuard<ThrowAlias>;
+    };
+}
+
+TEST_CASE("AbiGuard")
+{
+    {
+        com_ptr<Simple> impl = make_self<Simple>();
+
+        impl->Close();
+        impl->ToString();
+        REQUIRE(impl->m_enter == 0);
+        REQUIRE(impl->m_exit == 0);
+
+        IClosable closable = impl.as<IClosable>();
+        closable.Close();
+        REQUIRE(impl->m_enter == 1);
+        REQUIRE(impl->m_exit == 1);
+
+        IStringable stringable = impl.as<IStringable>();
+        stringable.ToString();
+        REQUIRE(impl->m_enter == 2);
+        REQUIRE(impl->m_exit == 2);
+    }
+    {
+        com_ptr<OnlyEnter> impl = make_self<OnlyEnter>();
+
+        impl->Close();
+        impl->ToString();
+
+        REQUIRE(impl->m_enter == 0);
+
+        IClosable closable = impl.as<IClosable>();
+        closable.Close();
+
+        REQUIRE(impl->m_enter == 1);
+
+        IStringable stringable = impl.as<IStringable>();
+        stringable.ToString();
+
+        REQUIRE(impl->m_enter == 2);
+    }
+    {
+        com_ptr<Throwing> impl = make_self<Throwing>();
+
+        impl->Close();
+        impl->ToString();
+
+        IClosable closable = impl.as<IClosable>();
+        REQUIRE_THROWS_AS(closable.Close(), hresult_wrong_thread);
+
+        IStringable stringable = impl.as<IStringable>();
+        REQUIRE_THROWS_AS(stringable.ToString(), hresult_wrong_thread);
+
+        REQUIRE(impl->m_exit == 0);
+    }
+    {
+        com_ptr<NestedGuard> impl = make_self<NestedGuard>();
+
+        impl->Close();
+        impl->ToString();
+
+        REQUIRE(impl->m_enter == 0);
+        REQUIRE(impl->m_exit == 0);
+
+        IClosable closable = impl.as<IClosable>();
+        closable.Close();
+
+        REQUIRE(impl->m_enter == 1);
+        REQUIRE(impl->m_exit == 1);
+
+        IStringable stringable = impl.as<IStringable>();
+        stringable.ToString();
+
+        REQUIRE(impl->m_enter == 2);
+        REQUIRE(impl->m_exit == 2);
+    }
+    {
+        com_ptr<GuardAlias> impl = make_self<GuardAlias>();
+
+        impl->Close();
+        impl->ToString();
+
+        REQUIRE(impl->m_enter == 0);
+        REQUIRE(impl->m_exit == 0);
+
+        IClosable closable = impl.as<IClosable>();
+        closable.Close();
+
+        REQUIRE(impl->m_enter == 1);
+        REQUIRE(impl->m_exit == 1);
+
+        IStringable stringable = impl.as<IStringable>();
+        stringable.ToString();
+
+        REQUIRE(impl->m_enter == 2);
+        REQUIRE(impl->m_exit == 2);
+    }
+    {
+        com_ptr<ThrowAlias> impl = make_self<ThrowAlias>();
+
+        impl->Close();
+        impl->ToString();
+
+        IClosable closable = impl.as<IClosable>();
+        REQUIRE_THROWS_AS(closable.Close(), hresult_wrong_thread);
+
+        IStringable stringable = impl.as<IStringable>();
+        REQUIRE_THROWS_AS(stringable.ToString(), hresult_wrong_thread);
+    }
+}

--- a/src/test/cpp/test/AgileRef.cpp
+++ b/src/test/cpp/test/AgileRef.cpp
@@ -1,0 +1,55 @@
+#include "pch.h"
+#include "winrt/Windows.Foundation.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    struct Object : implements<Object, IStringable>
+    {
+        hstring ToString()
+        {
+            return L"Object";
+        }
+    };
+}
+
+TEST_CASE("AgileRef")
+{
+    agile_ref<IStringable> ref = make<Object>();
+
+    //
+    // Here we're creating an agile_ref explicitly and using a traditional lambda variable capture
+    // to pass it to the delegate.
+    //
+
+    delegate<> a = [ref]
+    {
+        IStringable object = ref.get();
+        REQUIRE(object.ToString() == L"Object");
+    };
+
+    a();
+
+    //
+    // Here's we're using the make_agile helper with generalized lambda capture to produce a
+    // variable local to the lambda.
+    //
+
+    delegate<> b = [ref = make_agile(make<Object>())]
+    {
+        IStringable object = ref.get();
+        REQUIRE(object.ToString() == L"Object");
+    };
+
+    b();
+
+    //
+    // And it's ok to resolve a nullptr agile_ref.
+    //
+
+    agile_ref<IStringable> empty;
+    IStringable object = empty.get();
+    REQUIRE(object == nullptr);
+}

--- a/src/test/cpp/test/Capture.cpp
+++ b/src/test/cpp/test/Capture.cpp
@@ -1,0 +1,73 @@
+#include "catch.hpp"
+#include <inspectable.h>
+#include "winrt/Windows.Foundation.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+struct __declspec(uuid("5fb96f8d-409c-42a9-99a7-8a95c1459dbd")) ICapture : ::IUnknown
+{
+    virtual int32_t WINRT_CALL GetValue() noexcept = 0;
+    virtual int32_t WINRT_CALL CreateMemberCapture(int32_t value, GUID const& iid, void** object) noexcept = 0;
+};
+
+struct Capture : implements<Capture, ICapture, IStringable>
+{
+    int32_t const m_value{};
+
+    Capture(int32_t value) :
+        m_value{ value }
+    {
+    }
+
+    hstring ToString()
+    {
+        return hstring{ std::to_wstring(m_value) };
+    }
+
+    int32_t WINRT_CALL GetValue() noexcept override
+    {
+        return m_value;
+    }
+
+    int32_t WINRT_CALL CreateMemberCapture(int32_t value, GUID const& iid, void** object) noexcept override
+    {
+        auto capture = make<Capture>(value);
+        return capture->QueryInterface(iid, object);
+    }
+};
+
+HRESULT __stdcall CreateNonMemberCapture(int value, GUID const& iid, void** object) noexcept
+{
+    auto capture = make<Capture>(value);
+    return capture->QueryInterface(iid, object);
+}
+
+TEST_CASE("capture")
+{
+    com_ptr<ICapture> a = capture<ICapture>(CreateNonMemberCapture, 10);
+    REQUIRE(a->GetValue() == 10);
+    a = nullptr;
+    a.capture(CreateNonMemberCapture, 20);
+    REQUIRE(a->GetValue() == 20);
+
+    com_ptr<ICapture> b = capture<ICapture>(a, &ICapture::CreateMemberCapture, 30);
+    REQUIRE(b->GetValue() == 30);
+    b = nullptr;
+    b.capture(a, &ICapture::CreateMemberCapture, 40);
+    REQUIRE(b->GetValue() == 40);
+
+    IStringable c = capture<IStringable>(CreateNonMemberCapture, 50);
+    REQUIRE(c.ToString() == L"50");
+    c = capture<IStringable>(a, &ICapture::CreateMemberCapture, 60);
+    REQUIRE(c.ToString() == L"60");
+
+    com_ptr<IDispatch> d;
+
+    REQUIRE_THROWS_AS(capture<IDispatch>(CreateNonMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(capture<IClosable>(CreateNonMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(d.capture(CreateNonMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(capture<IDispatch>(a, &ICapture::CreateMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(capture<IClosable>(a, &ICapture::CreateMemberCapture, 0), hresult_no_interface);
+    REQUIRE_THROWS_AS(d.capture(a, &ICapture::CreateMemberCapture, 0), hresult_no_interface);
+}

--- a/src/test/cpp/test/VariadicDelegate.cpp
+++ b/src/test/cpp/test/VariadicDelegate.cpp
@@ -1,0 +1,174 @@
+#include "pch.h"
+#include "winrt/Windows.Foundation.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    int callback_state{};
+
+    void callback(int state)
+    {
+        callback_state = state;
+    }
+
+    struct callback_object
+    {
+        int m_state{};
+
+        void member(int state)
+        {
+            m_state = state;
+        }
+    };
+
+    struct Object : implements<Object, IStringable>
+    {
+        int& m_count;
+
+        Object(int& count) : m_count(count)
+        {
+        }
+
+        void Callback()
+        {
+            ++m_count;
+        }
+
+        hstring ToString()
+        {
+            return L"Object";
+        }
+    };
+}
+
+TEST_CASE("VariadicDelegate")
+{
+    // Zero arguments
+    {
+        int count{};
+
+        delegate<> up = [&] { ++count; };
+        delegate<> down = [&] { --count; };
+
+        REQUIRE(count == 0);
+        up();
+        REQUIRE(count == 1);
+        up();
+        REQUIRE(count == 2);
+        down();
+        REQUIRE(count == 1);
+        down();
+        REQUIRE(count == 0);
+    }
+
+    // get_strong
+    {
+        int count{};
+        auto object = make_self<Object>(count);
+
+        delegate<> up{ object->get_strong(), &Object::Callback };
+
+        REQUIRE(count == 0);
+        up();
+        REQUIRE(count == 1);
+        up();
+        REQUIRE(count == 2);
+
+        object = nullptr;
+
+        up();
+        REQUIRE(count == 3);
+    }
+
+    // get_weak
+    {
+        int count{};
+        auto object = make_self<Object>(count);
+
+        delegate<> up{ object->get_weak(), &Object::Callback };
+
+        REQUIRE(count == 0);
+        up();
+        REQUIRE(count == 1);
+        up();
+        REQUIRE(count == 2);
+
+        object = nullptr;
+
+        up();
+        REQUIRE(count == 2); // Unchanged
+    }
+
+    // Mixed arguments
+    {
+        int count{};
+
+        delegate<int, std::shared_ptr<int>, Windows::Foundation::IInspectable> d =
+            [&](int const a, std::shared_ptr<int> const& b, Windows::Foundation::IInspectable const& c)
+        {
+            count = a;
+
+            if (b)
+            {
+                count += *b;
+            }
+
+            if (c)
+            {
+                ++count;
+            }
+        };
+
+        d(5, nullptr, box_value(0));
+        REQUIRE(count == 6);
+
+        d(6, std::make_shared<int>(7), nullptr);
+        REQUIRE(count == 6 + 7);
+    }
+
+    // Event
+    {
+        int a{};
+        int b{};
+        int c{};
+
+        event<delegate<int>> e;
+        REQUIRE(!e);
+
+        e.add([&](int value) { a = value + 1; });
+        auto b_token = e.add([&](int value) { b = value + 2; });
+        e.add([&](int value) { c = value + 3; });
+
+        REQUIRE(e);
+        e.remove(b_token);
+        e(10);
+        REQUIRE(a == 11);
+        REQUIRE(b == 0);
+        REQUIRE(c == 13);
+    }
+
+    // Exception
+    {
+        delegate<> d = [] { throw std::exception("what"); };
+        REQUIRE_THROWS_AS(d(), std::exception);
+    }
+
+    // Function
+    {
+        delegate<int> d = callback;
+        REQUIRE(callback_state == 0);
+        d(123);
+        REQUIRE(callback_state == 123);
+    }
+
+    // Function object
+    {
+        callback_object object;
+        delegate<int> d{ &object, &callback_object::member };
+        REQUIRE(object.m_state == 0);
+        d(123);
+        REQUIRE(object.m_state == 123);
+    }
+}

--- a/src/tool/cpp/cppwinrt/main.cpp
+++ b/src/tool/cpp/cppwinrt/main.cpp
@@ -252,5 +252,4 @@ namespace xlang
 int main(int const argc, char** argv)
 {
     xlang::run(argc, argv);
-
 }

--- a/src/tool/cpp/cppwinrt/strings/base_com_ptr.h
+++ b/src/tool/cpp/cppwinrt/strings/base_com_ptr.h
@@ -207,16 +207,15 @@ WINRT_EXPORT namespace winrt
     template <typename T, typename F, typename...Args>
     auto capture(F function, Args&&...args)
     {
-        com_ptr<T> result;
-        check_hresult(function(args..., guid_of<T>(), result.put_void()));
+        impl::com_ref<T> result{ nullptr };
+        check_hresult(function(args..., guid_of<T>(), reinterpret_cast<void**>(put_abi(result))));
         return result;
     }
-
     template <typename T, typename O, typename M, typename...Args>
     auto capture(com_ptr<O> const& object, M method, Args&&...args)
     {
-        com_ptr<T> result;
-        check_hresult((object.get()->*(method))(args..., guid_of<T>(), result.put_void()));
+        impl::com_ref<T> result{ nullptr };
+        check_hresult((object.get()->*(method))(args..., guid_of<T>(), reinterpret_cast<void**>(put_abi(result))));
         return result;
     }
 

--- a/src/tool/cpp/cppwinrt/strings/base_delegate.h
+++ b/src/tool/cpp/cppwinrt/strings/base_delegate.h
@@ -127,6 +127,16 @@ WINRT_EXPORT namespace winrt
             delegate([=](auto&&... args) { ((*object).*(method))(args...); })
         {}
 
+        template <typename O, typename M> delegate(com_ptr<O>&& object, M method) :
+            delegate([o = std::move(object), method](auto&&... args) { return ((*o).*(method))(args...); })
+        {
+        }
+
+        template <typename O, typename M> delegate(weak_ref<O>&& object, M method) :
+            delegate([o = std::move(object), method](auto&&... args) { if (auto s = o.get()) { ((*s).*(method))(args...); } })
+        {
+        }
+
         void operator()(T const&... args) const
         {
             (*(impl::variadic_delegate_abi<T...>**)this)->invoke(args...);

--- a/src/tool/cpp/cppx/main.cpp
+++ b/src/tool/cpp/cppx/main.cpp
@@ -1,5 +1,5 @@
 #include "pch.h"
 
-int main(int const argc, char** argv)
+int main()
 {
 }


### PR DESCRIPTION
This update fixes the limitation with the `winrt::capture` helpers by supporting projected types as well. The comes up now and then with the WinRT interop APIs when they return a projected type.

This update also adds support for `get_strong/get_weak` when creating variadic a `winrt::delegate`.

I have also ported the original capture tests from cppwinrt and fixed some minor issues building xlang with VS 2019.

Issues: #113, #112 