### PR TITLE
Fixed some cppwinrt 2.0 migration regressions in debug visualizer

### DIFF
--- a/src/package/natvis/cppwinrt.natvis
+++ b/src/package/natvis/cppwinrt.natvis
@@ -10,6 +10,10 @@
     <CustomVisualizer Condition="this != 0" VisualizerId="2ec1a02f-997c-4693-840e-88ffa1e21b56"/>
     <DisplayString Condition="this == 0">null</DisplayString>
   </Type>
+  <Type Name="winrt::impl::inspectable_abi">
+    <CustomVisualizer Condition="this != 0" VisualizerId="2ec1a02f-997c-4693-840e-88ffa1e21b56"/>
+    <DisplayString Condition="this == 0">null</DisplayString>
+  </Type>
   <!--Visualize all raw IInspectable pointers-->
   <Type Name="IInspectable">
     <CustomVisualizer Condition="this != 0" VisualizerId="2ec1a02f-997c-4693-840e-88ffa1e21b56"/>

--- a/src/package/natvis/cppwinrt_visualizer.cpp
+++ b/src/package/natvis/cppwinrt_visualizer.cpp
@@ -45,7 +45,11 @@ cppwinrt_visualizer::cppwinrt_visualizer()
     try
     {
         std::array<char, MAX_PATH> local{};
+#ifdef _WIN64
         ExpandEnvironmentStringsA("%windir%\\System32\\WinMetadata", local.data(), static_cast<DWORD>(local.size()));
+#else
+        ExpandEnvironmentStringsA("%windir%\\SysNative\\WinMetadata", local.data(), static_cast<DWORD>(local.size()));
+#endif
         for (auto&& file : std::experimental::filesystem::directory_iterator(local.data()))
         {
             if (std::experimental::filesystem::is_regular_file(file))
@@ -100,7 +104,8 @@ HRESULT cppwinrt_visualizer::EvaluateVisualizedExpression(
             isAbiObject = false;
         }
         // Visualize nested object properties via raw ABI pointers
-        else if (wcscmp(bstrTypeName, L"winrt::impl::IInspectable") == 0)
+        else if ((wcscmp(bstrTypeName, L"winrt::impl::IInspectable") == 0) ||
+                 (wcscmp(bstrTypeName, L"winrt::impl::inspectable_abi") == 0))
         {
             isAbiObject = true;
         }

--- a/src/package/natvis/object_visualizer.cpp
+++ b/src/package/natvis/object_visualizer.cpp
@@ -387,7 +387,7 @@ void GetInterfaceData(
                         if(get_category(type) == category::class_type)
                         {
                             propCategory = PropertyCategory::Class;
-                            propAbiType = L"winrt::impl::IInspectable*";
+                            propAbiType = L"winrt::impl::inspectable_abi*";
                         }
                         else
                         {


### PR DESCRIPTION
Nested objects broke due to winrt::impl::IInspectable rename
Workaround for removal of syswow64\winmetadata fell out