### PR TITLE
Async timeout support for C++/WinRT - part 1

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -1339,7 +1339,7 @@ namespace xlang
         {
             wait_get(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
         }
-        auto wait_for(std::chrono::high_resolution_clock::duration const& timeout) const
+        auto wait_for(Windows::Foundation::TimeSpan const& timeout) const
         {
             return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
         }
@@ -1351,9 +1351,9 @@ namespace xlang
         {
             return wait_get(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
         }
-        auto wait_for(std::chrono::high_resolution_clock::duration const& timeout) const
+        auto wait_for(Windows::Foundation::TimeSpan const& timeout) const
         {
-            return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
+            return impl::wait_for(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)), timeout);
         }
 )");
         }
@@ -1363,9 +1363,9 @@ namespace xlang
         {
             wait_get(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
         }
-        auto wait_for(std::chrono::high_resolution_clock::duration const& timeout) const
+        auto wait_for(Windows::Foundation::TimeSpan const& timeout) const
         {
-            return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
+            return impl::wait_for(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)), timeout);
         }
 )");
         }
@@ -1375,9 +1375,9 @@ namespace xlang
         {
             return wait_get(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
         }
-        auto wait_for(std::chrono::high_resolution_clock::duration const& timeout) const
+        auto wait_for(Windows::Foundation::TimeSpan const& timeout) const
         {
-            return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
+            return impl::wait_for(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)), timeout);
         }
 )");
         }

--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -1337,33 +1337,49 @@ namespace xlang
         {
             w.write(R"(        void get() const
         {
-            blocking_suspend(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
-            GetResults();
-        })");
+            wait_get(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
+        }
+        auto wait_for(std::chrono::high_resolution_clock::duration const& timeout) const
+        {
+            return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
+        }
+)");
         }
         else if (type_name == "Windows.Foundation.IAsyncOperation`1")
         {
             w.write(R"(        TResult get() const
         {
-            blocking_suspend(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
-            return GetResults();
-        })");
+            return wait_get(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
+        }
+        auto wait_for(std::chrono::high_resolution_clock::duration const& timeout) const
+        {
+            return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
+        }
+)");
         }
         else if (type_name == "Windows.Foundation.IAsyncActionWithProgress`1")
         {
             w.write(R"(        void get() const
         {
-            blocking_suspend(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
-            GetResults();
-        })");
+            wait_get(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
+        }
+        auto wait_for(std::chrono::high_resolution_clock::duration const& timeout) const
+        {
+            return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
+        }
+)");
         }
         else if (type_name == "Windows.Foundation.IAsyncOperationWithProgress`2")
         {
             w.write(R"(        TResult get() const
         {
-            blocking_suspend(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
-            return GetResults();
-        })");
+            return wait_get(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
+        }
+        auto wait_for(std::chrono::high_resolution_clock::duration const& timeout) const
+        {
+            return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
+        }
+)");
         }
     }
 

--- a/src/tool/cppwinrt/old_tests/Component/pch.h
+++ b/src/tool/cppwinrt/old_tests/Component/pch.h
@@ -2,7 +2,6 @@
 
 #pragma warning(disable:4100)
 
-#include "winrt/coroutine.h"
 #include "winrt/Windows.Foundation.Collections.h"
 #include "winrt/Composable.h"
 

--- a/src/tool/cppwinrt/old_tests/Composable/precomp.hpp
+++ b/src/tool/cppwinrt/old_tests/Composable/precomp.hpp
@@ -2,6 +2,5 @@
 
 #pragma warning(disable:4100)
 
-#include "winrt/coroutine.h"
 #include "winrt/Windows.Foundation.h"
 #include "winrt/Composable.h"

--- a/src/tool/cppwinrt/old_tests/UnitTests/pch.h
+++ b/src/tool/cppwinrt/old_tests/UnitTests/pch.h
@@ -8,8 +8,6 @@
 #include <unknwn.h>
 #undef GetCurrentTime
 
-#include "winrt\coroutine.h"
-
 #include "winrt\Windows.Foundation.Collections.h"
 #include "winrt\Windows.Foundation.Diagnostics.h"
 #include "winrt\Windows.ApplicationModel.Activation.h"

--- a/src/tool/cppwinrt/strings/base_coroutine_foundation.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_foundation.h
@@ -1,6 +1,36 @@
 
 namespace winrt::impl
 {
+    template <typename Async>
+    struct async_completed_handler;
+
+    template <typename Async>
+    using async_completed_handler_t = typename async_completed_handler<Async>::type;
+
+    template <>
+    struct async_completed_handler<Windows::Foundation::IAsyncAction>
+    {
+        using type = Windows::Foundation::AsyncActionCompletedHandler;
+    };
+
+    template <typename TProgress>
+    struct async_completed_handler<Windows::Foundation::IAsyncActionWithProgress<TProgress>>
+    {
+        using type = Windows::Foundation::AsyncActionWithProgressCompletedHandler<TProgress>;
+    };
+
+    template <typename TResult>
+    struct async_completed_handler<Windows::Foundation::IAsyncOperation<TResult>>
+    {
+        using type = Windows::Foundation::AsyncOperationCompletedHandler<TResult>;
+    };
+
+    template <typename TResult, typename TProgress>
+    struct async_completed_handler<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress>>
+    {
+        using type = Windows::Foundation::AsyncOperationWithProgressCompletedHandler<TResult, TProgress>;
+    };
+
     inline bool is_sta() noexcept
     {
         int32_t aptType;
@@ -9,31 +39,25 @@ namespace winrt::impl
     }
 
     template <typename Async>
-    void wait_for_completed(Async const& async, std::chrono::high_resolution_clock::duration const& timeout)
+    void wait_for_completed(Async const& async, uint32_t const timeout)
     {
-        // TODO: Maybe WaitForSingleObject is now faster.
+        void* event = check_pointer(WINRT_CreateEventW(nullptr, true, false, nullptr));
 
-        slim_mutex m;
-        slim_condition_variable cv;
-        bool completed = false;
-        async.Completed([&](auto&&...)
-            {
-                {
-                    slim_lock_guard const guard(m);
-                    completed = true;
-                }
-                cv.notify_one();
-            });
+        // The delegate is a local to ensure that the event outlives the call to WaitForSingleObject.
+        async_completed_handler_t<Async> delegate = [event = handle(event)](auto && ...)
+        {
+            WINRT_VERIFY(WINRT_SetEvent(event.get()));
+        };
 
-        slim_lock_guard guard(m);
-        cv.wait_for(m, timeout, [&] { return completed; });
+        async.Completed(delegate);
+        WINRT_WaitForSingleObject(event, timeout);
     }
 
     template <typename Async>
-    auto wait_for(Async const& async, std::chrono::high_resolution_clock::duration const& timeout)
+    auto wait_for(Async const& async, Windows::Foundation::TimeSpan const& timeout)
     {
         WINRT_ASSERT(!is_sta());
-        wait_for_completed(async, timeout);
+        wait_for_completed(async, static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count()));
         return async.Status();
     }
 
@@ -44,7 +68,7 @@ namespace winrt::impl
 
         if (async.Status() == Windows::Foundation::AsyncStatus::Started)
         {
-            wait_for_completed(async, {});
+            wait_for_completed(async, 0xFFFFFFFF); // INFINITE
         }
 
         return async.GetResults();
@@ -201,7 +225,7 @@ namespace winrt::impl
         Promise* m_promise;
     };
 
-    template <typename Derived, typename AsyncInterface, typename CompletedHandler, typename TProgress = void>
+    template <typename Derived, typename AsyncInterface, typename TProgress = void>
     struct promise_base : implements<Derived, AsyncInterface, Windows::Foundation::IAsyncInfo>
     {
         using AsyncStatus = Windows::Foundation::AsyncStatus;
@@ -219,7 +243,7 @@ namespace winrt::impl
             return remaining;
         }
 
-        void Completed(CompletedHandler const& handler)
+        void Completed(async_completed_handler_t<AsyncInterface> const& handler)
         {
             AsyncStatus status;
 
@@ -248,7 +272,7 @@ namespace winrt::impl
             }
         }
 
-        CompletedHandler Completed() noexcept
+        auto Completed() noexcept
         {
             slim_lock_guard const guard(m_lock);
             return m_completed;
@@ -329,7 +353,7 @@ namespace winrt::impl
 
         void set_completed() noexcept
         {
-            CompletedHandler handler;
+            async_completed_handler_t<AsyncInterface> handler;
             AsyncStatus status;
 
             {
@@ -461,7 +485,7 @@ namespace winrt::impl
 
         std::exception_ptr m_exception{};
         slim_mutex m_lock;
-        CompletedHandler m_completed;
+        async_completed_handler_t<AsyncInterface> m_completed;
         winrt::delegate<> m_cancel;
         AsyncStatus m_status{ AsyncStatus::Started };
         bool m_completed_assigned{ false };
@@ -473,9 +497,7 @@ namespace std::experimental
     template <typename... Args>
     struct coroutine_traits<winrt::Windows::Foundation::IAsyncAction, Args...>
     {
-        struct promise_type final : winrt::impl::promise_base<promise_type,
-            winrt::Windows::Foundation::IAsyncAction,
-            winrt::Windows::Foundation::AsyncActionCompletedHandler>
+        struct promise_type final : winrt::impl::promise_base<promise_type, winrt::Windows::Foundation::IAsyncAction>
         {
             void return_void() const noexcept
             {
@@ -486,9 +508,7 @@ namespace std::experimental
     template <typename TProgress, typename... Args>
     struct coroutine_traits<winrt::Windows::Foundation::IAsyncActionWithProgress<TProgress>, Args...>
     {
-        struct promise_type final : winrt::impl::promise_base<promise_type,
-            winrt::Windows::Foundation::IAsyncActionWithProgress<TProgress>,
-            winrt::Windows::Foundation::AsyncActionWithProgressCompletedHandler<TProgress>, TProgress>
+        struct promise_type final : winrt::impl::promise_base<promise_type, winrt::Windows::Foundation::IAsyncActionWithProgress<TProgress>, TProgress>
         {
             using ProgressHandler = winrt::Windows::Foundation::AsyncActionProgressHandler<TProgress>;
 
@@ -523,9 +543,7 @@ namespace std::experimental
     template <typename TResult, typename... Args>
     struct coroutine_traits<winrt::Windows::Foundation::IAsyncOperation<TResult>, Args...>
     {
-        struct promise_type final : winrt::impl::promise_base<promise_type,
-            winrt::Windows::Foundation::IAsyncOperation<TResult>,
-            winrt::Windows::Foundation::AsyncOperationCompletedHandler<TResult>>
+        struct promise_type final : winrt::impl::promise_base<promise_type, winrt::Windows::Foundation::IAsyncOperation<TResult>>
         {
             TResult get_return_value() noexcept
             {
@@ -550,8 +568,7 @@ namespace std::experimental
     struct coroutine_traits<winrt::Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress>, Args...>
     {
         struct promise_type final : winrt::impl::promise_base<promise_type,
-            winrt::Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress>,
-            winrt::Windows::Foundation::AsyncOperationWithProgressCompletedHandler<TResult, TProgress>, TProgress>
+            winrt::Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress>, TProgress>
         {
             using ProgressHandler = winrt::Windows::Foundation::AsyncOperationProgressHandler<TResult, TProgress>;
 

--- a/src/tool/cppwinrt/strings/base_extern.h
+++ b/src/tool/cppwinrt/strings/base_extern.h
@@ -32,7 +32,6 @@ extern "C"
     void     WINRT_CALL WINRT_SysFreeString(winrt::impl::bstr string) noexcept;
     uint32_t WINRT_CALL WINRT_SysStringLen(winrt::impl::bstr string) noexcept;
     int32_t  WINRT_CALL WINRT_IIDFromString(wchar_t const* string, winrt::guid* iid) noexcept;
-    int32_t  WINRT_CALL WINRT_CloseHandle(void* hObject) noexcept;
     int32_t  WINRT_CALL WINRT_MultiByteToWideChar(uint32_t codepage, uint32_t flags, char const* in_string, int32_t in_size, wchar_t* out_string, int32_t out_size) noexcept;
     int32_t  WINRT_CALL WINRT_WideCharToMultiByte(uint32_t codepage, uint32_t flags, wchar_t const* int_string, int32_t in_size, char* out_string, int32_t out_size, char const* default_char, int32_t* default_used) noexcept;
     int32_t  WINRT_CALL WINRT_HeapFree(void* heap, uint32_t flags, void* value) noexcept;
@@ -61,7 +60,11 @@ extern "C"
     void*   WINRT_CALL WINRT_InterlockedPushEntrySList(void* head, void* entry) noexcept;
     void*   WINRT_CALL WINRT_InterlockedFlushSList(void* head) noexcept;
 
+    void* WINRT_CALL WINRT_CreateEventW(void*, int32_t, int32_t, void*) noexcept;
+    int32_t WINRT_CALL WINRT_SetEvent(void*) noexcept;
+    int32_t  WINRT_CALL WINRT_CloseHandle(void* hObject) noexcept;
     uint32_t WINRT_CALL WINRT_WaitForSingleObject(void* handle, uint32_t milliseconds) noexcept;
+
     int32_t  WINRT_CALL WINRT_TrySubmitThreadpoolCallback(void(WINRT_CALL *callback)(void*, void* context), void* context, void*) noexcept;
     winrt::impl::ptp_timer WINRT_CALL WINRT_CreateThreadpoolTimer(void(WINRT_CALL *callback)(void*, void* context, void*), void* context, void*) noexcept;
     void     WINRT_CALL WINRT_SetThreadpoolTimer(winrt::impl::ptp_timer timer, void* time, uint32_t period, uint32_t window) noexcept;
@@ -113,7 +116,6 @@ WINRT_LINK(CoTaskMemFree, 4)
 WINRT_LINK(SysFreeString, 4)
 WINRT_LINK(SysStringLen, 4)
 WINRT_LINK(IIDFromString, 8)
-WINRT_LINK(CloseHandle, 4)
 WINRT_LINK(MultiByteToWideChar, 24)
 WINRT_LINK(WideCharToMultiByte, 32)
 WINRT_LINK(HeapFree, 12)
@@ -142,7 +144,11 @@ WINRT_LINK(InitializeSListHead, 4)
 WINRT_LINK(InterlockedPushEntrySList, 8)
 WINRT_LINK(InterlockedFlushSList, 4)
 
+WINRT_LINK(CreateEventW, 16)
+WINRT_LINK(SetEvent, 4)
+WINRT_LINK(CloseHandle, 4)
 WINRT_LINK(WaitForSingleObject, 8)
+
 WINRT_LINK(TrySubmitThreadpoolCallback, 12)
 WINRT_LINK(CreateThreadpoolTimer, 12)
 WINRT_LINK(SetThreadpoolTimer, 16)

--- a/src/tool/cppwinrt/test/async_wait_for.cpp
+++ b/src/tool/cppwinrt/test/async_wait_for.cpp
@@ -1,0 +1,136 @@
+#include "pch.h"
+
+using namespace std::literals;
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    IAsyncAction Action(TimeSpan delay, AsyncStatus result)
+    {
+        co_await resume_after(delay);
+
+        if (result == AsyncStatus::Error)
+        {
+            throw hresult_invalid_argument();
+        }
+
+        if (result == AsyncStatus::Canceled)
+        {
+            throw hresult_canceled();
+        }
+    }
+
+    IAsyncActionWithProgress<int> ActionWithProgress(TimeSpan delay, AsyncStatus result)
+    {
+        co_await resume_after(delay);
+
+        if (result == AsyncStatus::Error)
+        {
+            throw hresult_invalid_argument();
+        }
+
+        if (result == AsyncStatus::Canceled)
+        {
+            throw hresult_canceled();
+        }
+    }
+
+    IAsyncOperation<int> Operation(TimeSpan delay, AsyncStatus result)
+    {
+        co_await resume_after(delay);
+
+        if (result == AsyncStatus::Error)
+        {
+            throw hresult_invalid_argument();
+        }
+
+        if (result == AsyncStatus::Canceled)
+        {
+            throw hresult_canceled();
+        }
+
+        co_return 1;
+    }
+
+    IAsyncOperationWithProgress<int, int> OperationWithProgress(TimeSpan delay, AsyncStatus result)
+    {
+        co_await resume_after(delay);
+
+        if (result == AsyncStatus::Error)
+        {
+            throw hresult_invalid_argument();
+        }
+
+        if (result == AsyncStatus::Canceled)
+        {
+            throw hresult_canceled();
+        }
+
+        co_return 1;
+    }
+
+    template <typename T>
+    void check(T const& no_suspend_ok, T const& no_suspend_fail, T const& delay_ok, T const& delay_fail, T const& no_suspend_cancel, T const& delay_cancel, T const& long_delay)
+    {
+        REQUIRE(no_suspend_ok.wait_for(0s) == AsyncStatus::Completed);
+        no_suspend_ok.get();
+        REQUIRE_THROWS_AS(no_suspend_ok.wait_for(0s), hresult_illegal_delegate_assignment);
+
+        REQUIRE(no_suspend_fail.wait_for(0s) == AsyncStatus::Error);
+        REQUIRE_THROWS_AS(no_suspend_fail.get(), hresult_invalid_argument);
+
+        REQUIRE(delay_ok.wait_for(1s) == AsyncStatus::Completed);
+        delay_ok.get();
+
+        REQUIRE(delay_fail.wait_for(1s) == AsyncStatus::Error);
+        REQUIRE_THROWS_AS(delay_fail.get(), hresult_invalid_argument);
+
+        REQUIRE(no_suspend_cancel.wait_for(0s) == AsyncStatus::Canceled);
+        REQUIRE_THROWS_AS(no_suspend_cancel.get(), hresult_canceled);
+
+        REQUIRE(delay_cancel.wait_for(1s) == AsyncStatus::Canceled);
+        REQUIRE_THROWS_AS(delay_cancel.get(), hresult_canceled);
+
+        REQUIRE(long_delay.wait_for(100ms) == AsyncStatus::Started);
+    }
+}
+
+TEST_CASE("async_wait_for")
+{
+    check(
+        Action(0s, AsyncStatus::Completed),
+        Action(0s, AsyncStatus::Error),
+        Action(100ms, AsyncStatus::Completed),
+        Action(100ms, AsyncStatus::Error),
+        Action(0s, AsyncStatus::Canceled),
+        Action(100ms, AsyncStatus::Canceled),
+        Action(1h, AsyncStatus::Completed));
+
+    check(
+        ActionWithProgress(0s, AsyncStatus::Completed),
+        ActionWithProgress(0s, AsyncStatus::Error),
+        ActionWithProgress(100ms, AsyncStatus::Completed),
+        ActionWithProgress(100ms, AsyncStatus::Error),
+        ActionWithProgress(0s, AsyncStatus::Canceled),
+        ActionWithProgress(100ms, AsyncStatus::Canceled),
+        ActionWithProgress(1h, AsyncStatus::Completed));
+
+    check(
+        Operation(0s, AsyncStatus::Completed),
+        Operation(0s, AsyncStatus::Error),
+        Operation(100ms, AsyncStatus::Completed),
+        Operation(100ms, AsyncStatus::Error),
+        Operation(0s, AsyncStatus::Canceled),
+        Operation(100ms, AsyncStatus::Canceled),
+        Operation(1h, AsyncStatus::Completed));
+
+    check(
+        OperationWithProgress(0s, AsyncStatus::Completed),
+        OperationWithProgress(0s, AsyncStatus::Error),
+        OperationWithProgress(100ms, AsyncStatus::Completed),
+        OperationWithProgress(100ms, AsyncStatus::Error),
+        OperationWithProgress(0s, AsyncStatus::Canceled),
+        OperationWithProgress(100ms, AsyncStatus::Canceled),
+        OperationWithProgress(1h, AsyncStatus::Completed));
+}

--- a/src/tool/cppwinrt/test/pch.h
+++ b/src/tool/cppwinrt/test/pch.h
@@ -4,7 +4,6 @@
 #include <winstring.h>
 
 #include "catch.hpp"
-#include "winrt/coroutine.h"
 #include "winrt/Windows.Foundation.Collections.h"
 #include "winrt/Windows.Foundation.Numerics.h"
 

--- a/src/tool/cppwinrt/test/test.vcxproj
+++ b/src/tool/cppwinrt/test/test.vcxproj
@@ -208,6 +208,7 @@
     <ClCompile Include="async_return.cpp" />
     <ClCompile Include="async_suspend.cpp" />
     <ClCompile Include="async_throw.cpp" />
+    <ClCompile Include="async_wait_for.cpp" />
     <ClCompile Include="capture.cpp" />
     <ClCompile Include="cmd_reader.cpp" />
     <ClCompile Include="coro_foundation.cpp">

--- a/src/tool/cppwinrt/test_component/pch.h
+++ b/src/tool/cppwinrt/test_component/pch.h
@@ -1,4 +1,4 @@
 #pragma once
 
 #include <numeric>
-#include "winrt/coroutine.h"
+#include <winrt/Windows.Foundation.h>

--- a/src/tool/cppwinrt/test_fast/pch.h
+++ b/src/tool/cppwinrt/test_fast/pch.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "catch.hpp"
-#include "winrt/coroutine.h"
 #include "winrt/Windows.Foundation.Collections.h"
 
 using namespace std::literals;

--- a/src/tool/cppwinrt/test_slow/pch.h
+++ b/src/tool/cppwinrt/test_slow/pch.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "catch.hpp"
-#include "winrt/coroutine.h"
 #include "winrt/Windows.Foundation.Collections.h"
 
 using namespace std::literals;


### PR DESCRIPTION
Today C++/WinRT provides support for blocking wait via `async.get()` and cooperative wait via `co_await async` but there is not ability to use a timeout. This has lead some teams needing timeout support to implement various workarounds that are not very efficient or robust. Part 1 introduces support for a timeout for the blocking scenario. Part 2 introduces support for cooperative timeout for coroutines.

The `get` function follows the pattern established by `std::future` so it makes sense to adopt future's `wait_for` function to support a timeout as well. Note that WinRT only allows waiting once. That means you cannot use `wait_for` in a loop, or any other scenario where multiple waits would occur.

You can wait for an `IAsyncAction` as follows:

```C++
using namespace Windows::Foundation;

IAsyncAction async = ...

if (async.wait_for(5s) == AsyncStatus::Completed)
{
    puts("done");
}
```

You can wait for an `IAsyncOperation` as follows:

```C++
IAsyncOperation<hstring> async = ...

if (async.wait_for(5s) == AsyncStatus::Completed)
{
    printf("result: %ls\n", async.get().c_str());
}
```

Or more comprehensively:

```C++
IAsyncOperation<hstring> async = ...

switch (async.wait_for(2s))
{
case AsyncStatus::Completed:
    printf("result: %ls\n", async.get().c_str());
    break;
case AsyncStatus::Started:
    puts("still running");
    break;
case AsyncStatus::Canceled:
    puts("canceled");
    break;
case AsyncStatus::Error:
    puts("failed");
    break;
}
```



