### PR TITLE
Improve C++/WinRT component incremental builds

### DIFF
--- a/src/library/text_writer.h
+++ b/src/library/text_writer.h
@@ -143,9 +143,13 @@ namespace xlang::text
 
         void flush_to_file(std::string const& filename)
         {
+            if (static_cast<T*>(this)->skip_flush_to_file(filename))
+            {
+                return;
+            }
+
             std::ofstream file{ filename, std::ios::out | std::ios::binary };
-            std::array<uint8_t, 3> bom{ 0xEF, 0xBB, 0xBF };
-            file.write(reinterpret_cast<char*>(bom.data()), bom.size());
+            file.write(reinterpret_cast<char const*>(m_bom.data()), m_bom.size());
             file.write(m_first.data(), m_first.size());
             file.write(m_second.data(), m_second.size());
             m_first.clear();
@@ -162,11 +166,45 @@ namespace xlang::text
             return m_first.empty() ? char{} : m_first.back();
         }
 
+        bool file_equal(std::string const& filename) const
+        {
+            if (!std::experimental::filesystem::exists(filename))
+            {
+                return false;
+            }
+
+            meta::reader::file_view file{ filename };
+
+            if (file.size() != m_bom.size() + m_first.size() + m_second.size())
+            {
+                return false;
+            }
+
+            if (!std::equal(m_bom.begin(), m_bom.end(), file.begin(), file.begin() + m_bom.size()))
+            {
+                return false;
+            }
+
+            if (!std::equal(m_first.begin(), m_first.end(), file.begin() + m_bom.size(), file.begin() + m_bom.size() + m_first.size()))
+            {
+                return false;
+            }
+
+            return std::equal(m_second.begin(), m_second.end(), file.begin() + m_bom.size() + m_first.size(), file.end());
+        }
+
 #if defined(XLANG_DEBUG)
         bool debug_trace{};
 #endif
 
     private:
+
+        static constexpr std::array<uint8_t, 3> m_bom{ 0xEF, 0xBB, 0xBF };
+
+        constexpr bool skip_flush_to_file(std::string const&) const noexcept
+        {
+            return false;
+        }
 
         static constexpr uint32_t count_placeholders(std::string_view const& format) noexcept
         {

--- a/src/tool/cpp/cppwinrt/type_writers.h
+++ b/src/tool/cpp/cppwinrt/type_writers.h
@@ -535,5 +535,15 @@ namespace xlang
             filename += ".h";
             flush_to_file(filename);
         }
+
+        bool skip_flush_to_file(std::string const& filename) const
+        {
+            if (!settings.component)
+            {
+                return false;
+            }
+
+            return file_equal(filename);
+        }
     };
 }


### PR DESCRIPTION
This update avoids rewriting headers for components when their contents has not changed. This can improve build time considerably when cppwinrt is rerun for some reason but leaves all or some of the headers unchanged. For example, if a given component implements types from two different (child) namespaces then only the sources that actually include the namespace headers that were affected will actually have to be recompiled.