### PR TITLE
Improved error message to help diagnose invalid winmd files 

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -748,8 +748,18 @@ namespace xlang
 
         for (auto&& method : type.MethodList())
         {
-            method_signature signature{ method };
-            w.write(format, get_abi_name(method), bind<write_abi_params>(signature));
+            try
+            {
+                method_signature signature{ method };
+                w.write(format, get_abi_name(method), bind<write_abi_params>(signature));
+            }
+            catch (std::exception const& e)
+            {
+                throw_invalid(e.what(),
+                    "\n method: ", get_name(method),
+                    "\n type: ", type.TypeNamespace(), ".", type.TypeName(),
+                    "\n database: ", type.get_database().path());
+            }
         }
 
         write_fast_interface_abi(w, type);


### PR DESCRIPTION
This is a small targeted improvement to the diagnostics produced by `cppwinrt.exe` to help apply the blame accurately when encountering types in a winmd that use non-WinRT types in an ABI context. For example, given this invalid C++/CX code (that sadly compiles):

```C++
namespace BadCppCxComponent
{
    public ref struct Class sealed
    {
        Class()
        {
        }

        Platform::Type^ GetInvalidType()
        {
            return nullptr;
        }
    };
}
```

The cppwinrt compiler now produces a more helpful diagnostic pinpointing the source of the problem:

```
C:\scratch>cppwinrt.exe -in BadCppCxComponent.winmd
 error: Type 'System.Type' could not be found
 method: GetInvalidType
 type: BadCppCxComponent.__IClassPublicNonVirtuals
 database: C:\scratch\BadCppCxComponent.winmd
```

Given a large winmd with hundreds of types, this can make a world of difference.