### PR TITLE
Adopt function-try-blocks for C++ code generation

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -1585,16 +1585,13 @@ namespace xlang
         }
         else
         {
-            format = R"(        int32_t WINRT_CALL %(%) noexcept final
+            format = R"(        int32_t WINRT_CALL %(%) noexcept final try
         {
-%            try
-            {
-                typename D::abi_guard guard(this->shim());
-                %
-                return 0;
-            }
-            catch (...) { return to_hresult(); }
+%            typename D::abi_guard guard(this->shim());
+            %
+            return 0;
         }
+        catch (...) { return to_hresult(); }
 )";
         }
 

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -184,29 +184,25 @@ int32_t WINRT_CALL WINRT_CanUnloadNow() noexcept
     return %_can_unload_now() ? 0 : 1;
 }
 
-int32_t WINRT_CALL WINRT_GetActivationFactory(void* classId, void** factory) noexcept
+int32_t WINRT_CALL WINRT_GetActivationFactory(void* classId, void** factory) noexcept try
 {
-    try
+    uint32_t length{};
+    wchar_t const* const buffer = WINRT_WindowsGetStringRawBuffer(classId, &length);
+    std::wstring_view const name{ buffer, length };
+    *factory = %_get_activation_factory(name);
+
+    if (*factory)
     {
-        uint32_t length{};
-        wchar_t const* const buffer = WINRT_WindowsGetStringRawBuffer(classId, &length);
-        std::wstring_view const name{ buffer, length };
-
-        *factory = %_get_activation_factory(name);
-
-        if (*factory)
-        {
-            return 0;
-        }
+        return 0;
+    }
 
 #ifdef _WRL_MODULE_H_
-        return ::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().GetActivationFactory(static_cast<HSTRING>(classId), reinterpret_cast<::IActivationFactory**>(factory));
+    return ::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().GetActivationFactory(static_cast<HSTRING>(classId), reinterpret_cast<::IActivationFactory**>(factory));
 #else
-        return winrt::hresult_class_not_available(name).to_abi();
+    return winrt::hresult_class_not_available(name).to_abi();
 #endif
-    }
-    catch (...) { return winrt::to_hresult(); }
 }
+catch (...) { return winrt::to_hresult(); }
 )";
 
         w.write(format,

--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -325,17 +325,14 @@ namespace winrt::impl
 
     template <typename D> struct produce<D, Windows::Foundation::IActivationFactory> : produce_base<D, Windows::Foundation::IActivationFactory>
     {
-        int32_t WINRT_CALL ActivateInstance(void** instance) noexcept final
+        int32_t WINRT_CALL ActivateInstance(void** instance) noexcept final try
         {
-            try
-            {
-                *instance = nullptr;
-                typename D::abi_guard guard(this->shim());
-                *instance = detach_abi(this->shim().ActivateInstance());
-                return error_ok;
-            }
-            catch (...) { return to_hresult(); }
+            *instance = nullptr;
+            typename D::abi_guard guard(this->shim());
+            *instance = detach_abi(this->shim().ActivateInstance());
+            return error_ok;
         }
+        catch (...) { return to_hresult(); }
     };
 }
 

--- a/src/tool/cppwinrt/strings/base_implements.h
+++ b/src/tool/cppwinrt/strings/base_implements.h
@@ -965,25 +965,19 @@ namespace winrt::impl
             return error_ok;
         }
 
-        int32_t WINRT_CALL NonDelegatingGetRuntimeClassName(void** name) noexcept
+        int32_t WINRT_CALL NonDelegatingGetRuntimeClassName(void** name) noexcept try
         {
-            try
-            {
-                *name = detach_abi(static_cast<D*>(this)->GetRuntimeClassName());
-                return error_ok;
-            }
-            catch (...) { return to_hresult(); }
+            *name = detach_abi(static_cast<D*>(this)->GetRuntimeClassName());
+            return error_ok;
         }
+        catch (...) { return to_hresult(); }
 
-        int32_t WINRT_CALL NonDelegatingGetTrustLevel(Windows::Foundation::TrustLevel* trustLevel) noexcept
+        int32_t WINRT_CALL NonDelegatingGetTrustLevel(Windows::Foundation::TrustLevel* trustLevel) noexcept try
         {
-            try
-            {
-                *trustLevel = static_cast<D*>(this)->GetTrustLevel();
-                return error_ok;
-            }
-            catch (...) { return to_hresult(); }
+            *trustLevel = static_cast<D*>(this)->GetTrustLevel();
+            return error_ok;
         }
+        catch (...) { return to_hresult(); }
 
         uint32_t subtract_reference() noexcept
         {

--- a/src/tool/cppxlang/code_writers.h
+++ b/src/tool/cppxlang/code_writers.h
@@ -1585,16 +1585,13 @@ namespace xlang
         }
         else
         {
-            format = R"(        int32_t WINRT_CALL %(%) noexcept final
+            format = R"(        int32_t WINRT_CALL %(%) noexcept final try
         {
-%            try
-            {
-                typename D::abi_guard guard(this->shim());
-                %
-                return 0;
-            }
-            catch (...) { return to_hresult(); }
+%            typename D::abi_guard guard(this->shim());
+            %
+            return 0;
         }
+        catch (...) { return to_hresult(); }
 )";
         }
 

--- a/src/tool/cppxlang/component_writers.h
+++ b/src/tool/cppxlang/component_writers.h
@@ -184,29 +184,25 @@ int32_t WINRT_CALL WINRT_CanUnloadNow() noexcept
     return %_can_unload_now() ? 0 : 1;
 }
 
-int32_t WINRT_CALL WINRT_GetActivationFactory(void* classId, void** factory) noexcept
+int32_t WINRT_CALL WINRT_GetActivationFactory(void* classId, void** factory) noexcept try
 {
-    try
+    uint32_t length{};
+    wchar_t const* const buffer = WINRT_WindowsGetStringRawBuffer(classId, &length);
+    std::wstring_view const name{ buffer, length };
+    *factory = %_get_activation_factory(name);
+
+    if (*factory)
     {
-        uint32_t length{};
-        wchar_t const* const buffer = WINRT_WindowsGetStringRawBuffer(classId, &length);
-        std::wstring_view const name{ buffer, length };
-
-        *factory = %_get_activation_factory(name);
-
-        if (*factory)
-        {
-            return 0;
-        }
+        return 0;
+    }
 
 #ifdef _WRL_MODULE_H_
-        return ::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().GetActivationFactory(static_cast<HSTRING>(classId), reinterpret_cast<::IActivationFactory**>(factory));
+    return ::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().GetActivationFactory(static_cast<HSTRING>(classId), reinterpret_cast<::IActivationFactory**>(factory));
 #else
-        return winrt::hresult_class_not_available(name).to_abi();
+    return winrt::hresult_class_not_available(name).to_abi();
 #endif
-    }
-    catch (...) { return winrt::to_hresult(); }
 }
+catch (...) { return winrt::to_hresult(); }
 )";
 
         w.write(format,

--- a/src/tool/cppxlang/strings/base_activation.h
+++ b/src/tool/cppxlang/strings/base_activation.h
@@ -99,17 +99,14 @@ namespace winrt::impl
 
     template <typename D> struct produce<D, Windows::Foundation::IActivationFactory> : produce_base<D, Windows::Foundation::IActivationFactory>
     {
-        int32_t WINRT_CALL ActivateInstance(void** instance) noexcept final
+        int32_t WINRT_CALL ActivateInstance(void** instance) noexcept final try
         {
-            try
-            {
-                *instance = nullptr;
-                typename D::abi_guard guard(this->shim());
-                *instance = detach_abi(this->shim().ActivateInstance());
-                return error_ok;
-            }
-            catch (...) { return to_hresult(); }
+            *instance = nullptr;
+            typename D::abi_guard guard(this->shim());
+            *instance = detach_abi(this->shim().ActivateInstance());
+            return error_ok;
         }
+        catch (...) { return to_hresult(); }
     };
 }
 

--- a/src/tool/cppxlang/strings/base_implements.h
+++ b/src/tool/cppxlang/strings/base_implements.h
@@ -965,25 +965,19 @@ namespace winrt::impl
             return error_ok;
         }
 
-        int32_t WINRT_CALL NonDelegatingGetRuntimeClassName(void** name) noexcept
+        int32_t WINRT_CALL NonDelegatingGetRuntimeClassName(void** name) noexcept try
         {
-            try
-            {
-                *name = detach_abi(static_cast<D*>(this)->GetRuntimeClassName());
-                return error_ok;
-            }
-            catch (...) { return to_hresult(); }
+            *name = detach_abi(static_cast<D*>(this)->GetRuntimeClassName());
+            return error_ok;
         }
+        catch (...) { return to_hresult(); }
 
-        int32_t WINRT_CALL NonDelegatingGetTrustLevel(Windows::Foundation::TrustLevel* trustLevel) noexcept
+        int32_t WINRT_CALL NonDelegatingGetTrustLevel(Windows::Foundation::TrustLevel* trustLevel) noexcept try
         {
-            try
-            {
-                *trustLevel = static_cast<D*>(this)->GetTrustLevel();
-                return error_ok;
-            }
-            catch (...) { return to_hresult(); }
+            *trustLevel = static_cast<D*>(this)->GetTrustLevel();
+            return error_ok;
         }
+        catch (...) { return to_hresult(); }
 
         uint32_t subtract_reference() noexcept
         {


### PR DESCRIPTION
The `produce` specializations benefit from a more concise and terse syntax for function bodies. 