### PR TITLE
C++/WinRT generates headers for empty namespaces

### DIFF
--- a/src/tool/cpp/cppwinrt/main.cpp
+++ b/src/tool/cpp/cppwinrt/main.cpp
@@ -140,6 +140,16 @@ namespace xlang
         }
     }
 
+    static bool has_projected_types(cache::namespace_members const& members)
+    {
+        return
+            !members.interfaces.empty() ||
+            !members.classes.empty() ||
+            !members.enums.empty() ||
+            !members.structs.empty() ||
+            !members.delegates.empty();
+    }
+
     static void run(int const argc, char** argv)
     {
         writer w;
@@ -182,7 +192,7 @@ namespace xlang
             {
                 group.add([&, &ns = ns, &members = members]
                 {
-                    if (members.types.empty() || !settings.filter.includes(members))
+                    if (!has_projected_types(members) || !settings.filter.includes(members))
                     {
                         return;
                     }


### PR DESCRIPTION
Namespaces that only include contract/attribute types must not produce headers. 