### PR TITLE
C++/WinRT workaround for OS compiler

### DIFF
--- a/src/test/cpp/compare/out/winrt/base.h
+++ b/src/test/cpp/compare/out/winrt/base.h
@@ -1960,17 +1960,16 @@ namespace winrt::impl
     template <typename T>
     using com_ref = std::conditional_t<std::is_base_of_v<Windows::Foundation::IUnknown, T>, T, com_ptr<T>>;
 
-    template <typename T>
+    template <typename T, std::enable_if_t<is_implements_v<T>, int> = 0>
     com_ref<T> wrap_as_result(void* result)
     {
-        if constexpr (is_implements_v<T>)
-        {
-            return { &static_cast<produce<T, typename default_interface<T>::type>*>(result)->shim(), take_ownership_from_abi };
-        }
-        else
-        {
-            return { result, take_ownership_from_abi };
-        }
+        return { &static_cast<produce<T, typename default_interface<T>::type>*>(result)->shim(), take_ownership_from_abi };
+    }
+
+    template <typename T, std::enable_if_t<!is_implements_v<T>, int> = 0>
+    com_ref<T> wrap_as_result(void* result)
+    {
+        return { result, take_ownership_from_abi };
     }
 
     template <typename To, typename From>

--- a/src/tool/cpp/cppwinrt/main.cpp
+++ b/src/tool/cpp/cppwinrt/main.cpp
@@ -140,6 +140,16 @@ namespace xlang
         }
     }
 
+    static bool has_projected_types(cache::namespace_members const& members)
+    {
+        return
+            !members.interfaces.empty() ||
+            !members.classes.empty() ||
+            !members.enums.empty() ||
+            !members.structs.empty() ||
+            !members.delegates.empty();
+    }
+
     static void run(int const argc, char** argv)
     {
         writer w;
@@ -182,7 +192,7 @@ namespace xlang
             {
                 group.add([&, &ns = ns, &members = members]
                 {
-                    if (members.types.empty() || !settings.filter.includes(members))
+                    if (!has_projected_types(members) || !settings.filter.includes(members))
                     {
                         return;
                     }

--- a/src/tool/cpp/cppwinrt/main.cpp
+++ b/src/tool/cpp/cppwinrt/main.cpp
@@ -19,7 +19,7 @@ namespace xlang
     {
         std::vector<cmd::option> options
         {
-            { "input", 1 },
+            { "input", 0 },
             { "reference", 0 },
             { "output", 0, 1 },
             { "component", 0, 1 },

--- a/src/tool/cpp/cppwinrt/strings/base_windows.h
+++ b/src/tool/cpp/cppwinrt/strings/base_windows.h
@@ -4,17 +4,16 @@ namespace winrt::impl
     template <typename T>
     using com_ref = std::conditional_t<std::is_base_of_v<Windows::Foundation::IUnknown, T>, T, com_ptr<T>>;
 
-    template <typename T>
+    template <typename T, std::enable_if_t<is_implements_v<T>, int> = 0>
     com_ref<T> wrap_as_result(void* result)
     {
-        if constexpr (is_implements_v<T>)
-        {
-            return { &static_cast<produce<T, typename default_interface<T>::type>*>(result)->shim(), take_ownership_from_abi };
-        }
-        else
-        {
-            return { result, take_ownership_from_abi };
-        }
+        return { &static_cast<produce<T, typename default_interface<T>::type>*>(result)->shim(), take_ownership_from_abi };
+    }
+
+    template <typename T, std::enable_if_t<!is_implements_v<T>, int> = 0>
+    com_ref<T> wrap_as_result(void* result)
+    {
+        return { result, take_ownership_from_abi };
     }
 
     template <typename To, typename From>


### PR DESCRIPTION
The Windows OS is built with a fork of the Microsoft C++ compiler. The current version of this compiler is roughly comparable to Visual C++ 15.8, but includes a critical constexpr bug that has since been fixed in commercial releases. This workaround allows C++/WinRT to be ingested into the OS repo and build successfully with the this compiler.