### PR TITLE
C++/WinRT now uses [[nodiscard]] to avoid creating useless temporaries by failing to co_await the thread pool helpers

### DIFF
--- a/src/library/text_writer.h
+++ b/src/library/text_writer.h
@@ -143,7 +143,7 @@ namespace xlang::text
 
         void flush_to_file(std::string const& filename)
         {
-            if (static_cast<T*>(this)->skip_flush_to_file(filename))
+            if (file_equal(filename))
             {
                 return;
             }
@@ -200,11 +200,6 @@ namespace xlang::text
     private:
 
         static constexpr std::array<uint8_t, 3> m_bom{ 0xEF, 0xBB, 0xBF };
-
-        constexpr bool skip_flush_to_file(std::string const&) const noexcept
-        {
-            return false;
-        }
 
         static constexpr uint32_t count_placeholders(std::string_view const& format) noexcept
         {

--- a/src/test/cpp/component.idl
+++ b/src/test/cpp/component.idl
@@ -1,15 +1,13 @@
 namespace Windows.Foundation.Metadata
 {
     [attributeusage(target_runtimeclass)]
-    [attributename("fastabi")]
-    [version(1.0)]
     attribute FastAbiAttribute
     {
+        type Contract;
+        Int32 Version;
     }
 
     [attributeusage(target_method, target_property)]
-    [attributename("noexcept")]
-    [version(1.0)]
     attribute NoExceptionAttribute
     {
     }
@@ -89,6 +87,11 @@ namespace Component
 
     namespace Fast
     {
+        struct DummyType
+        {
+            Int32 Value;
+        };
+
         [exclusiveto(FastClass)]
         interface IFastClass
         {
@@ -123,7 +126,7 @@ namespace Component
             static String StaticMethod();
         }
 
-        [fastabi]
+        [Windows.Foundation.Metadata.FastAbi(DummyType, 123)]
         runtimeclass FastClass : [default] IFastClass, IFastClass2, Component.INotExclusive
         {
             FastClass();

--- a/src/tool/cpp/cppwinrt/type_writers.h
+++ b/src/tool/cpp/cppwinrt/type_writers.h
@@ -535,15 +535,5 @@ namespace xlang
             filename += ".h";
             flush_to_file(filename);
         }
-
-        bool skip_flush_to_file(std::string const& filename) const
-        {
-            if (!settings.component)
-            {
-                return false;
-            }
-
-            return file_equal(filename);
-        }
     };
 }


### PR DESCRIPTION
The various thread pool helpers must all be used as `co_await` expressions for them to function:

```
co_await resume_background();

co_await resume_background(token);

co_await resume_after(5s);

co_await resume_on_signal(handle);
```

But I noticed that some developers forget or don't realize they need to `co_await` them in order for them to work. The following effectively does nothing:

```
resume_background();

resume_background(token);

resume_after(5s);

resume_on_signal(handle);
```

With this update, all of these are marked as [[nodiscard]] and will produce a compiler warning if the return value is not used. 

I've also included contract parameters for the FastAbi attribute. This is in preparation for adding these attributes to the OS metadata (coming up next).

I have also turned on the text writer optimization (to skip flushing files that haven't changed) for all as it has shown to have a very perceptible value in practice and very little downside. 