### PR TITLE
Disambiguate get_abi use in C++/WinRT implementation

### DIFF
--- a/src/tool/cppwinrt/strings/base_implements.h
+++ b/src/tool/cppwinrt/strings/base_implements.h
@@ -1297,6 +1297,12 @@ namespace winrt
         }
 
         template <typename T>
+        auto get_abi(T const& value) const noexcept
+        {
+            return winrt::get_abi(value);
+        }
+
+        template <typename T>
         void* get_abi() const noexcept
         {
             return static_cast<impl::producer_vtable<T>>(*this).value;


### PR DESCRIPTION
In rare cases, the use of get_abi within an implementation can be ambiguous. This update resolves that ambiguity.