### PR TITLE
Restore static_assert for WinRT types in C++/WinRT generics

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -166,6 +166,17 @@ namespace xlang
         }
     }
 
+    static void write_generic_asserts(writer& w, std::pair<GenericParam, GenericParam> const& params)
+    {
+        for (auto&& param : params)
+        {
+            auto format = R"(
+        static_assert(impl::has_category_v<%>, "% must be WinRT type.");)";
+
+            w.write(format, param, param);
+        }
+    }
+
     static void write_comma_generic_typenames(writer& w, std::pair<GenericParam, GenericParam> const& params)
     {
         for (auto&& param : params)
@@ -2244,7 +2255,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
     struct WINRT_EBO % :
         Windows::Foundation::IInspectable,
         impl::consume_t<%>%
-    {
+    {%
         %(std::nullptr_t = nullptr) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : Windows::Foundation::IInspectable(ptr, take_ownership_from_abi) {}
 %%    };
@@ -2255,6 +2266,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
                 type_name,
                 type,
                 bind<write_interface_requires>(type),
+                bind<write_generic_asserts>(generics),
                 type_name,
                 type_name,
                 bind<write_interface_usings>(type),
@@ -2279,7 +2291,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         }
 
         auto format = R"(    struct % : Windows::Foundation::IUnknown
-    {
+    {%
         %(std::nullptr_t = nullptr) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : Windows::Foundation::IUnknown(ptr, take_ownership_from_abi) {}
         template <typename L> %(L lambda);
@@ -2295,6 +2307,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
 
         w.write(format,
             type_name,
+            bind<write_generic_asserts>(generics),
             type_name,
             type_name,
             type_name,


### PR DESCRIPTION
In C++/WinRT 1.0, I had hand-written the generic types and included a static_assert to provide a more helpful compiler error when developers used something like `Windows::Foundation::AsyncActionProgressHandler<TProgress>` or `Windows::Foundation::Collections::IVector<T>` with non-WinRT types. This didn't get preserved when I originally ported cppwinrt.exe over to xlang. Here I'm just restoring that static_assert so that it behaves the way it did in C++/WinRT 1.0. For example:

```
Windows.Foundation.2.h(101): error C2338: T must be WinRT type. (compiling source file scratch.cpp)
sample.cpp(7): note: see reference to class template instantiation 'winrt::Windows::Foundation::EventHandler<std::string>' being compiled
```