### PR TITLE
xlang::call propagates return value of std::visit

### DIFF
--- a/src/library/impl/base.h
+++ b/src/library/impl/base.h
@@ -76,8 +76,8 @@ namespace xlang
     template <typename...T> struct visit_overload : T... { using T::operator()...; };
 
     template <typename V, typename...C>
-    void call(V&& variant, C&&...call)
+    auto call(V&& variant, C&&...call)
     {
-        std::visit(visit_overload<C...>{ std::forward<C>(call)... }, std::forward<V>(variant));
+        return std::visit(visit_overload<C...>{ std::forward<C>(call)... }, std::forward<V>(variant));
     }
 }


### PR DESCRIPTION
Makes it easier to visit things and return a value.