### PR TITLE
Improve C++/WinRT compat with Xaml projects

### DIFF
--- a/src/library/impl/meta_reader/cache.h
+++ b/src/library/impl/meta_reader/cache.h
@@ -21,12 +21,7 @@ namespace xlang::meta::reader
                     }
 
                     auto& ns = m_namespaces[type.TypeNamespace()];
-                    auto insert = ns.types.try_emplace(type.TypeName(), type);
-
-                    if (insert.second == false)
-                    {
-                        throw_invalid("Duplicate type indicates invalid combination of metadata files");
-                    }
+                    ns.types.try_emplace(type.TypeName(), type);
                 }
             }
 

--- a/src/tool/cpp/cppwinrt/helpers.h
+++ b/src/tool/cpp/cppwinrt/helpers.h
@@ -117,7 +117,7 @@ namespace xlang
 
         if (impls.first != impls.second)
         {
-            throw_invalid("Type '", type.TypeNamespace(), ".", type.TypeName(), "' does not have a default interface");
+            return impls.first.Interface();
         }
 
         return {};


### PR DESCRIPTION
It turns out that Xaml projects are a source of questionable metadata and cppwinrt needs to be a little more resilient for compatibility. Previously, cppwinrt allowed for activatable runtime classes that didn't declare a default interface. This was never supposed to happen but MIDLRT mistakenly allowed it, so we need to maintain this accommodation for now. Also, some build configurations for Xaml projects will mistakenly end up feeding xppwinrt winmds with overlapping types. The cppwinrt compiler has to ignore dupes on the assumption that the types are identical. 