### PR TITLE
Add support for using winrt::com_ptr with IID_PPV_ARGS

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/cppwinrt.vcxproj.filters
+++ b/src/tool/cppwinrt/cppwinrt/cppwinrt.vcxproj.filters
@@ -3,7 +3,7 @@
   <ItemGroup>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="pch.cpp" />
-    <ClCompile Include="$(CmakeOutDir)strings.cpp" />
+    <ClCompile Include="$(OutDir)strings.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="code_writers.h" />
@@ -165,7 +165,7 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="$(CmakeOutDir)version.rc" />
+    <ResourceCompile Include="$(OutDir)version.rc" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="strings">

--- a/src/tool/cppwinrt/strings/base_com_ptr.h
+++ b/src/tool/cppwinrt/strings/base_com_ptr.h
@@ -303,3 +303,9 @@ namespace winrt
         return !(left < right);
     }
 }
+
+template <typename T>
+void** IID_PPV_ARGS_Helper(winrt::com_ptr<T>* ptr) noexcept
+{
+    return winrt::put_abi(*ptr);
+}

--- a/src/tool/cppwinrt/test_cpp/iid_ppv_args.cpp
+++ b/src/tool/cppwinrt/test_cpp/iid_ppv_args.cpp
@@ -1,0 +1,39 @@
+#include "pch.h"
+#include <windows.foundation.h>
+
+namespace
+{
+    struct Stringable : winrt::implements<Stringable, winrt::Windows::Foundation::IStringable>
+    {
+        winrt::hstring ToString()
+        {
+            return L"hello";
+        }
+    };
+
+    HRESULT GetStringable(GUID const& id, void** object) noexcept
+    {
+        *object = nullptr;
+
+        if (id != __uuidof(ABI::Windows::Foundation::IStringable))
+        {
+            return E_NOINTERFACE;
+        }
+
+        *object = winrt::detach_abi(winrt::make<Stringable>());
+        return S_OK;
+    }
+}
+
+TEST_CASE("iid_ppv_args")
+{
+    {
+        winrt::com_ptr<ABI::Windows::Foundation::IStringable> ptr;
+        REQUIRE(S_OK == GetStringable(IID_PPV_ARGS(&ptr)));
+        REQUIRE(ptr.as<winrt::Windows::Foundation::IStringable>().ToString() == L"hello");
+    }
+    {
+        winrt::com_ptr<ABI::Windows::Foundation::IClosable> ptr;
+        REQUIRE(E_NOINTERFACE == GetStringable(IID_PPV_ARGS(&ptr)));
+    }
+}

--- a/src/tool/cppwinrt/test_cpp/unit_tests.vcxproj
+++ b/src/tool/cppwinrt/test_cpp/unit_tests.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="enum.cpp" />
     <ClCompile Include="final_release.cpp" />
     <ClCompile Include="GetMany.cpp" />
+    <ClCompile Include="iid_ppv_args.cpp" />
     <ClCompile Include="interop.cpp" />
     <ClCompile Include="invalid_events.cpp" />
     <ClCompile Include="in_params.cpp" />


### PR DESCRIPTION
While I'm not fond of macros, this macro is rather popular in the OS when dealing with COM APIs. Fortunately, it's extensible thanks to a clever implementation that allows overrides:

```
#define IID_PPV_ARGS(ppType) __uuidof(**(ppType)), IID_PPV_ARGS_Helper(ppType)
```

This update makes it easier to use C++/WinRT with existing COM APIs.
