### PR TITLE
Add parent reference to class and interface in event method and property

### DIFF
--- a/src/tool/xmeta/cpp/models/event_model.h
+++ b/src/tool/xmeta/cpp/models/event_model.h
@@ -17,11 +17,19 @@ namespace xlang::xmeta
     struct event_model : base_model
     {
         event_model() = delete;
-        event_model(std::string_view const& id, size_t decl_line, std::string_view const& assembly_name, event_semantics const& sem, std::shared_ptr<method_model> const& add_method_ref, std::shared_ptr<method_model> const& remove_method_ref, type_ref&& t) :
+        event_model(std::string_view const& id, 
+                size_t decl_line, 
+                std::string_view const& assembly_name, 
+                event_semantics const& sem, 
+                std::shared_ptr<method_model> const& add_method_ref, 
+                std::shared_ptr<method_model> const& remove_method_ref,
+                std::variant<std::shared_ptr<class_model>, std::shared_ptr<interface_model>> const& parent,
+                type_ref&& t) :
             base_model{ id, decl_line, assembly_name },
             m_semantic{ sem },
             m_add_method_ref{ add_method_ref },
             m_remove_method_ref{ remove_method_ref },
+            m_parent{ parent },
             m_type{ std::move(t) }
         { }
 

--- a/src/tool/xmeta/cpp/models/event_model.h
+++ b/src/tool/xmeta/cpp/models/event_model.h
@@ -45,11 +45,18 @@ namespace xlang::xmeta
             return m_type;
         }
 
+        auto const& get_parent() const noexcept
+        {
+            return m_parent;
+        }
+
     private:
         event_semantics m_semantic;
         type_ref m_type;
 
         std::shared_ptr<method_model> m_add_method_ref;
         std::shared_ptr<method_model> m_remove_method_ref;
+
+        std::variant<std::shared_ptr<class_model>, std::shared_ptr<interface_model>> m_parent;
     };
 }

--- a/src/tool/xmeta/cpp/models/method_model.h
+++ b/src/tool/xmeta/cpp/models/method_model.h
@@ -53,6 +53,11 @@ namespace xlang::xmeta
             return m_semantic;
         }
 
+        auto const& get_parent() const noexcept
+        {
+            return m_parent;
+        }
+
         void set_overridden_method_ref(std::shared_ptr<method_model> const& ref) noexcept
         {
             m_overridden_method_ref = ref;
@@ -63,6 +68,7 @@ namespace xlang::xmeta
         std::optional<type_ref> m_return_type;
         std::vector<formal_parameter_model> m_formal_parameters;
         std::variant<std::string, std::shared_ptr<method_model>> m_overridden_method_ref;
+        std::variant<std::shared_ptr<class_model>, std::shared_ptr<interface_model>> m_parent;
         // TODO: Add type parameters (generic types)
     };
 }

--- a/src/tool/xmeta/cpp/models/method_model.h
+++ b/src/tool/xmeta/cpp/models/method_model.h
@@ -19,17 +19,30 @@ namespace xlang::xmeta
     struct method_model : base_model
     {
         method_model() = delete;
-        method_model(std::string_view const& id, size_t decl_line, std::string_view const& assembly_name, std::optional<type_ref>&& return_type, std::vector<formal_parameter_model>&& formal_params, method_semantics const& sem) :
+        method_model(std::string_view const& id, size_t decl_line, 
+                std::string_view const& assembly_name, 
+                std::optional<type_ref>&& return_type, 
+                std::vector<formal_parameter_model>&& formal_params,
+                std::variant<std::shared_ptr<class_model>, std::shared_ptr<interface_model>> const& parent,
+                method_semantics const& sem) :
             base_model{ id, decl_line, assembly_name },
             m_formal_parameters{ std::move(formal_params) },
             m_return_type{ std::move(return_type) },
+            m_parent{ parent },
             m_semantic{ sem }
         { }
 
-        method_model(std::string_view const& id, size_t decl_line, std::string_view const& assembly_name, std::optional<type_ref>&& return_type, std::vector<formal_parameter_model>&& formal_params, std::string_view const& overridden_method_ref) :
+        method_model(std::string_view const& id, 
+                size_t decl_line, 
+                std::string_view const& assembly_name, 
+                std::optional<type_ref>&& return_type, 
+                std::vector<formal_parameter_model>&& formal_params,
+                std::variant<std::shared_ptr<class_model>, std::shared_ptr<interface_model>> const& parent,
+                std::string_view const& overridden_method_ref) :
             base_model{ id, decl_line, assembly_name },
             m_formal_parameters{ std::move(formal_params) },
             m_return_type{ std::move(return_type) },
+            m_parent{ parent },
             m_overridden_method_ref{ std::string(overridden_method_ref) }
         { }
 

--- a/src/tool/xmeta/cpp/models/property_model.h
+++ b/src/tool/xmeta/cpp/models/property_model.h
@@ -51,10 +51,16 @@ namespace xlang::xmeta
             return m_set_method;
         }
 
+        auto const& get_parent() const noexcept
+        {
+            return m_parent;
+        }
+
     private:
         property_semantics m_semantic;
         property_type_semantics m_type;
         std::shared_ptr<method_model> m_get_method;
         std::shared_ptr<method_model> m_set_method;
+        std::variant<std::shared_ptr<class_model>, std::shared_ptr<interface_model>> m_parent;
     };
 }

--- a/src/tool/xmeta/cpp/models/property_model.h
+++ b/src/tool/xmeta/cpp/models/property_model.h
@@ -23,12 +23,20 @@ namespace xlang::xmeta
     struct property_model : base_model
     {
         property_model() = delete;
-        property_model(std::string_view const& id, size_t decl_line, std::string_view const& assembly_name, property_semantics const& sem, property_type_semantics&& type, std::shared_ptr<method_model> const& get_method, std::shared_ptr<method_model> const& set_method) :
+        property_model(std::string_view const& id, 
+                size_t decl_line, 
+                std::string_view const& assembly_name, 
+                property_semantics const& sem, 
+                property_type_semantics&& type, 
+                std::shared_ptr<method_model> const& get_method, 
+                std::shared_ptr<method_model> const& set_method,
+                std::variant<std::shared_ptr<class_model>, std::shared_ptr<interface_model>> const& parent) :
             base_model{ id, decl_line, assembly_name },
             m_semantic{ sem },
             m_type{ std::move(type) },
             m_get_method{ get_method },
-            m_set_method{ set_method }
+            m_set_method{ set_method },
+            m_parent{ parent }
         { }
 
         auto const& get_semantic() const noexcept


### PR DESCRIPTION
Because of how my walker works, I need a reference to the parent model that holds the methods, properties, and events in the methods, properties, and events model. This helps reduce coupling in my walker and listener. 