### PR TITLE
Remove fixed size buffer when reading lines from the response file.

### DIFF
--- a/src/library/cmd_reader.h
+++ b/src/library/cmd_reader.h
@@ -271,7 +271,7 @@ namespace xlang::cmd
             }
             std::string line_buf;
             std::ifstream response_file(absolute(response_path));
-            while (getline(response_file, line_buf)) // getline calls line_buf.erase()
+            while (getline(response_file, line_buf))
             {
                 size_t argc = 0;
                 std::vector<std::string> argv;

--- a/src/library/cmd_reader.h
+++ b/src/library/cmd_reader.h
@@ -269,9 +269,9 @@ namespace xlang::cmd
             {
                 throw_invalid("'@' is reserved for response files");
             }
-            std::array<char, 8192> line_buf;
+            std::string line_buf;
             std::ifstream response_file(absolute(response_path));
-            while (response_file.getline(line_buf.data(), line_buf.size()))
+            while (getline(response_file, line_buf)) // getline calls line_buf.erase()
             {
                 size_t argc = 0;
                 std::vector<std::string> argv;


### PR DESCRIPTION
This PR removes a hardcoded maximum line length and instead, dynamically allocates a string to read lines. 

Currently cppwinrt.exe silently fails. @kennykerr thoughts on outputting some kind of error when the response file contains invalid data?