### PR TITLE
Generate C++/WinRT fast ABI base calls automatically for implementations

### DIFF
--- a/src/tool/cppwinrt/test_component_fast/Composition.SpriteVisual.h
+++ b/src/tool/cppwinrt/test_component_fast/Composition.SpriteVisual.h
@@ -10,10 +10,5 @@ namespace winrt::test_component_fast::Composition::implementation
 
         void Brush();
         void Shadow();
-
-        auto base_Visual()
-        {
-            return get_abi<Composition::Visual>();
-        }
     };
 }

--- a/src/tool/cppwinrt/test_component_fast/Composition.Visual.h
+++ b/src/tool/cppwinrt/test_component_fast/Composition.Visual.h
@@ -12,11 +12,6 @@ namespace winrt::test_component_fast::Composition::implementation
         void Offset(int32_t value);
         void ParentForTransform(Composition::Visual const& value);
 
-        auto base_CompositionObject() const
-        {
-            return get_abi<Composition::CompositionObject>();
-        }
-
     private:
 
         int32_t m_offset{};


### PR DESCRIPTION
Implementations can still override it if needed, but that isn't necessary in almost all cases.