### PR TITLE
opt out of heap enforcement for existing xaml apps

### DIFF
--- a/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.targets
@@ -25,6 +25,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <PrepareForBuildDependsOn>
             $(PrepareForBuildDependsOn);CppWinRTVerifyKitVersion
         </PrepareForBuildDependsOn>
+        <ComputeCompileInputsTargets>
+          $(ComputeCompileInputsTargets);
+          CppWinRTHeapEnforcementOptOut;
+        </ComputeCompileInputsTargets>
         <BeforeClCompileTargets>
             $(BeforeClCompileTargets);CppWinRTMakePlatformProjection;CppWinRTMakeReferenceProjection
         </BeforeClCompileTargets>
@@ -65,6 +69,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <_FilesToDelete Include="$(CppWinRTUnmergedDir)\**"/>
         </ItemGroup>
         <Delete Files="@(_FilesToDelete)"/>
+    </Target>
+
+    <Target Name="CppWinRTHeapEnforcementOptOut" Condition="'@(ClCompile)' != ''">
+      <ItemGroup Condition="'$(CppWinRTHeapEnforcement)'=='' and ('@(Page)' != '' Or '@(ApplicationDefinition)' != '')">
+        <ClCompile>
+          <AdditionalOptions>%(ClCompile.AdditionalOptions) /DWINRT_NO_MAKE_DETECTION</AdditionalOptions>
+        </ClCompile>
+      </ItemGroup>
     </Target>
 
     <!--Define platform projection WinMD inputs-->


### PR DESCRIPTION
this prevents the new heap enforcement (aka make detection) from breaking existing xaml apps, until the xaml compiler fix turns the feature back on