### PR TITLE
Fix C++/WinRT's support for detecting the SDK version to consume

### DIFF
--- a/src/library/impl/cmd_reader_windows.h
+++ b/src/library/impl/cmd_reader_windows.h
@@ -187,7 +187,12 @@ namespace xlang::impl
 
         if (std::regex_search(module_path.c_str(), match, rx))
         {
-            return match[1].str();
+            auto path = get_sdk_path() / "Platforms\\UAP" / match[1].str() / "Platform.xml";
+
+            if (std::experimental::filesystem::exists(path))
+            {
+                return match[1].str();
+            }
         }
 
         auto key = open_sdk();


### PR DESCRIPTION
The `-in sdk` option will find the winmds for the latest version of the SDK that is locally installed... unless cppwinrt.exe itself is contained within the SDK in which case it defaults to that version of the SDK. This behavior is desirable but fails when cppwinrt.exe is instead distributed via a NuGet package because the version detection mistakes the NuGet package version for the SDK version and then fails.

This update simply adds an additional existence check to make sure that the inferred version actually represents an installed SDK version. If not, it simply continues to look for the latest SDK version.