### PR TITLE
Allow cache to be constructed with any container

### DIFF
--- a/src/library/impl/meta_reader/cache.h
+++ b/src/library/impl/meta_reader/cache.h
@@ -7,7 +7,8 @@ namespace xlang::meta::reader
         cache(cache const&) = delete;
         cache& operator=(cache const&) = delete;
 
-        explicit cache(std::vector<std::string> const& files)
+        template<typename C, typename T = typename C::value_type>
+        explicit cache(C const& files)
         {
             for (auto&& file : files)
             {


### PR DESCRIPTION
Allow `xlang::meta::reader::cache` to be constructed with any standard container, which we detect by using SFINAE to sniff for a `value_type`.

This removes the obvious friction between the cache constructor and the `reader::files()` method.