### PR TITLE
MethodDef::Params() should return a pair of iterators

### DIFF
--- a/src/library/impl/meta_reader/signature.h
+++ b/src/library/impl/meta_reader/signature.h
@@ -313,9 +313,9 @@ namespace xlang::meta::reader
             return m_ret_type;
         }
 
-        auto const& Params() const noexcept
+        auto Params() const noexcept
         {
-            return m_params;
+            return std::pair{ m_params.cbegin(), m_params.cend() };
         }
 
     private:

--- a/src/tool/cppwinrt/cppwinrt/helpers.h
+++ b/src/tool/cppwinrt/cppwinrt/helpers.h
@@ -25,9 +25,9 @@ namespace xlang
                 ++params.first;
             }
 
-            for (uint32_t i{}; i != m_method.Params().size(); ++i)
+            for (uint32_t i{}; i != size(m_method.Params()); ++i)
             {
-                m_params.emplace_back(params.first + i, m_method.Params().data() + i);
+                m_params.emplace_back(params.first + i, &m_method.Params().first[i]);
             }
         }
 

--- a/src/tool/cppxlang/helpers.h
+++ b/src/tool/cppxlang/helpers.h
@@ -25,9 +25,9 @@ namespace xlang
                 ++params.first;
             }
 
-            for (uint32_t i{}; i != m_method.Params().size(); ++i)
+            for (uint32_t i{}; i != size(m_method.Params()); ++i)
             {
-                m_params.emplace_back(params.first + i, m_method.Params().data() + i);
+                m_params.emplace_back(params.first + i, &m_method.Params().first[i]);
             }
         }
 

--- a/src/tool/python/helpers.h
+++ b/src/tool/python/helpers.h
@@ -164,9 +164,9 @@ namespace xlang
                 ++params.first;
             }
 
-            for (uint32_t i{}; i != m_method.Params().size(); ++i)
+            for (uint32_t i{}; i != size(m_method.Params()); ++i)
             {
-                m_params.emplace_back(params.first + i, m_method.Params().data() + i);
+                m_params.emplace_back(params.first + i, &m_method.Params().first[i]);
             }
         }
 


### PR DESCRIPTION
Most collection methods return a pair of iterators, but `MethodDef::Params()` returns a const vector.

Fix to make it act like the others for consistency. Otherwise, consumers have to write a range specialization for this one case.