### PR TITLE
C++/WinRT help diagnose stack allocations

### DIFF
--- a/src/tool/cpp/cppwinrt/code_writers.h
+++ b/src/tool/cpp/cppwinrt/code_writers.h
@@ -888,10 +888,7 @@ static_assert(winrt::check_version(CPPWINRT_VERSION, "%"), "Mismatched C++/WinRT
                 }
             }
 
-            if (w.param_names)
-            {
-                w.write(" %", param.Name());
-            }
+            w.write(" %", param.Name());
         }
     }
 

--- a/src/tool/cpp/cppwinrt/component_writers.h
+++ b/src/tool/cpp/cppwinrt/component_writers.h
@@ -381,8 +381,7 @@ int32_t WINRT_CALL WINRT_GetActivationFactory(void* classId, void** factory) noe
 
         if (has_factory_members(w, type))
         {
-            auto format = R"(
-void* winrt_make_%()
+            auto format = R"(void* winrt_make_%()
 {
     return winrt::detach_abi(winrt::make<winrt::@::factory_implementation::%>());
 }

--- a/src/tool/cpp/cppwinrt/component_writers.h
+++ b/src/tool/cpp/cppwinrt/component_writers.h
@@ -1083,15 +1083,30 @@ namespace winrt::@::implementation
 
     static void write_component_cpp(writer& w, TypeDef const& type)
     {
-        auto format = R"(#include "%.h"
+        auto filename = get_component_filename(type);
 
+        {
+            auto format = R"(#include "%.h"
+)";
+
+            w.write(format, filename);
+        }
+
+        if (settings.component_opt)
+        {
+            auto format = R"(#include "%.g.cpp"
+)";
+
+            w.write(format, filename);
+        }
+
+        auto format = R"(
 namespace winrt::@::implementation
 {
 %}
 )";
 
         w.write(format,
-            get_component_filename(type),
             type.TypeNamespace(),
             bind<write_component_member_definitions>(type));
     }

--- a/src/tool/cpp/cppwinrt/main.cpp
+++ b/src/tool/cpp/cppwinrt/main.cpp
@@ -167,7 +167,8 @@ namespace xlang
 
             if (settings.verbose)
             {
-                w.write(" tool:  % (C++/WinRT v%)\n", canonical(argv[0]).string(), XLANG_VERSION_STRING);
+                w.write(" tool:  %\n", canonical(argv[0]).string());
+                w.write(" ver:   %\n", XLANG_VERSION_STRING);
 
                 for (auto&& file : settings.input)
                 {

--- a/src/tool/cpp/cppwinrt/main.cpp
+++ b/src/tool/cpp/cppwinrt/main.cpp
@@ -163,7 +163,7 @@ namespace xlang
             c.remove_cppwinrt_foundation_types();
             supplement_includes(c);
             settings.filter = { settings.include, settings.exclude };
-            settings.base = settings.base || !settings.component;
+            settings.base = settings.base || (!settings.component && settings.filter.empty());
 
             if (settings.verbose)
             {

--- a/src/tool/cpp/cppwinrt/strings/base_extern.h
+++ b/src/tool/cpp/cppwinrt/strings/base_extern.h
@@ -40,6 +40,7 @@ extern "C"
     uint32_t WINRT_CALL WINRT_FormatMessageW(uint32_t flags, void const* source, uint32_t code, uint32_t language, wchar_t* buffer, uint32_t size, va_list* arguments) noexcept;
     uint32_t WINRT_CALL WINRT_GetLastError() noexcept;
     void     WINRT_CALL WINRT_GetSystemTimePreciseAsFileTime(void* result) noexcept;
+    size_t   WINRT_CALL WINRT_VirtualQuery(void const* address, void* buffer, size_t length) noexcept;
 
     int32_t  WINRT_CALL WINRT_OpenProcessToken(void* process, uint32_t access, void** token) noexcept;
     void*    WINRT_CALL WINRT_GetCurrentProcess() noexcept;
@@ -117,6 +118,7 @@ WINRT_LINK(GetProcessHeap, 0)
 WINRT_LINK(FormatMessageW, 28)
 WINRT_LINK(GetLastError, 0)
 WINRT_LINK(GetSystemTimePreciseAsFileTime, 4)
+WINRT_LINK(VirtualQuery, 12)
 
 WINRT_LINK(OpenProcessToken, 12)
 WINRT_LINK(GetCurrentProcess, 0)

--- a/src/tool/cpp/cppwinrt/strings/base_extern.h
+++ b/src/tool/cpp/cppwinrt/strings/base_extern.h
@@ -40,7 +40,7 @@ extern "C"
     uint32_t WINRT_CALL WINRT_FormatMessageW(uint32_t flags, void const* source, uint32_t code, uint32_t language, wchar_t* buffer, uint32_t size, va_list* arguments) noexcept;
     uint32_t WINRT_CALL WINRT_GetLastError() noexcept;
     void     WINRT_CALL WINRT_GetSystemTimePreciseAsFileTime(void* result) noexcept;
-    size_t   WINRT_CALL WINRT_VirtualQuery(void const* address, void* buffer, size_t length) noexcept;
+    void     WINRT_CALL WINRT_GetCurrentThreadStackLimits(uintptr_t* low_limit, uintptr_t* high_limit) noexcept;
 
     int32_t  WINRT_CALL WINRT_OpenProcessToken(void* process, uint32_t access, void** token) noexcept;
     void*    WINRT_CALL WINRT_GetCurrentProcess() noexcept;
@@ -118,7 +118,7 @@ WINRT_LINK(GetProcessHeap, 0)
 WINRT_LINK(FormatMessageW, 28)
 WINRT_LINK(GetLastError, 0)
 WINRT_LINK(GetSystemTimePreciseAsFileTime, 4)
-WINRT_LINK(VirtualQuery, 12)
+WINRT_LINK(GetCurrentThreadStackLimits, 8)
 
 WINRT_LINK(OpenProcessToken, 12)
 WINRT_LINK(GetCurrentProcess, 0)


### PR DESCRIPTION
This update contains a few minor tweaks to aid component developers. Some code gen and formatting fixes as well as a debug-only assertion to help detect stack allocations. 

Since the projected and implementation class names are (by default) the same and only differ by namespace, it is possible to mistake the one for the other and accidentally create an implementation on the stack rather than using the `make<T>` helpers. WRL avoids this by playing tricks with `new` and `delete`, which is basically guaranteed to cause other problems and is why C++/WinRT intentionally does not mess with new and delete.

Still, this can be hard to diagnose in some cases as the object may be destroyed while outstanding references are still in flight. An assertion will now pick this up for debug builds. The `is_stack_object` function was kindly donated by @jamesmcnellis. 