### PR TITLE
C++/WinRT must skip empty namespaces when including parents

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -2455,6 +2455,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
 
     static void write_constructor_declarations(writer& w, TypeDef const& type, std::map<std::string, factory_info> const& factories)
     {
+        w.async_types = false;
         auto type_name = type.TypeName();
 
         for (auto&& [factory_name, factory] : factories)

--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -67,6 +67,28 @@ namespace xlang
         w.write(format);
     }
 
+    static void write_parent_depends(writer& w, cache const& c, std::string_view const& type_namespace)
+    {
+        auto pos = type_namespace.rfind('.');
+
+        if (pos == std::string::npos)
+        {
+            return;
+        }
+
+        auto parent = type_namespace.substr(0, pos);
+        auto found = c.namespaces().find(parent);
+
+        if (found != c.namespaces().end() && has_projected_types(found->second))
+        {
+            w.write_root_include(parent);
+        }
+        else
+        {
+            write_parent_depends(w, c, parent);
+        }
+    }
+
     static void write_pch(writer& w)
     {
         auto format = R"(#include "%"

--- a/src/tool/cppwinrt/cppwinrt/file_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/file_writers.h
@@ -197,7 +197,7 @@ namespace xlang
         write_preamble(w);
         write_open_file_guard(w, ns);
         write_version_assert(w);
-        w.write_parent_depends(c);
+        write_parent_depends(w, c, ns);
 
         for (auto&& depends : w.depends)
         {

--- a/src/tool/cppwinrt/cppwinrt/helpers.h
+++ b/src/tool/cppwinrt/cppwinrt/helpers.h
@@ -548,4 +548,14 @@ namespace xlang
 
         return false;
     }
+
+    static bool has_projected_types(cache::namespace_members const& members)
+    {
+        return
+            !members.interfaces.empty() ||
+            !members.classes.empty() ||
+            !members.enums.empty() ||
+            !members.structs.empty() ||
+            !members.delegates.empty();
+    }
 }

--- a/src/tool/cppwinrt/cppwinrt/main.cpp
+++ b/src/tool/cppwinrt/cppwinrt/main.cpp
@@ -252,24 +252,6 @@ Where <spec> is one or more of:
                 });
             }
 
-//            {
-//                writer test;
-//
-//                for (auto&& [ns, members] : c.namespaces())
-//                {
-//                    if (!has_projected_types(members) || !settings.projection_filter.includes(members))
-//                    {
-//                        continue;
-//                    }
-//
-//                    test.write(R"(#include "winrt/%.h"
-//)",
-//                        ns);
-//                }
-//
-//                test.flush_to_file(settings.output_folder + "all.h");
-//            }
-
             group.add([&]
             {
                 if (settings.base)

--- a/src/tool/cppwinrt/cppwinrt/main.cpp
+++ b/src/tool/cppwinrt/cppwinrt/main.cpp
@@ -196,16 +196,6 @@ Where <spec> is one or more of:
 
     }
 
-    static bool has_projected_types(cache::namespace_members const& members)
-    {
-        return
-            !members.interfaces.empty() ||
-            !members.classes.empty() ||
-            !members.enums.empty() ||
-            !members.structs.empty() ||
-            !members.delegates.empty();
-    }
-
     static int run(int const argc, char** argv)
     {
         int result{};
@@ -261,6 +251,24 @@ Where <spec> is one or more of:
                     write_namespace_h(c, ns, members);
                 });
             }
+
+//            {
+//                writer test;
+//
+//                for (auto&& [ns, members] : c.namespaces())
+//                {
+//                    if (!has_projected_types(members) || !settings.projection_filter.includes(members))
+//                    {
+//                        continue;
+//                    }
+//
+//                    test.write(R"(#include "winrt/%.h"
+//)",
+//                        ns);
+//                }
+//
+//                test.flush_to_file(settings.output_folder + "all.h");
+//            }
 
             group.add([&]
             {

--- a/src/tool/cppwinrt/cppwinrt/type_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/type_writers.h
@@ -501,25 +501,6 @@ namespace xlang
             }
         }
 
-        void write_parent_depends(cache const& c)
-        {
-            auto pos = type_namespace.rfind('.');
-
-            if (pos == std::string::npos)
-            {
-                return;
-            }
-
-            auto parent = type_namespace.substr(0, pos);
-
-            if (c.namespaces().find(parent) == c.namespaces().end())
-            {
-                return;
-            }
-
-            write_root_include(parent);
-        }
-
         void save_header(char impl = 0)
         {
             auto filename{ settings.output_folder + "winrt/" };

--- a/src/tool/cppwinrt/test_component/test_component.idl
+++ b/src/tool/cppwinrt/test_component/test_component.idl
@@ -224,4 +224,24 @@ namespace test_component
             };
         }
     }
+
+    namespace Parent
+    {
+        // This validates namespace inclusion rules. The "...Three.h" header must include the 
+        // "...Parent.h" header but skip over the intermediate namespaces as they are empty
+        // and won't be generated and those won't exist.
+
+        struct ParentStruct
+        {
+            Int32 Value;
+        };
+
+        namespace One.Two.Three
+        {
+            struct ThreeStruct
+            {
+                Int32 Value;
+            };
+        }
+    }
 }

--- a/src/tool/cppwinrt/test_cpp/parent_includes.cpp
+++ b/src/tool/cppwinrt/test_cpp/parent_includes.cpp
@@ -1,0 +1,17 @@
+#include "pch.h"
+#include "winrt/test_component.Parent.One.Two.Three.h"
+
+using namespace winrt::test_component;
+
+TEST_CASE("parent_includes")
+{
+    // Including "...Three.h" should include all (available) ancestors, skipping 
+    // any that are empty. In this case, "Three" and "Parent" are not empty while
+    // the intermediate namespaces are empty.
+
+    Parent::One::Two::Three::ThreeStruct three;
+    three.Value = 0;
+
+    Parent::ParentStruct parent;
+    parent.Value = 0;
+}

--- a/src/tool/cppwinrt/test_cpp/unit_tests.vcxproj
+++ b/src/tool/cppwinrt/test_cpp/unit_tests.vcxproj
@@ -228,6 +228,7 @@
     <ClCompile Include="noexcept.cpp" />
     <ClCompile Include="out_params.cpp" />
     <ClCompile Include="out_params_abi.cpp" />
+    <ClCompile Include="parent_includes.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>


### PR DESCRIPTION
When "winrt/A.B.C.D.h" is included, C+/WinRT will automatically include it's parent namespace header as well. However, if the parent is empty then the header will not exist and C++/WinRT must keep looking for a non-empty parent header to include, if any. 

This is now handled correctly with tests to validate.