### PR TITLE
take_ownership_from_abi should be an inline variable

### DIFF
--- a/src/tool/cppwinrt/strings/base_meta.h
+++ b/src/tool/cppwinrt/strings/base_meta.h
@@ -8,7 +8,7 @@ namespace winrt
     D* get_self(I const& from) noexcept;
 
     struct take_ownership_from_abi_t {};
-    constexpr take_ownership_from_abi_t take_ownership_from_abi{};
+    inline constexpr take_ownership_from_abi_t take_ownership_from_abi{};
 
     template <typename T>
     struct com_ptr;

--- a/src/tool/cppxlang/strings/base_meta.h
+++ b/src/tool/cppxlang/strings/base_meta.h
@@ -9,7 +9,7 @@ namespace xlang
     D* get_self(I const& from) noexcept;
 
     struct take_ownership_from_abi_t {};
-    constexpr take_ownership_from_abi_t take_ownership_from_abi{};
+    inline constexpr take_ownership_from_abi_t take_ownership_from_abi{};
 
     template <typename T>
     struct com_ptr;


### PR DESCRIPTION
To avoid each c…pp file getting its own copy.