### PR TITLE
Add output messages to debug visualizer, tied to natvis diagnostics level (VS16)

### DIFF
--- a/src/package/natvis/cppwinrt.natvis
+++ b/src/package/natvis/cppwinrt.natvis
@@ -31,8 +31,8 @@
     <DisplayString>{m_handle.m_value,sh}</DisplayString>
     <StringView>m_handle.m_value,sh</StringView>
     <Expand>
-      <Item Name="Length">WindowsGetStringLen((HSTRING__*)m_handle.m_value)</Item>
-      <Item Name="[Pointer]">WindowsGetStringRawBuffer((HSTRING__*)m_handle.m_value, nullptr)</Item>
+      <Item Name="size">WindowsGetStringLen(m_handle.m_value)</Item>
+      <Item Name="[ptr]">WindowsGetStringRawBuffer(m_handle.m_value, nullptr)</Item>
     </Expand>
   </Type>
 </AutoVisualizer>

--- a/src/package/natvis/cppwinrt_visualizer.cpp
+++ b/src/package/natvis/cppwinrt_visualizer.cpp
@@ -25,6 +25,12 @@ void LoadMetadata(DkmProcess* process, WCHAR const* processPath, std::string con
     do
     {
         winmd_path.replace_filename(probeFileName + ".winmd");
+        if (GetNatvisDiagnosticLevel() == NatvisDiagnosticLevel::Verbose)
+        {
+            auto winmd_path_str = winmd_path.string();
+            auto message = std::wstring(L"Looking for ") + std::wstring(winmd_path_str.begin(), winmd_path_str.end());
+            NatvisDiagnostic(process, message, NatvisDiagnosticLevel::Verbose);
+        }
         if (exists(winmd_path))
         {
             if (GetNatvisDiagnosticLevel() == NatvisDiagnosticLevel::Verbose)

--- a/src/package/natvis/cppwinrt_visualizer.cpp
+++ b/src/package/natvis/cppwinrt_visualizer.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<cache> db;
 // If type not indexed, simulate RoGetMetaDataFile's strategy for finding app-local metadata
 // and add to the database dynamically.  RoGetMetaDataFile looks for types in the current process
 // so cannot be called directly.
-void LoadMetadata(DkmProcess* process, WCHAR const* processPath, std::string typeName)
+void LoadMetadata(DkmProcess* process, WCHAR const* processPath, std::string const& typeName)
 {
     auto winmd_path = path{ processPath };
     auto probeFileName = typeName;

--- a/src/package/natvis/cppwinrtvisualizer.vcxproj
+++ b/src/package/natvis/cppwinrtvisualizer.vcxproj
@@ -117,6 +117,7 @@
       <AdditionalDependencies>advapi32.lib;shell32.lib;windowsapp.lib;$(VsDebugEng_Lib);%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>.\cppwinrtvisualizer.def</ModuleDefinitionFile>
       <FullProgramDatabaseFile>true</FullProgramDatabaseFile>
+      <DelayLoadDLLs>vsdebugeng.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -141,6 +142,7 @@
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>advapi32.lib;shell32.lib;windowsapp.lib;$(VsDebugEng_Lib);%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>.\cppwinrtvisualizer.def</ModuleDefinitionFile>
+      <DelayLoadDLLs>vsdebugeng.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -169,6 +171,7 @@
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>advapi32.lib;shell32.lib;windowsapp.lib;$(VsDebugEng_Lib);%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>.\cppwinrtvisualizer.def</ModuleDefinitionFile>
+      <DelayLoadDLLs>vsdebugeng.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -197,6 +200,7 @@
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>advapi32.lib;shell32.lib;windowsapp.lib;$(VsDebugEng_Lib);%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>.\cppwinrtvisualizer.def</ModuleDefinitionFile>
+      <DelayLoadDLLs>vsdebugeng.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/package/natvis/object_visualizer.cpp
+++ b/src/package/natvis/object_visualizer.cpp
@@ -48,7 +48,7 @@ NatvisDiagnosticLevel GetNatvisDiagnosticLevel()
     }
     level = NatvisDiagnosticLevel::Error;
 
-    // If < VS16, look for private registry setting
+    // If < VS16, just output errors
     if (!DkmComponentManager::IsApiVersionSupported(DkmApiVersion::VS16RTM))
     {
         return level;

--- a/src/package/natvis/pch.h
+++ b/src/package/natvis/pch.h
@@ -31,5 +31,19 @@ winrt::com_ptr<T> make_com_ptr(T* ptr)
     return result;
 }
 
-extern std::unique_ptr<xlang::meta::reader::cache> db;
-void load_type_winmd(WCHAR const* processPath, std::string runtimeTypeName);
+xlang::meta::reader::TypeDef FindType(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::string const& typeName);
+
+enum class NatvisDiagnosticLevel
+{
+    Unknown = -1,
+    Off,
+    Error,
+    Warning,
+    Verbose
+};
+NatvisDiagnosticLevel GetNatvisDiagnosticLevel();
+HRESULT NatvisDiagnostic(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::wstring_view const& messageText, NatvisDiagnosticLevel level, HRESULT errorCode = S_OK);
+inline HRESULT NatvisDiagnostic(Microsoft::VisualStudio::Debugger::Evaluation::DkmVisualizedExpression* expression, std::wstring_view const& messageText, NatvisDiagnosticLevel level, HRESULT errorCode = S_OK)
+{
+    return NatvisDiagnostic(expression->RuntimeInstance()->Process(), messageText, level, errorCode);
+}

--- a/src/scripts/windows/build.cmd
+++ b/src/scripts/windows/build.cmd
@@ -20,7 +20,8 @@ goto :init
 
 :init
     set "OPT_HELP="
-    set "OPT_VERBOSE="
+    set "OPT_VERBOSE_NINJA="
+    set "OPT_VERBOSE_CMAKE="
     set "OPT_FORCE_CMAKE="
     set "BUILD_TYPE=Debug"
     set "BUILD_VERSION=1.0.0"
@@ -37,9 +38,9 @@ goto :init
     if /i "%~1"=="-h"         call :usage "%~2" & goto :end
     if /i "%~1"=="--help"     call :usage "%~2" & goto :end
 
-    if /i "%~1"=="/v"         set "OPT_VERBOSE=-v"  & shift & goto :parse
-    if /i "%~1"=="-v"         set "OPT_VERBOSE=-v"  & shift & goto :parse
-    if /i "%~1"=="--verbose"  set "OPT_VERBOSE=-v"  & shift & goto :parse
+    if /i "%~1"=="/v"         set "OPT_VERBOSE_NINJA=-v" & set "OPT_VERBOSE_CMAKE=-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON" & shift & goto :parse
+    if /i "%~1"=="-v"         set "OPT_VERBOSE_NINJA=-v" & set "OPT_VERBOSE_CMAKE=-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON" & shift & goto :parse
+    if /i "%~1"=="--verbose"  set "OPT_VERBOSE_NINJA=-v" & set "OPT_VERBOSE_CMAKE=-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON" & shift & goto :parse
 
     if /i "%~1"=="/f"               set "OPT_FORCE_CMAKE=yes"  & shift & goto :parse
     if /i "%~1"=="-f"               set "OPT_FORCE_CMAKE=yes"  & shift & goto :parse
@@ -65,10 +66,10 @@ goto :init
     if not exist "%BUILD_PATH%/CMakeCache.txt"  set "RUN_CMAKE=yes"
 
     if defined RUN_CMAKE (
-        cmake "%SRC_PATH%" "-B%BUILD_PATH%" -GNinja -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DXLANG_BUILD_VERSION=%BUILD_VERSION% "-DCMAKE_INSTALL_PREFIX=%BUILD_PATH%/Install"
+        cmake "%SRC_PATH%" "-B%BUILD_PATH%" %OPT_VERBOSE_CMAKE% -GNinja -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DXLANG_BUILD_VERSION=%BUILD_VERSION% "-DCMAKE_INSTALL_PREFIX=%BUILD_PATH%/Install"
     )
 
-    ninja -C "%BUILD_PATH%" %OPT_VERBOSE% %BUILD_TARGET%
+    ninja -C "%BUILD_PATH%" %OPT_VERBOSE_NINJA% %BUILD_TARGET%
 
 
 :end


### PR DESCRIPTION
Resolved an intermittent issue with winrt::hstring not visualizing due to missing COMBase!HSTRING__ symbol
Added copious diagnostic output to help with any remaining failures

fixes #280, #281 