### PR TITLE
C++/WinRT events don't gracefully handle invalid tokens

### DIFF
--- a/src/test/cpp/CMakeLists.txt
+++ b/src/test/cpp/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(cpp_test PUBLIC
     test/Edge.cpp
     test/Enum.cpp
     test/Events.cpp
+    test/EventsInvalid.cpp
     test/Fast.cpp
     test/FinalRelease.cpp
     test/Names.cpp

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -4686,8 +4686,7 @@ WINRT_EXPORT namespace winrt
                 token = get_token(new_targets->back());
 
                 slim_lock_guard const swap_guard(m_swap);
-                temp_targets = m_targets;
-                m_targets = new_targets;
+                temp_targets = std::exchange(m_targets, std::move(new_targets));
             }
 
             return token;
@@ -4745,8 +4744,7 @@ WINRT_EXPORT namespace winrt
                 if (removed)
                 {
                     slim_lock_guard const swap_guard(m_swap);
-                    temp_targets = std::move(m_targets);
-                    m_targets = std::move(new_targets);
+                    temp_targets = std::exchange(m_targets, std::move(new_targets));
                 }
             }
         }

--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -4706,7 +4706,7 @@ WINRT_EXPORT namespace winrt
                     return;
                 }
 
-                uint32_t const available_slots = m_targets->size() - 1;
+                uint32_t available_slots = m_targets->size() - 1;
                 delegate_array new_targets;
                 bool removed = false;
 
@@ -4724,22 +4724,29 @@ WINRT_EXPORT namespace winrt
 
                     for (delegate_type const& element : *m_targets)
                     {
-                        if (!removed&& token == get_token(element))
+                        if (!removed && token == get_token(element))
                         {
                             removed = true;
                             continue;
                         }
 
+                        if (available_slots == 0)
+                        {
+                            WINRT_ASSERT(!removed);
+                            break;
+                        }
+
                         *new_iterator = element;
                         ++new_iterator;
+                        --available_slots;
                     }
                 }
 
                 if (removed)
                 {
                     slim_lock_guard const swap_guard(m_swap);
-                    temp_targets = m_targets;
-                    m_targets = new_targets;
+                    temp_targets = std::move(m_targets);
+                    m_targets = std::move(new_targets);
                 }
             }
         }

--- a/src/test/cpp/test/EventsInvalid.cpp
+++ b/src/test/cpp/test/EventsInvalid.cpp
@@ -5,7 +5,7 @@ using namespace winrt;
 using namespace Windows::Foundation;
 
 //
-// Checks that invalid tokens may safely be removed.
+// Checks that invalid tokens may be removed harmlessly.
 //
 
 TEST_CASE("EventsInvalid")

--- a/src/test/cpp/test/EventsInvalid.cpp
+++ b/src/test/cpp/test/EventsInvalid.cpp
@@ -1,0 +1,64 @@
+#include "pch.h"
+#include "winrt/Windows.Foundation.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+//
+// Checks that invalid tokens may safely be removed.
+//
+
+TEST_CASE("EventsInvalid")
+{
+    event<TypedEventHandler<int, int>> event;
+    int counter{};
+
+    auto a = event.add([&](auto&&...)
+        {
+            counter += 1;
+        });
+
+    auto b = event.add([&](auto&&...)
+        {
+            counter += 10;
+        });
+
+    REQUIRE(counter == 0);
+    event(0, 0);
+    REQUIRE(counter == 11);
+
+    // Remove invalid token (with two valids)
+    event.remove(event_token {1});
+
+    counter = 0;
+    event(0, 0);
+    REQUIRE(counter == 11);
+
+    // Remove valid token
+    event.remove(b);
+
+    counter = 0;
+    event(0, 0);
+    REQUIRE(counter == 1);
+
+    // Remove invalid token (with one valid)
+    event.remove(event_token {1});
+
+    counter = 0;
+    event(0, 0);
+    REQUIRE(counter == 1);
+
+    // Remove remaining valid token
+    event.remove(a);
+
+    counter = 0;
+    event(0, 0);
+    REQUIRE(counter == 0);
+
+    // Remove invalid token (with no valids)
+    event.remove(event_token {1});
+
+    counter = 0;
+    event(0, 0);
+    REQUIRE(counter == 0);
+}

--- a/src/tool/cpp/cppwinrt/strings/base_events.h
+++ b/src/tool/cpp/cppwinrt/strings/base_events.h
@@ -407,7 +407,7 @@ WINRT_EXPORT namespace winrt
                     return;
                 }
 
-                uint32_t const available_slots = m_targets->size() - 1;
+                uint32_t available_slots = m_targets->size() - 1;
                 delegate_array new_targets;
                 bool removed = false;
 
@@ -425,22 +425,29 @@ WINRT_EXPORT namespace winrt
 
                     for (delegate_type const& element : *m_targets)
                     {
-                        if (!removed&& token == get_token(element))
+                        if (!removed && token == get_token(element))
                         {
                             removed = true;
                             continue;
                         }
 
+                        if (available_slots == 0)
+                        {
+                            WINRT_ASSERT(!removed);
+                            break;
+                        }
+
                         *new_iterator = element;
                         ++new_iterator;
+                        --available_slots;
                     }
                 }
 
                 if (removed)
                 {
                     slim_lock_guard const swap_guard(m_swap);
-                    temp_targets = m_targets;
-                    m_targets = new_targets;
+                    temp_targets = std::move(m_targets);
+                    m_targets = std::move(new_targets);
                 }
             }
         }

--- a/src/tool/cpp/cppwinrt/strings/base_events.h
+++ b/src/tool/cpp/cppwinrt/strings/base_events.h
@@ -387,8 +387,7 @@ WINRT_EXPORT namespace winrt
                 token = get_token(new_targets->back());
 
                 slim_lock_guard const swap_guard(m_swap);
-                temp_targets = m_targets;
-                m_targets = new_targets;
+                temp_targets = std::exchange(m_targets, std::move(new_targets));
             }
 
             return token;
@@ -446,8 +445,7 @@ WINRT_EXPORT namespace winrt
                 if (removed)
                 {
                     slim_lock_guard const swap_guard(m_swap);
-                    temp_targets = std::move(m_targets);
-                    m_targets = std::move(new_targets);
+                    temp_targets = std::exchange(m_targets, std::move(new_targets));
                 }
             }
         }


### PR DESCRIPTION
The `winrt::event<Delegate>` implementation does not gracefully handle the case where its `remove` method is called with an invalid token value (a value not present in the array). This update brings the implementation in line with WRL, which handles this scenario.

Tests have been added to validate this scenario.