### PR TITLE
Fix type order stability in C++/WinRT headers

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/type_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/type_writers.h
@@ -71,12 +71,20 @@ namespace xlang
     {
         using writer_base<writer>::write;
 
+        struct depends_compare
+        {
+            bool operator()(TypeDef const& left, TypeDef const& right) const
+            {
+                return left.TypeName() < right.TypeName();
+            }
+        };
+
         std::string type_namespace;
         bool abi_types{};
         bool param_names{};
         bool consume_types{};
         bool async_types{};
-        std::map<std::string_view, std::set<TypeDef>> depends;
+        std::map<std::string_view, std::set<TypeDef, depends_compare>> depends;
         std::vector<std::vector<std::string>> generic_param_stack;
 
         struct generic_param_guard


### PR DESCRIPTION
Type declaration order can become unpredictable, leading to headers changing when they shouldn't. This can cause PCH files to recompile unnecessarily. 