### PR TITLE
meta_reader improvements

### DIFF
--- a/src/library/impl/meta_reader/column.h
+++ b/src/library/impl/meta_reader/column.h
@@ -479,7 +479,7 @@ namespace xlang::meta::reader
 
     inline auto AssemblyRef::Version() const
     {
-        auto const temp = get_value<uint64_t>(1);
+        auto const temp = get_value<uint64_t>(0);
         return AssemblyVersion{ static_cast<uint16_t>(temp & 0xffff), static_cast<uint16_t>((temp >> 16) & 0xffff), static_cast<uint16_t>((temp >> 32) & 0xffff), static_cast<uint16_t>((temp >> 48) & 0xffff) };
     }
 

--- a/src/library/impl/meta_reader/enum.h
+++ b/src/library/impl/meta_reader/enum.h
@@ -314,7 +314,7 @@ namespace xlang::meta::reader
     {
         PublicKey = 0x0001, // The assembly reference holds the full (unhashed) public key
         Retargetable = 0x0100,
-		WindowsRuntime = 0x0200,
+        WindowsRuntime = 0x0200,
         DisableJITcompileOptimizer = 0x4000,
         EnableJITcompileTracking = 0x8000,
     };

--- a/src/library/impl/meta_reader/enum.h
+++ b/src/library/impl/meta_reader/enum.h
@@ -313,7 +313,8 @@ namespace xlang::meta::reader
     enum class AssemblyFlags : uint32_t
     {
         PublicKey = 0x0001, // The assembly reference holds the full (unhashed) public key
-        Retargetable = 0x01000,
+        Retargetable = 0x0100,
+		WindowsRuntime = 0x0200,
         DisableJITcompileOptimizer = 0x4000,
         EnableJITcompileTracking = 0x8000,
     };

--- a/src/library/impl/meta_reader/flags.h
+++ b/src/library/impl/meta_reader/flags.h
@@ -40,20 +40,20 @@ namespace xlang::impl
 
 namespace xlang::meta::reader
 {
-	struct AssemblyAttributes : impl::AttributesBase<uint32_t>
-	{
-		constexpr bool WindowsRuntime() const noexcept
-		{
-			return get_bit(WindowsRuntime_bit);
-		}
-		void WindowsRuntime(bool arg) noexcept
-		{
-			set_bit(arg, WindowsRuntime_bit);
-		}
+    struct AssemblyAttributes : impl::AttributesBase<uint32_t>
+    {
+        constexpr bool WindowsRuntime() const noexcept
+        {
+            return get_bit(WindowsRuntime_bit);
+        }
+        void WindowsRuntime(bool arg) noexcept
+        {
+            set_bit(arg, WindowsRuntime_bit);
+        }
 
-	private:
-		static constexpr int WindowsRuntime_bit{ 9 };
-	};
+    private:
+        static constexpr int WindowsRuntime_bit{ 9 };
+    };
 
     struct EventAttributes : impl::AttributesBase<uint16_t>
     {

--- a/src/library/impl/meta_reader/flags.h
+++ b/src/library/impl/meta_reader/flags.h
@@ -40,6 +40,21 @@ namespace xlang::impl
 
 namespace xlang::meta::reader
 {
+	struct AssemblyAttributes : impl::AttributesBase<uint32_t>
+	{
+		constexpr bool WindowsRuntime() const noexcept
+		{
+			return get_bit(WindowsRuntime_bit);
+		}
+		void WindowsRuntime(bool arg) noexcept
+		{
+			set_bit(arg, WindowsRuntime_bit);
+		}
+
+	private:
+		static constexpr int WindowsRuntime_bit{ 9 };
+	};
+
     struct EventAttributes : impl::AttributesBase<uint16_t>
     {
         constexpr bool SpecialName() const noexcept

--- a/src/library/impl/meta_reader/index.h
+++ b/src/library/impl/meta_reader/index.h
@@ -10,6 +10,16 @@ namespace xlang::meta::reader
         auto Property() const;
     };
 
+	template <> struct typed_index<ResolutionScope> : index_base<ResolutionScope>
+	{
+		using index_base<ResolutionScope>::index_base;
+
+		auto Module() const;
+		auto ModuleRef() const;
+		auto AssemblyRef() const;
+		auto TypeRef() const;
+	};
+
     template <> struct typed_index<TypeDefOrRef> : index_base<TypeDefOrRef>
     {
         using index_base<TypeDefOrRef>::index_base;

--- a/src/library/impl/meta_reader/index.h
+++ b/src/library/impl/meta_reader/index.h
@@ -1,15 +1,15 @@
 
 namespace xlang::meta::reader
 {
-	template <> struct typed_index<CustomAttributeType> : index_base<CustomAttributeType>
-	{
-		using index_base<CustomAttributeType>::index_base;
+    template <> struct typed_index<CustomAttributeType> : index_base<CustomAttributeType>
+    {
+        using index_base<CustomAttributeType>::index_base;
 
-		auto MemberRef() const;
-		auto MethodDef() const;
-	};
+        auto MemberRef() const;
+        auto MethodDef() const;
+    };
 
-	template <> struct typed_index<HasConstant> : index_base<HasConstant>
+    template <> struct typed_index<HasConstant> : index_base<HasConstant>
     {
         using index_base<HasConstant>::index_base;
 
@@ -18,31 +18,31 @@ namespace xlang::meta::reader
         auto Property() const;
     };
 
-	template <> struct typed_index<HasSemantics> : index_base<HasSemantics>
-	{
-		using index_base<HasSemantics>::index_base;
+    template <> struct typed_index<HasSemantics> : index_base<HasSemantics>
+    {
+        using index_base<HasSemantics>::index_base;
 
-		auto Property() const;
-		auto Event() const;
-	};
+        auto Property() const;
+        auto Event() const;
+    };
 
-	template <> struct typed_index<MethodDefOrRef> : index_base<MethodDefOrRef>
-	{
-		using index_base<MethodDefOrRef>::index_base;
-		
-		auto MethodDef() const;
-		auto MemberRef() const;
-	};
+    template <> struct typed_index<MethodDefOrRef> : index_base<MethodDefOrRef>
+    {
+        using index_base<MethodDefOrRef>::index_base;
+        
+        auto MethodDef() const;
+        auto MemberRef() const;
+    };
 
-	template <> struct typed_index<ResolutionScope> : index_base<ResolutionScope>
-	{
-		using index_base<ResolutionScope>::index_base;
+    template <> struct typed_index<ResolutionScope> : index_base<ResolutionScope>
+    {
+        using index_base<ResolutionScope>::index_base;
 
-		auto Module() const;
-		auto ModuleRef() const;
-		auto AssemblyRef() const;
-		auto TypeRef() const;
-	};
+        auto Module() const;
+        auto ModuleRef() const;
+        auto AssemblyRef() const;
+        auto TypeRef() const;
+    };
 
     template <> struct typed_index<TypeDefOrRef> : index_base<TypeDefOrRef>
     {

--- a/src/library/impl/meta_reader/index.h
+++ b/src/library/impl/meta_reader/index.h
@@ -1,7 +1,15 @@
 
 namespace xlang::meta::reader
 {
-    template <> struct typed_index<HasConstant> : index_base<HasConstant>
+	template <> struct typed_index<CustomAttributeType> : index_base<CustomAttributeType>
+	{
+		using index_base<CustomAttributeType>::index_base;
+
+		auto MemberRef() const;
+		auto MethodDef() const;
+	};
+
+	template <> struct typed_index<HasConstant> : index_base<HasConstant>
     {
         using index_base<HasConstant>::index_base;
 
@@ -9,6 +17,22 @@ namespace xlang::meta::reader
         auto Param() const;
         auto Property() const;
     };
+
+	template <> struct typed_index<HasSemantics> : index_base<HasSemantics>
+	{
+		using index_base<HasSemantics>::index_base;
+
+		auto Property() const;
+		auto Event() const;
+	};
+
+	template <> struct typed_index<MethodDefOrRef> : index_base<MethodDefOrRef>
+	{
+		using index_base<MethodDefOrRef>::index_base;
+		
+		auto MethodDef() const;
+		auto MemberRef() const;
+	};
 
 	template <> struct typed_index<ResolutionScope> : index_base<ResolutionScope>
 	{
@@ -28,21 +52,5 @@ namespace xlang::meta::reader
         auto TypeRef() const;
         auto TypeSpec() const;
         auto CustomAttribute() const;
-    };
-
-    template <> struct typed_index<CustomAttributeType> : index_base<CustomAttributeType>
-    {
-        using index_base<CustomAttributeType>::index_base;
-
-        auto MemberRef() const;
-        auto MethodDef() const;
-    };
-
-    template <> struct typed_index<HasSemantics> : index_base<HasSemantics>
-    {
-        using index_base<HasSemantics>::index_base;
-
-        auto Property() const;
-        auto Event() const;
     };
 }

--- a/src/library/impl/meta_reader/key.h
+++ b/src/library/impl/meta_reader/key.h
@@ -9,6 +9,26 @@ namespace xlang::meta::reader
         return get_database().template get_table<Row>()[index()];
     }
 
+	inline auto typed_index<ResolutionScope>::Module() const
+	{
+		return get_row<reader::Module>();
+	}
+
+	inline auto typed_index<ResolutionScope>::ModuleRef() const
+	{
+		return get_row<reader::ModuleRef>();
+	}
+
+	inline auto typed_index<ResolutionScope>::AssemblyRef() const
+	{
+		return get_row<reader::AssemblyRef>();
+	}
+
+	inline auto typed_index<ResolutionScope>::TypeRef() const
+	{
+		return get_row<reader::TypeRef>();
+	}
+
     inline auto typed_index<TypeDefOrRef>::TypeDef() const
     {
         return get_row<reader::TypeDef>();

--- a/src/library/impl/meta_reader/key.h
+++ b/src/library/impl/meta_reader/key.h
@@ -9,70 +9,70 @@ namespace xlang::meta::reader
         return get_database().template get_table<Row>()[index()];
     }
 
-	inline auto typed_index<CustomAttributeType>::MemberRef() const
-	{
-		return get_row<reader::MemberRef>();
-	}
+    inline auto typed_index<CustomAttributeType>::MemberRef() const
+    {
+        return get_row<reader::MemberRef>();
+    }
 
-	inline auto typed_index<CustomAttributeType>::MethodDef() const
-	{
-		return get_row<reader::MethodDef>();
-	}
+    inline auto typed_index<CustomAttributeType>::MethodDef() const
+    {
+        return get_row<reader::MethodDef>();
+    }
 
-	inline auto typed_index<HasConstant>::Field() const
-	{
-		return get_row<reader::Field>();
-	}
+    inline auto typed_index<HasConstant>::Field() const
+    {
+        return get_row<reader::Field>();
+    }
 
-	inline auto typed_index<HasConstant>::Param() const
-	{
-		return get_row<reader::Param>();
-	}
+    inline auto typed_index<HasConstant>::Param() const
+    {
+        return get_row<reader::Param>();
+    }
 
-	inline auto typed_index<HasConstant>::Property() const
-	{
-		return get_row<reader::Property>();
-	}
+    inline auto typed_index<HasConstant>::Property() const
+    {
+        return get_row<reader::Property>();
+    }
 
-	inline auto typed_index<HasSemantics>::Property() const
-	{
-		return get_row<reader::Property>();
-	}
+    inline auto typed_index<HasSemantics>::Property() const
+    {
+        return get_row<reader::Property>();
+    }
 
-	inline auto typed_index<HasSemantics>::Event() const
-	{
-		return get_row<reader::Event>();
-	}
+    inline auto typed_index<HasSemantics>::Event() const
+    {
+        return get_row<reader::Event>();
+    }
 
-	inline auto typed_index<MethodDefOrRef>::MethodDef() const
-	{
-		return get_row<reader::MethodDef>();
-	}
+    inline auto typed_index<MethodDefOrRef>::MethodDef() const
+    {
+        return get_row<reader::MethodDef>();
+    }
 
-	inline auto typed_index<MethodDefOrRef>::MemberRef() const
-	{
-		return get_row<reader::MemberRef>();
-	}
+    inline auto typed_index<MethodDefOrRef>::MemberRef() const
+    {
+        return get_row<reader::MemberRef>();
+    }
 
-	inline auto typed_index<ResolutionScope>::Module() const
-	{
-		return get_row<reader::Module>();
-	}
+    inline auto typed_index<ResolutionScope>::Module() const
+    {
+        return get_row<reader::Module>();
+    }
 
-	inline auto typed_index<ResolutionScope>::ModuleRef() const
-	{
-		return get_row<reader::ModuleRef>();
-	}
+    inline auto typed_index<ResolutionScope>::ModuleRef() const
+    {
+        return get_row<reader::ModuleRef>();
+    }
 
-	inline auto typed_index<ResolutionScope>::AssemblyRef() const
-	{
-		return get_row<reader::AssemblyRef>();
-	}
+    inline auto typed_index<ResolutionScope>::AssemblyRef() const
+    {
+        return get_row<reader::AssemblyRef>();
+    }
 
-	inline auto typed_index<ResolutionScope>::TypeRef() const
-	{
-		return get_row<reader::TypeRef>();
-	}
+    inline auto typed_index<ResolutionScope>::TypeRef() const
+    {
+        return get_row<reader::TypeRef>();
+    }
 
     inline auto typed_index<TypeDefOrRef>::TypeDef() const
     {
@@ -139,7 +139,7 @@ namespace xlang::meta::reader
         TypeDef m_typedef;
         ElementType m_underlying_type{};
     
-	};
+    };
 
     inline auto TypeDef::get_enum_definition() const
     {

--- a/src/library/impl/meta_reader/key.h
+++ b/src/library/impl/meta_reader/key.h
@@ -9,6 +9,51 @@ namespace xlang::meta::reader
         return get_database().template get_table<Row>()[index()];
     }
 
+	inline auto typed_index<CustomAttributeType>::MemberRef() const
+	{
+		return get_row<reader::MemberRef>();
+	}
+
+	inline auto typed_index<CustomAttributeType>::MethodDef() const
+	{
+		return get_row<reader::MethodDef>();
+	}
+
+	inline auto typed_index<HasConstant>::Field() const
+	{
+		return get_row<reader::Field>();
+	}
+
+	inline auto typed_index<HasConstant>::Param() const
+	{
+		return get_row<reader::Param>();
+	}
+
+	inline auto typed_index<HasConstant>::Property() const
+	{
+		return get_row<reader::Property>();
+	}
+
+	inline auto typed_index<HasSemantics>::Property() const
+	{
+		return get_row<reader::Property>();
+	}
+
+	inline auto typed_index<HasSemantics>::Event() const
+	{
+		return get_row<reader::Event>();
+	}
+
+	inline auto typed_index<MethodDefOrRef>::MethodDef() const
+	{
+		return get_row<reader::MethodDef>();
+	}
+
+	inline auto typed_index<MethodDefOrRef>::MemberRef() const
+	{
+		return get_row<reader::MemberRef>();
+	}
+
 	inline auto typed_index<ResolutionScope>::Module() const
 	{
 		return get_row<reader::Module>();
@@ -59,31 +104,6 @@ namespace xlang::meta::reader
         return TypeSpec().CustomAttribute();
     }
 
-    inline auto typed_index<HasConstant>::Field() const
-    {
-        return get_row<reader::Field>();
-    }
-
-    inline auto typed_index<HasConstant>::Param() const
-    {
-        return get_row<reader::Param>();
-    }
-
-    inline auto typed_index<HasConstant>::Property() const
-    {
-        return get_row<reader::Property>();
-    }
-
-    inline auto typed_index<CustomAttributeType>::MemberRef() const
-    {
-        return get_row<reader::MemberRef>();
-    }
-
-    inline auto typed_index<CustomAttributeType>::MethodDef() const
-    {
-        return get_row<reader::MethodDef>();
-    }
-
     inline auto typed_index<MemberRefParent>::TypeRef() const
     {
         return get_row<reader::TypeRef>();
@@ -92,16 +112,6 @@ namespace xlang::meta::reader
     inline auto typed_index<MemberRefParent>::TypeDef() const
     {
         return get_row<reader::TypeDef>();
-    }
-
-    inline auto typed_index<HasSemantics>::Property() const
-    {
-        return get_row<reader::Property>();
-    }
-
-    inline auto typed_index<HasSemantics>::Event() const
-    {
-        return get_row<reader::Event>();
     }
 
     inline bool TypeDef::is_enum() const
@@ -128,7 +138,8 @@ namespace xlang::meta::reader
         }
         TypeDef m_typedef;
         ElementType m_underlying_type{};
-    };
+    
+	};
 
     inline auto TypeDef::get_enum_definition() const
     {

--- a/src/library/impl/meta_reader/schema.h
+++ b/src/library/impl/meta_reader/schema.h
@@ -433,7 +433,7 @@ namespace xlang::meta::reader
 
         auto Flags() const
         {
-            return get_value<AssemblyFlags>(2);
+			return AssemblyAttributes{{ get_value<uint32_t>(2) }};
         }
 
         auto PublicKey() const
@@ -492,7 +492,7 @@ namespace xlang::meta::reader
 
         auto Flags() const
         {
-            return get_value<AssemblyFlags>(1);
+			return AssemblyAttributes{{ get_value<uint32_t>(1) }};
         }
 
         auto PublicKeyOrToken() const

--- a/src/library/impl/meta_reader/schema.h
+++ b/src/library/impl/meta_reader/schema.h
@@ -433,7 +433,7 @@ namespace xlang::meta::reader
 
         auto Flags() const
         {
-			return AssemblyAttributes{{ get_value<uint32_t>(2) }};
+            return AssemblyAttributes{{ get_value<uint32_t>(2) }};
         }
 
         auto PublicKey() const
@@ -492,7 +492,7 @@ namespace xlang::meta::reader
 
         auto Flags() const
         {
-			return AssemblyAttributes{{ get_value<uint32_t>(1) }};
+            return AssemblyAttributes{{ get_value<uint32_t>(1) }};
         }
 
         auto PublicKeyOrToken() const

--- a/src/library/impl/meta_reader/schema.h
+++ b/src/library/impl/meta_reader/schema.h
@@ -394,12 +394,12 @@ namespace xlang::meta::reader
 
         auto MethodBody() const
         {
-            return get_value<MethodDefOrRef>(1);
+            return get_coded_index<MethodDefOrRef>(1);
         }
 
         auto MethodDeclaration() const
         {
-            return get_value<MethodDefOrRef>(2);
+            return get_coded_index<MethodDefOrRef>(2);
         }
     };
 

--- a/src/library/impl/meta_reader/signature.h
+++ b/src/library/impl/meta_reader/signature.h
@@ -160,7 +160,7 @@ namespace xlang::meta::reader
         TypeSig(table_base const* table, byte_view& data)
             : m_is_szarray(parse_szarray(table, data))
             , m_cmod(parse_cmods(table, data))
-			, m_element_type(parse_element_type(data))
+            , m_element_type(parse_element_type(data))
             , m_type(ParseType(table, data))
         {}
 
@@ -169,10 +169,10 @@ namespace xlang::meta::reader
             return m_type;
         }
 
-		ElementType element_type() const noexcept
-		{
-			return m_element_type;
-		}
+        ElementType element_type() const noexcept
+        {
+            return m_element_type;
+        }
 
         bool is_szarray() const noexcept
         {
@@ -180,16 +180,16 @@ namespace xlang::meta::reader
         }
 
     private:
-		static ElementType parse_element_type(byte_view& data)
-		{
-			auto cursor = data;
-			return uncompress_enum<ElementType>(cursor);
-		}
+        static ElementType parse_element_type(byte_view& data)
+        {
+            auto cursor = data;
+            return uncompress_enum<ElementType>(cursor);
+        }
 
         static value_type ParseType(table_base const* table, byte_view& data);
         bool m_is_szarray;
         std::vector<CustomModSig> m_cmod;
-		ElementType m_element_type;
+        ElementType m_element_type;
         value_type m_type;
     };
 
@@ -379,10 +379,10 @@ namespace xlang::meta::reader
             return m_type;
         }
 
-		CallingConvention CallConvention() const noexcept
-		{
-			return m_calling_convention;
-		}
+        CallingConvention CallConvention() const noexcept
+        {
+            return m_calling_convention;
+        }
 
     private:
         static CallingConvention check_convention(byte_view& data)

--- a/src/library/impl/meta_reader/signature.h
+++ b/src/library/impl/meta_reader/signature.h
@@ -154,12 +154,19 @@ namespace xlang::meta::reader
         uint32_t index;
     };
 
+	inline ElementType parse_element_type(table_base const* table, byte_view& data)
+	{
+		auto cursor = data;
+		return uncompress_enum<ElementType>(cursor);
+	}
+
     struct TypeSig
     {
         using value_type = std::variant<ElementType, coded_index<TypeDefOrRef>, GenericTypeIndex, GenericTypeInstSig>;
         TypeSig(table_base const* table, byte_view& data)
             : m_is_szarray(parse_szarray(table, data))
             , m_cmod(parse_cmods(table, data))
+			, m_element_type(parse_element_type(table, data))
             , m_type(ParseType(table, data))
         {}
 
@@ -167,6 +174,11 @@ namespace xlang::meta::reader
         {
             return m_type;
         }
+
+		ElementType element_type() const noexcept
+		{
+			return m_element_type;
+		}
 
         bool is_szarray() const noexcept
         {
@@ -177,6 +189,7 @@ namespace xlang::meta::reader
         static value_type ParseType(table_base const* table, byte_view& data);
         bool m_is_szarray;
         std::vector<CustomModSig> m_cmod;
+		ElementType m_element_type;
         value_type m_type;
     };
 

--- a/src/library/impl/meta_reader/signature.h
+++ b/src/library/impl/meta_reader/signature.h
@@ -154,19 +154,13 @@ namespace xlang::meta::reader
         uint32_t index;
     };
 
-	inline ElementType parse_element_type(table_base const* table, byte_view& data)
-	{
-		auto cursor = data;
-		return uncompress_enum<ElementType>(cursor);
-	}
-
     struct TypeSig
     {
         using value_type = std::variant<ElementType, coded_index<TypeDefOrRef>, GenericTypeIndex, GenericTypeInstSig>;
         TypeSig(table_base const* table, byte_view& data)
             : m_is_szarray(parse_szarray(table, data))
             , m_cmod(parse_cmods(table, data))
-			, m_element_type(parse_element_type(table, data))
+			, m_element_type(parse_element_type(data))
             , m_type(ParseType(table, data))
         {}
 
@@ -186,6 +180,12 @@ namespace xlang::meta::reader
         }
 
     private:
+		static ElementType parse_element_type(byte_view& data)
+		{
+			auto cursor = data;
+			return uncompress_enum<ElementType>(cursor);
+		}
+
         static value_type ParseType(table_base const* table, byte_view& data);
         bool m_is_szarray;
         std::vector<CustomModSig> m_cmod;
@@ -378,6 +378,11 @@ namespace xlang::meta::reader
         {
             return m_type;
         }
+
+		CallingConvention CallConvention() const noexcept
+		{
+			return m_calling_convention;
+		}
 
     private:
         static CallingConvention check_convention(byte_view& data)


### PR DESCRIPTION
* add ResolutionScope typed_index
* add TypeSig::element_type method
* add PropertySig::CallConvention method
* Add WindowsRutnime AssemblyFlags value
* add AssemblyAttributes struct and return it from Assembly/AssemblyRef Flags methods
* add MethodDefOrRef support
* fix bug in AssemblyRef::Version
