### PR TITLE
Update msbuild invocations to allow RelWithDebInfo/MinSizeRel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ function(CONSUME_PAL target)
     target_link_libraries(${target} pal)
 endfunction()
 
-# set test_platform linker flags to look for .so files in the current directory 
+# set test_platform linker flags to look for .so files in the current directory
 # adapted from https://serverfault.com/a/926072
 function(RPATH_ORIGIN target)
     if (NOT WIN32)
@@ -113,7 +113,7 @@ if (MSVC)
         add_compile_options(/permissive- /await)
     endif()
 
-    # Explicitly configure _DEBUG preprocessor macro 
+    # Explicitly configure _DEBUG preprocessor macro
     string(APPEND CMAKE_CXX_FLAGS_DEBUG " /D_DEBUG")
 else()
     add_compile_options(-stdlib=libc++)
@@ -124,6 +124,12 @@ endif()
 
 if (WIN32)
     add_definitions(-DNOMINMAX)
+
+    # By default, msbuild project files don't recognize RelWithDebInfo/MinSizeRel, so translate them to 'Release'
+    set (MSBUILD_CONFIGURATION ${CMAKE_BUILD_TYPE})
+    if ((${MSBUILD_CONFIGURATION} STREQUAL "RelWithDebInfo") OR (${MSBUILD_CONFIGURATION} STREQUAL "MinSizeRel"))
+        set(MSBUILD_CONFIGURATION Release)
+    endif()
 endif()
 
 add_subdirectory(tool)

--- a/src/package/natvis/CMakeLists.txt
+++ b/src/package/natvis/CMakeLists.txt
@@ -7,13 +7,7 @@ file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/build_tools/nuget.exe" nuget_exe)
 file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/$ENV{VSCMD_ARG_TGT_ARCH}/${CMAKE_BUILD_TYPE}" cppwinrt_natvis_dir)
 file(TO_NATIVE_PATH ${cppwinrt_natvis_dir}/cppwinrtvisualizer.dll cppwinrtvisualizer_dll)
 
-# The vcxproj does not recognize RelWithDebInfo/MinSizeRel as valid build configurations, so translate them to 'Release'
-set (MSBUILD_CONFIGURATION ${CMAKE_BUILD_TYPE})
-if ((${MSBUILD_CONFIGURATION} STREQUAL "RelWithDebInfo") OR (${MSBUILD_CONFIGURATION} STREQUAL "MinSizeRel"))
-    set(MSBUILD_CONFIGURATION Release)
-endif()
-
-set(build_visualizer msbuild ${CMAKE_CURRENT_SOURCE_DIR}/cppwinrtvisualizer.vcxproj /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION})
+set(build_visualizer msbuild ${CMAKE_CURRENT_SOURCE_DIR}/cppwinrtvisualizer.vcxproj /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION},CmakeConfiguration=${CMAKE_BUILD_TYPE})
 
 file(DOWNLOAD https://dist.nuget.org/win-x86-commandline/latest/nuget.exe ${nuget_exe})
 

--- a/src/package/natvis/CMakeLists.txt
+++ b/src/package/natvis/CMakeLists.txt
@@ -7,7 +7,13 @@ file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/build_tools/nuget.exe" nuget_exe)
 file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/$ENV{VSCMD_ARG_TGT_ARCH}/${CMAKE_BUILD_TYPE}" cppwinrt_natvis_dir)
 file(TO_NATIVE_PATH ${cppwinrt_natvis_dir}/cppwinrtvisualizer.dll cppwinrtvisualizer_dll)
 
-set(build_visualizer msbuild ${CMAKE_CURRENT_SOURCE_DIR}/cppwinrtvisualizer.vcxproj /nologo /m /p:Configuration=${CMAKE_BUILD_TYPE})
+# The vcxproj does not recognize RelWithDebInfo/MinSizeRel as valid build configurations, so translate them to 'Release'
+set (MSBUILD_CONFIGURATION ${CMAKE_BUILD_TYPE})
+if ((${MSBUILD_CONFIGURATION} STREQUAL "RelWithDebInfo") OR (${MSBUILD_CONFIGURATION} STREQUAL "MinSizeRel"))
+    set(MSBUILD_CONFIGURATION Release)
+endif()
+
+set(build_visualizer msbuild ${CMAKE_CURRENT_SOURCE_DIR}/cppwinrtvisualizer.vcxproj /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION})
 
 file(DOWNLOAD https://dist.nuget.org/win-x86-commandline/latest/nuget.exe ${nuget_exe})
 

--- a/src/package/natvis/cppwinrtvisualizer.vcxproj
+++ b/src/package/natvis/cppwinrtvisualizer.vcxproj
@@ -56,6 +56,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
     <DIASDKInc>$(VSInstallDir)DIA SDK\include</DIASDKInc>
+    <CmakeConfiguration Condition="'$(CmakeConfiguration)'==''">$(Configuration)</CmakeConfiguration>
   </PropertyGroup>
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -76,23 +77,23 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>x86\$(Configuration)\</OutDir>
-    <IntDir>x86\$(Configuration)\</IntDir>
+    <OutDir>x86\$(CmakeConfiguration)\</OutDir>
+    <IntDir>x86\$(CmakeConfiguration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>x64\$(Configuration)\</OutDir>
-    <IntDir>x64\$(Configuration)\</IntDir>
+    <OutDir>x64\$(CmakeConfiguration)\</OutDir>
+    <IntDir>x64\$(CmakeConfiguration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>x86\$(Configuration)\</OutDir>
-    <IntDir>x86\$(Configuration)\</IntDir>
+    <OutDir>x86\$(CmakeConfiguration)\</OutDir>
+    <IntDir>x86\$(CmakeConfiguration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>x64\$(Configuration)\</OutDir>
-    <IntDir>x64\$(Configuration)\</IntDir>
+    <OutDir>x64\$(CmakeConfiguration)\</OutDir>
+    <IntDir>x64\$(CmakeConfiguration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/src/package/vsix/CMakeLists.txt
+++ b/src/package/vsix/CMakeLists.txt
@@ -14,12 +14,6 @@ file(TO_NATIVE_PATH "${cppwinrt_nupkg_dir}/Microsoft.Windows.CppWinRT.${XLANG_BU
 
 file(DOWNLOAD https://dist.nuget.org/win-x86-commandline/latest/nuget.exe ${nuget_exe})
 
-# The csproj does not recognize RelWithDebInfo/MinSizeRel as valid build configurations, so translate them to 'Release'
-set (MSBUILD_CONFIGURATION ${CMAKE_BUILD_TYPE})
-if ((${MSBUILD_CONFIGURATION} STREQUAL "RelWithDebInfo") OR (${MSBUILD_CONFIGURATION} STREQUAL "MinSizeRel"))
-    set(MSBUILD_CONFIGURATION Release)
-endif()
-
 set(build_vsix msbuild ${CMAKE_CURRENT_SOURCE_DIR}/vsix.csproj /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION},Platform=$ENV{VSCMD_ARG_TGT_ARCH})
 
 add_custom_command(OUTPUT ${cppwinrt_vsix}

--- a/src/package/vsix/CMakeLists.txt
+++ b/src/package/vsix/CMakeLists.txt
@@ -14,7 +14,7 @@ file(TO_NATIVE_PATH "${cppwinrt_nupkg_dir}/Microsoft.Windows.CppWinRT.${XLANG_BU
 
 file(DOWNLOAD https://dist.nuget.org/win-x86-commandline/latest/nuget.exe ${nuget_exe})
 
-set(build_vsix msbuild ${CMAKE_CURRENT_SOURCE_DIR}/vsix.csproj /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION},Platform=$ENV{VSCMD_ARG_TGT_ARCH})
+set(build_vsix msbuild ${CMAKE_CURRENT_SOURCE_DIR}/vsix.csproj /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION},CmakeConfiguration=${CMAKE_BUILD_TYPE},Platform=$ENV{VSCMD_ARG_TGT_ARCH})
 
 add_custom_command(OUTPUT ${cppwinrt_vsix}
     COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} & ${nuget_exe} restore

--- a/src/package/vsix/CMakeLists.txt
+++ b/src/package/vsix/CMakeLists.txt
@@ -14,7 +14,13 @@ file(TO_NATIVE_PATH "${cppwinrt_nupkg_dir}/Microsoft.Windows.CppWinRT.${XLANG_BU
 
 file(DOWNLOAD https://dist.nuget.org/win-x86-commandline/latest/nuget.exe ${nuget_exe})
 
-set(build_vsix msbuild ${CMAKE_CURRENT_SOURCE_DIR}/vsix.csproj /nologo /m /p:Configuration=${CMAKE_BUILD_TYPE},Platform=$ENV{VSCMD_ARG_TGT_ARCH})
+# The csproj does not recognize RelWithDebInfo/MinSizeRel as valid build configurations, so translate them to 'Release'
+set (MSBUILD_CONFIGURATION ${CMAKE_BUILD_TYPE})
+if ((${MSBUILD_CONFIGURATION} STREQUAL "RelWithDebInfo") OR (${MSBUILD_CONFIGURATION} STREQUAL "MinSizeRel"))
+    set(MSBUILD_CONFIGURATION Release)
+endif()
+
+set(build_vsix msbuild ${CMAKE_CURRENT_SOURCE_DIR}/vsix.csproj /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION},Platform=$ENV{VSCMD_ARG_TGT_ARCH})
 
 add_custom_command(OUTPUT ${cppwinrt_vsix}
     COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} & ${nuget_exe} restore

--- a/src/package/vsix/vsix.csproj
+++ b/src/package/vsix/vsix.csproj
@@ -14,6 +14,7 @@
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <DeployExtension>false</DeployExtension>
     <Deployment Condition="'$(Deployment)' == '' ">Standalone</Deployment>
+    <CmakeConfiguration Condition="'$(CmakeConfiguration)'==''">$(Configuration)</CmakeConfiguration>
     <ProjectGuid>{2F0C4AFA-FEFA-4D37-B824-0426CEB32DBA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -31,7 +32,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\$(Deployment)\</OutputPath>
+    <OutputPath>bin\$(CmakeConfiguration)\$(Deployment)\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -40,7 +41,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\$(Deployment)\</OutputPath>
+    <OutputPath>bin\$(CmakeConfiguration)\$(Deployment)\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -128,7 +129,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets'))" />
-  </Target>  
+  </Target>
   <Import Project=".\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets')" />
   <Target Name="GetCppWinRTVersion" Outputs="$(CppWinRTVersion)" />
   <Target Name="PrepareBuild" BeforeTargets="Build">

--- a/src/tool/cppwinrt/CMakeLists.txt
+++ b/src/tool/cppwinrt/CMakeLists.txt
@@ -3,7 +3,13 @@ cmake_minimum_required(VERSION 3.9)
 file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/cppwinrt.exe" cppwinrt_exe)
 file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" CmakeOutDir)
 
-set(build msbuild /nologo /m /p:Configuration=${CMAKE_BUILD_TYPE},Platform=$ENV{VSCMD_ARG_TGT_ARCH},XlangBuildVersion=${XLANG_BUILD_VERSION},CmakeOutDir=${CmakeOutDir}  ${CMAKE_CURRENT_SOURCE_DIR}/cppwinrt.sln)
+# The vcxprojs do not recognize RelWithDebInfo/MinSizeRel as valid build configurations, so translate them to 'Release'
+set (MSBUILD_CONFIGURATION ${CMAKE_BUILD_TYPE})
+if ((${MSBUILD_CONFIGURATION} STREQUAL "RelWithDebInfo") OR (${MSBUILD_CONFIGURATION} STREQUAL "MinSizeRel"))
+    set(MSBUILD_CONFIGURATION Release)
+endif()
+
+set(build msbuild /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION},Platform=$ENV{VSCMD_ARG_TGT_ARCH},XlangBuildVersion=${XLANG_BUILD_VERSION},CmakeOutDir=${CmakeOutDir}  ${CMAKE_CURRENT_SOURCE_DIR}/cppwinrt.sln)
 
 add_custom_command(OUTPUT ${cppwinrt_exe}
     COMMAND ${build} /t:cppwinrt

--- a/src/tool/cppwinrt/CMakeLists.txt
+++ b/src/tool/cppwinrt/CMakeLists.txt
@@ -3,12 +3,6 @@ cmake_minimum_required(VERSION 3.9)
 file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/cppwinrt.exe" cppwinrt_exe)
 file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" CmakeOutDir)
 
-# The vcxprojs do not recognize RelWithDebInfo/MinSizeRel as valid build configurations, so translate them to 'Release'
-set (MSBUILD_CONFIGURATION ${CMAKE_BUILD_TYPE})
-if ((${MSBUILD_CONFIGURATION} STREQUAL "RelWithDebInfo") OR (${MSBUILD_CONFIGURATION} STREQUAL "MinSizeRel"))
-    set(MSBUILD_CONFIGURATION Release)
-endif()
-
 set(build msbuild /nologo /m /p:Configuration=${MSBUILD_CONFIGURATION},Platform=$ENV{VSCMD_ARG_TGT_ARCH},XlangBuildVersion=${XLANG_BUILD_VERSION},CmakeOutDir=${CmakeOutDir}  ${CMAKE_CURRENT_SOURCE_DIR}/cppwinrt.sln)
 
 add_custom_command(OUTPUT ${cppwinrt_exe}


### PR DESCRIPTION
Right now it's not possible to build with just CMake+Ninja and get a release build with symbols (at least not without scoping the build down to specific target(s)) since none of the vcxproj/csproj files allow these as valid configurations. This updates msbuild invocations to translate RelWithDebInfo/MinSizeRel into 'Release' when invoking msbuild.