### PR TITLE
Reliably diagnose stack allocations in C++/WinRT breaks the Xaml compiler

### DIFF
--- a/src/tool/cppwinrt/strings/base_collections_input_iterable.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_iterable.h
@@ -42,7 +42,7 @@ namespace winrt::impl
             return range_container<InputIt>{ m_begin, m_end };
         }
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(WINRT_NO_MAKE_DETECTION)
         void use_make_function_to_create_this_object() final
         {
         }

--- a/src/tool/cppwinrt/strings/base_collections_input_map_view.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_map_view.h
@@ -42,7 +42,7 @@ namespace winrt::impl
             return m_values;
         }
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(WINRT_NO_MAKE_DETECTION)
         void use_make_function_to_create_this_object() final
         {
         }

--- a/src/tool/cppwinrt/strings/base_collections_input_vector_view.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_vector_view.h
@@ -42,7 +42,7 @@ namespace winrt::impl
             return range_container<InputIt>{ m_begin, m_end };
         }
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(WINRT_NO_MAKE_DETECTION)
         void use_make_function_to_create_this_object() final
         {
         }

--- a/src/tool/cppwinrt/strings/base_coroutine_foundation.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_foundation.h
@@ -467,7 +467,7 @@ namespace winrt::impl
             cancel();
         }
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(WINRT_NO_MAKE_DETECTION)
         void use_make_function_to_create_this_object() final
         {
         }

--- a/src/tool/cppwinrt/strings/base_implements.h
+++ b/src/tool/cppwinrt/strings/base_implements.h
@@ -1163,7 +1163,7 @@ namespace winrt::impl
     {
         using T::T;
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(WINRT_NO_MAKE_DETECTION)
         void use_make_function_to_create_this_object() final
         {
         }
@@ -1263,7 +1263,7 @@ namespace winrt
         using implements_type = implements;
         using IInspectable = Windows::Foundation::IInspectable;
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(WINRT_NO_MAKE_DETECTION)
         // Please use winrt::make<T>(args...) to avoid allocating a C++/WinRT implementation type on the stack.
         virtual void use_make_function_to_create_this_object() = 0;
 #endif


### PR DESCRIPTION
The Xaml compiler has a bug where it generates `std::shared_ptr<T>` instead of `winrt::com_ptr<T>` for WinRT types. This has always been wrong because it breaks the lifetime  guarantee of the implementation. The newly introduced diagnostics in C++/WinRT correctly flags this invalid use with a compiler error. Unfortunately, fixing the Xaml compiler may take some time so we need an opt-out for projects using the Xaml compiler until a fix is available. Now projects can define `WINRT_NO_MAKE_DETECTION` to turn off the detection of direct allocations.