### PR TITLE
Fix mishandling of escape character in writer_base::write

### DIFF
--- a/src/library/text_writer.h
+++ b/src/library/text_writer.h
@@ -236,14 +236,13 @@ namespace xlang::text
             if (next == '%' || next == '@')
             {
                 write(next);
-                offset++;
             }
             else
             {
                 write('^');
             }
 
-            write_segment(value.substr(offset + 1));
+            write_segment(value.substr(offset + 2));
         }
 
         template <typename First, typename... Rest>
@@ -262,13 +261,12 @@ namespace xlang::text
                 if (next == '%' || next == '@')
                 {
                     write(next);
-                    offset++;
                 }
                 else
                 {
                     write('^');
                 }
-                write_segment(value.substr(offset + 1), first, rest...);
+                write_segment(value.substr(offset + 2), first, rest...);
             }
             else
             {

--- a/src/library/text_writer.h
+++ b/src/library/text_writer.h
@@ -229,6 +229,9 @@ namespace xlang::text
             }
 
             write(value.substr(0, offset));
+
+            XLANG_ASSERT(offset != value.size() - 1);
+
             auto next = value[offset + 1];
             if (next == '%' || next == '@')
             {
@@ -252,6 +255,8 @@ namespace xlang::text
 
             if (value[offset] == '^')
             {
+                XLANG_ASSERT(offset != value.size() - 1);
+
                 auto next = value[offset + 1];
 
                 if (next == '%' || next == '@')
@@ -263,7 +268,6 @@ namespace xlang::text
                 {
                     write('^');
                 }
-
                 write_segment(value.substr(offset + 1), first, rest...);
             }
             else

--- a/src/library/text_writer.h
+++ b/src/library/text_writer.h
@@ -232,16 +232,7 @@ namespace xlang::text
 
             XLANG_ASSERT(offset != value.size() - 1);
 
-            auto next = value[offset + 1];
-            if (next == '%' || next == '@')
-            {
-                write(next);
-            }
-            else
-            {
-                write('^');
-            }
-
+            write(value[offset + 1]);
             write_segment(value.substr(offset + 2));
         }
 
@@ -256,16 +247,7 @@ namespace xlang::text
             {
                 XLANG_ASSERT(offset != value.size() - 1);
 
-                auto next = value[offset + 1];
-
-                if (next == '%' || next == '@')
-                {
-                    write(next);
-                }
-                else
-                {
-                    write('^');
-                }
+                write(value[offset + 1]);
                 write_segment(value.substr(offset + 2), first, rest...);
             }
             else

--- a/src/library/text_writer.h
+++ b/src/library/text_writer.h
@@ -200,17 +200,19 @@ namespace xlang::text
 
             for (auto c : format)
             {
-                if (c == '^')
+                if (!escape)
                 {
-                    escape = true;
-                    continue;
-                }
+                    if (c == '^')
+                    {
+                        escape = true;
+                        continue;
+                    }
 
-                if ((c == '%' || c == '@') && !escape)
-                {
-                    ++count;
+                    if (c == '%' || c == '@')
+                    {
+                        ++count;
+                    }
                 }
-
                 escape = false;
             }
 


### PR DESCRIPTION
Multiple issues with handling of escape characters in formatted writing.

* `count_placeholders` miscounted `^^%` as a placeholder.
* Format strings ending in `^` caused us to read past the end of a view.
* `^^` printed as two `^` characters instead of one.
* `^x` printed as `^` instead of `x`.
