### PR TITLE
More efficient GUID comparisons in C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/strings/base_types.h
+++ b/src/tool/cppwinrt/strings/base_types.h
@@ -17,11 +17,6 @@ namespace winrt::impl
     using srwlock = struct srwlock_*;
     using condition_variable = struct condition_variable_*;
     using bstr = wchar_t*;
-
-    inline bool is_guid_equal(uint32_t const* const left, uint32_t const* const right) noexcept
-    {
-        return left[0] == right[0] && left[1] == right[1] && left[2] == right[2] && left[3] == right[3];
-    }
 }
 
 namespace winrt
@@ -80,7 +75,7 @@ namespace winrt
 
     inline bool operator==(guid const& left, guid const& right) noexcept
     {
-        return impl::is_guid_equal(reinterpret_cast<uint32_t const*>(&left), reinterpret_cast<uint32_t const*>(&right));
+        return !memcmp(&left, &right, sizeof(guid));
     }
 
     inline bool operator!=(guid const& left, guid const& right) noexcept


### PR DESCRIPTION
Chatting with the optimizer team they suggested that `memcmp` should generate both the fastest comparison and the smallest binaries. The code is close to optimal (https://godbolt.org/z/5MWelc), but I will perform additional speed tests. The optimizer team requested I open bugs for any architectures that perform poorly and they would be happy to correct it, but at least this way we get the smallest binaries and a single portable implementation.

