### PR TITLE
Ensure that C++/WinRT may be compiled without /await

### DIFF
--- a/src/tool/cpp/cppwinrt/strings/base_coroutine_resume.h
+++ b/src/tool/cpp/cppwinrt/strings/base_coroutine_resume.h
@@ -165,10 +165,12 @@ namespace winrt
         return awaitable{ duration };
     }
 
+#ifdef _RESUMABLE_FUNCTIONS_SUPPORTED
     inline auto operator co_await(Windows::Foundation::TimeSpan duration)
     {
         return resume_after(duration);
     }
+#endif
 
     [[nodiscard]] inline auto resume_on_signal(void* handle, Windows::Foundation::TimeSpan timeout = {}) noexcept
     {


### PR DESCRIPTION
This will simplify OS ingestion and library adoption for projects that don't initially have coroutine support enabled. 