### PR TITLE
Smarter filtering for C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -2611,7 +2611,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
 
     static void write_class_definitions(writer& w, TypeDef const& type)
     {
-        if (settings.component_opt && settings.filter.includes(type))
+        if (settings.component_opt && settings.component_filter.includes(type))
         {
             return;
         }

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -8,7 +8,7 @@ namespace xlang
 
         for (auto&& base : get_bases(type))
         {
-            if (settings.filter.includes(base))
+            if (settings.component_filter.includes(base))
             {
                 continue;
             }
@@ -49,7 +49,7 @@ namespace xlang
 
         for (auto&& base : get_bases(type))
         {
-            if (settings.filter.includes(base))
+            if (settings.component_filter.includes(base))
             {
                 return;
             }
@@ -236,7 +236,7 @@ int32_t WINRT_CALL WINRT_GetActivationFactory(void* classId, void** factory) noe
             return;
         }
 
-        if (settings.filter.includes(base_type))
+        if (settings.component_filter.includes(base_type))
         {
             return;
         }
@@ -580,7 +580,7 @@ int32_t WINRT_CALL WINRT_GetActivationFactory(void* classId, void** factory) noe
             return;
         }
 
-        if (settings.filter.includes(base_type))
+        if (settings.component_filter.includes(base_type))
         {
             return;
         }
@@ -655,7 +655,7 @@ int32_t WINRT_CALL WINRT_GetActivationFactory(void* classId, void** factory) noe
 
             if (base_type)
             {
-                bool const external_base_type = !settings.filter.includes(base_type);
+                bool const external_base_type = !settings.component_filter.includes(base_type);
 
                 if (external_base_type)
                 {
@@ -785,7 +785,7 @@ namespace winrt::@::implementation
         auto type_name = type.TypeName();
         auto base_type = get_base_class(type);
 
-        if (base_type && settings.filter.includes(base_type))
+        if (base_type && settings.component_filter.includes(base_type))
         {
             w.write(" : %T<%, @::implementation::%>",
                 type_name,
@@ -882,7 +882,7 @@ namespace winrt::@::implementation
         auto base_type = get_base_class(type);
         std::string base_include;
 
-        if (base_type && settings.filter.includes(base_type))
+        if (base_type && settings.component_filter.includes(base_type))
         {
             base_include = "#include \"" + get_component_filename(base_type) + ".h\"\n";
         }

--- a/src/tool/cppwinrt/cppwinrt/main.cpp
+++ b/src/tool/cppwinrt/cppwinrt/main.cpp
@@ -153,7 +153,7 @@ Where <spec> is one or more of:
         return files;
     }
 
-    static void build_projection_filter(cache const& c)
+    static void build_filters(cache const& c)
     {
         if (settings.reference.empty())
         {
@@ -181,6 +181,16 @@ Where <spec> is one or more of:
         }
 
         settings.projection_filter = { include, {} };
+
+        if (settings.include.empty() && settings.exclude.empty())
+        {
+            settings.component_filter = { include, {} };
+        }
+        else
+        {
+            settings.component_filter = { settings.include, settings.exclude };
+        }
+
     }
 
     static bool has_projected_types(cache::namespace_members const& members)
@@ -204,8 +214,7 @@ Where <spec> is one or more of:
             process_args(argc, argv);
             cache c{ get_files_to_cache() };
             c.remove_cppwinrt_foundation_types();
-            build_projection_filter(c);
-            settings.component_filter = { settings.include, settings.exclude };
+            build_filters(c);
             settings.base = settings.base || (!settings.component && settings.projection_filter.empty());
 
             if (settings.verbose)

--- a/src/tool/cppwinrt/cppwinrt/main.cpp
+++ b/src/tool/cppwinrt/cppwinrt/main.cpp
@@ -153,12 +153,14 @@ Where <spec> is one or more of:
         return files;
     }
 
-    static void supplement_includes(cache const& c)
+    static void build_projection_filter(cache const& c)
     {
-        if (settings.reference.empty() || !settings.include.empty())
+        if (settings.reference.empty())
         {
             return;
         }
+
+        std::set<std::string> include;
 
         for (auto file : settings.input)
         {
@@ -174,12 +176,11 @@ Where <spec> is one or more of:
                     continue;
                 }
 
-                std::string include{ type.TypeNamespace() };
-                include += '.';
-                include += type.TypeName();
-                settings.include.insert(include);
+                include.insert(std::string{ type.TypeNamespace() });
             }
         }
+
+        settings.projection_filter = { include, {} };
     }
 
     static bool has_projected_types(cache::namespace_members const& members)
@@ -203,9 +204,9 @@ Where <spec> is one or more of:
             process_args(argc, argv);
             cache c{ get_files_to_cache() };
             c.remove_cppwinrt_foundation_types();
-            supplement_includes(c);
-            settings.filter = { settings.include, settings.exclude };
-            settings.base = settings.base || (!settings.component && settings.filter.empty());
+            build_projection_filter(c);
+            settings.component_filter = { settings.include, settings.exclude };
+            settings.base = settings.base || (!settings.component && settings.projection_filter.empty());
 
             if (settings.verbose)
             {
@@ -237,7 +238,7 @@ Where <spec> is one or more of:
             {
                 group.add([&, &ns = ns, &members = members]
                 {
-                    if (!has_projected_types(members) || !settings.filter.includes(members))
+                    if (!has_projected_types(members) || !settings.projection_filter.includes(members))
                     {
                         return;
                     }
@@ -265,7 +266,7 @@ Where <spec> is one or more of:
                     {
                         for (auto&& type : members.classes)
                         {
-                            if (settings.filter.includes(type))
+                            if (settings.component_filter.includes(type))
                             {
                                 classes.push_back(type);
                             }

--- a/src/tool/cppwinrt/cppwinrt/settings.h
+++ b/src/tool/cppwinrt/cppwinrt/settings.h
@@ -26,7 +26,8 @@ namespace xlang
         std::set<std::string> include;
         std::set<std::string> exclude;
 
-        meta::reader::filter filter;
+        meta::reader::filter projection_filter;
+        meta::reader::filter component_filter;
     };
 
     extern settings_type settings;


### PR DESCRIPTION
I discovered that the Cortana API is implemented with C++/WinRT but that they are using the command line in an unexpected way. This requires smarter command line filtering and the separation of projection and component filtering to make it sane.