### PR TITLE
added support for coded_index<TypeDefOrRef> 

### DIFF
--- a/src/library/xlang.meta.natvis
+++ b/src/library/xlang.meta.natvis
@@ -26,11 +26,24 @@
       <Parameter Name="row" Type="uint32_t" />
       <Parameter Name="column" Type="uint32_t" />
     </Intrinsic>
+    <Intrinsic Name="i_get_string" Expression="m_database->i_get_string(i_get_value(row, column))">
+      <Parameter Name="row" Type="uint32_t" />
+      <Parameter Name="column" Type="uint32_t" />
+    </Intrinsic>
+  </Type>
+
+  <Type Name="xlang::meta::reader::table&lt;*&gt;">
+    <Intrinsic Name="i_TypeName" Expression="i_get_string(row, 1)">
+      <Parameter Name="row" Type="uint32_t" />
+    </Intrinsic>
+    <Intrinsic Name="i_TypeNamespace" Expression="i_get_string(row, 2)">
+      <Parameter Name="row" Type="uint32_t" />
+    </Intrinsic>
   </Type>
 
   <Type Name="xlang::meta::reader::row_base&lt;*&gt;">
     <Intrinsic Name="i_get_database" Expression="m_table->i_get_database()" />
-    <Intrinsic Name="i_get_string" Expression="i_get_database()->i_get_string(m_table->i_get_value(m_index, column))">
+    <Intrinsic Name="i_get_string" Expression="m_table->i_get_string(m_index, column)">
       <Parameter Name="column" Type="uint32_t" />
     </Intrinsic>
   </Type>
@@ -50,6 +63,40 @@
     <Intrinsic Name="i_TypeNamespace" Expression="i_get_string(2)" />
     <DisplayString>{i_TypeNamespace(),sb}.{i_TypeName(),sb}</DisplayString>
     <Expand>
+      <Item Name="TypeNamespace">i_TypeNamespace()</Item>
+      <Item Name="TypeName">i_TypeName()</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="xlang::meta::reader::index_base&lt;*&gt;">
+    <Intrinsic Name="i_type" Expression="m_value &amp; ((1 &lt;&lt; coded_index_bits) - 1)">
+      <Parameter Name="coded_index_bits" Type="uint32_t" />
+    </Intrinsic>
+    <Intrinsic Name="i_index" Expression="(m_value &gt;&gt; coded_index_bits) - 1">
+      <Parameter Name="coded_index_bits" Type="uint32_t" />
+    </Intrinsic>
+    <Intrinsic Name="i_get_database" Expression="m_table->i_get_database()" />
+  </Type>
+
+  <Type Name="xlang::meta::reader::coded_index&lt;enum xlang::meta::reader::TypeDefOrRef&gt;">
+    <Intrinsic Name="i_type" Expression="i_type(2)"/>
+    <Intrinsic Name="i_index" Expression="i_index(2)"/>
+    <Intrinsic Name="i_TypeDef" Expression="&amp;i_get_database()->TypeDef" />
+    <Intrinsic Name="i_TypeRef" Expression="&amp;i_get_database()->TypeRef" />
+    <Intrinsic Name="i_TypeSpec" Expression="&amp;i_get_database()->TypeSpec" />
+    <Intrinsic Name="i_TypeName" Expression="i_type() == 0 ? i_TypeDef()->i_TypeName(i_index()) : i_type() == 1 ? i_TypeRef()->i_TypeName(i_index()) : i_TypeSpec()->i_TypeName(i_index())" />
+    <Intrinsic Name="i_TypeNamespace" Expression="i_type() == 0 ? i_TypeDef()->i_TypeNamespace(i_index()) : i_type() == 1 ? i_TypeRef()->i_TypeNamespace(i_index()) : i_TypeSpec()->i_TypeNamespace(i_index())" />
+    <DisplayString>{i_TypeNamespace(),sb}.{i_TypeName(),sb}</DisplayString>
+    <Expand>
+      <Synthetic Name="Type" Condition="i_type() == 0">
+        <DisplayString>TypeDef</DisplayString>
+      </Synthetic>
+      <Synthetic Name="Type" Condition="i_type() == 1">
+        <DisplayString>TypeRef</DisplayString>
+      </Synthetic>
+      <Synthetic Name="Type" Condition="i_type() == 2">
+        <DisplayString>TypeSpec</DisplayString>
+      </Synthetic>
       <Item Name="TypeNamespace">i_TypeNamespace()</Item>
       <Item Name="TypeName">i_TypeName()</Item>
     </Expand>

--- a/src/readme.md
+++ b/src/readme.md
@@ -97,7 +97,10 @@ The **/library** folder contains the C++ header libraries provided by xlang for 
 
 * **text_writer.h** writes formatted text output.
 
-* **xlang.meta.natvis** provides Visual Studio debug visualizations of xlang::meta types.  To use, see [Deploying .natvis files](https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2015#BKMK_natvis_location).
+* **xlang.meta.natvis** provides Visual Studio debug visualizations of xlang::meta types.  Recommended install technique is to create a symlink:
+  > mklink "%USERPROFILE%\Documents\Visual Studio 2017\Visualizers\xlang.meta.natvis" c:\xlang\src\library\xlang.meta.natvis
+
+  See also [Deploying .natvis files](https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2015#BKMK_natvis_location).
 
 ### /Platform
 


### PR DESCRIPTION
and thus TypeSig visualizations.  in future, can add other coded_index types.

Also, a great way to 'install' and pick up all future enhancements:
>mklink "%USERPROFILE%\Documents\Visual Studio 2017\Visualizers\xlang.meta.natvis" c:\xlang\src\library\xlang.meta.natvis
