### PR TITLE
Ensure C++/WinRT's resume_foreground always releases the calling thread

### DIFF
--- a/src/tool/cppwinrt/strings/base_coroutine_resume.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_resume.h
@@ -246,9 +246,9 @@ namespace winrt
             {
             }
 
-            bool await_ready() const
+            bool await_ready() const noexcept
             {
-                return m_dispatcher.HasThreadAccess();
+                return false;
             }
 
             void await_resume() const noexcept


### PR DESCRIPTION
It turns out that `resume_foreground` is being too clever and can introduce deadlocks in some scenarios because it only suspends if not already on the dispatcher thread. This update simply ensures that resumption is always re-queued/dispatched. 