### PR TITLE
Add option to ignore Velocity feature attributes

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/helpers.h
+++ b/src/tool/cppwinrt/cppwinrt/helpers.h
@@ -159,6 +159,11 @@ namespace xlang
 
     static bool is_always_disabled(TypeDef const& type)
     {
+        if (settings.component_ignore_velocity)
+        {
+            return false;
+        }
+
         auto feature = get_attribute(type, "Windows.Foundation.Metadata", "FeatureAttribute");
 
         if (!feature)

--- a/src/tool/cppwinrt/cppwinrt/main.cpp
+++ b/src/tool/cppwinrt/cppwinrt/main.cpp
@@ -35,6 +35,7 @@ namespace xlang
         { "filter" }, // One or more prefixes to include in input (same as -include)
         { "license", 0, 0 }, // Generate license comment
         { "brackets", 0, 0 }, // Use angle brackets for #includes (defaults to quotes)
+        { "ignore_velocity", 0, 0 }, // Ignore feature staging metadata and always include implementations
     };
 
     static void print_usage(writer& w)
@@ -135,6 +136,7 @@ Where <spec> is one or more of:
             settings.component_prefix = args.exists("prefix");
             settings.component_lib = args.value("lib", "winrt");
             settings.component_opt = args.exists("opt");
+            settings.component_ignore_velocity = args.exists("ignore_velocity");
 
             if (settings.component_pch == ".")
             {

--- a/src/tool/cppwinrt/cppwinrt/settings.h
+++ b/src/tool/cppwinrt/cppwinrt/settings.h
@@ -20,6 +20,7 @@ namespace xlang
         bool component_overwrite{};
         std::string component_lib;
         bool component_opt{};
+        bool component_ignore_velocity{};
 
         bool verbose{};
 


### PR DESCRIPTION
Some teams would like to implement AlwaysDisabled APIs and still have the code ship in their binaries. This update allows the caller to ignore any feature attributes.