### PR TITLE
Fix indentation for idl output

### DIFF
--- a/src/tool/idl/main.cpp
+++ b/src/tool/idl/main.cpp
@@ -919,7 +919,7 @@ int main(int const argc, char** argv)
 
         for (auto const& [ns, members] : c.namespaces())
         {
-            group.add([&]
+            group.add([&, &ns = ns, &members = members]
             {
                 if (!f.includes(members))
                 {


### PR DESCRIPTION
I was looking at output of idl and noticed that custom attributes for methods had wrong indentation of 4 spaces when method itself had 8 space indentation. Like this:

```
    interface ILearningModelStatics
    {
    [Windows.Foundation.Metadata.RemoteAsyncAttribute]
    [Windows.Foundation.Metadata.OverloadAttribute("LoadFromStorageFileAsync")]
        Windows.Foundation.IAsyncOperation`1<LearningModel> LoadFromStorageFileAsync(Windows.Storage.IStorageFile modelFile); 
```
vs.
```
    interface ILearningModelStatics
    {
        [Windows.Foundation.Metadata.RemoteAsyncAttribute]
        [Windows.Foundation.Metadata.OverloadAttribute("LoadFromStorageFileAsync")]
        Windows.Foundation.IAsyncOperation`1<LearningModel> LoadFromStorageFileAsync(Windows.Storage.IStorageFile modelFile); 
```

Inspired by devhawk python tool approach I used his indent_guard class to automatically increase indentation by one level where needed. Do not use hardcoded indentations of 4 or 8 spaces. Instead always use placeholder at the start of line where write_indent() will write proper number of spaces, depending on the current indentation level.

- Now write(CustomAttribute const& attr) and write_uuid(CustomAttributeSig const& arg) are similar to other other functions that they do not have enforced newline and indent at the start of line. The callers of these functions ensure that these are prepended.
- All manual loops that wrote custom attributes are replaced with bind_each<write_custom_attribute>(attribute)

I verified that idl output for windows.winmd differs only by whitespace changes for fixed custom attributes. 
