### PR TITLE
database.path() returns std::string const& to reduce friction

### DIFF
--- a/src/library/impl/meta_reader/database.h
+++ b/src/library/impl/meta_reader/database.h
@@ -383,7 +383,7 @@ namespace xlang::meta::reader
             return *m_cache;
         }
 
-        std::string_view path() const noexcept
+        std::string const& path() const noexcept
         {
             return m_path;
         }


### PR DESCRIPTION
This reduces friction with the `std::set<std::string>` returned by `reader.files()`,