### PR TITLE
adapt to recent cppwinrt breaking change

### DIFF
--- a/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-build-projection.yml
+++ b/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-build-projection.yml
@@ -30,7 +30,7 @@ steps:
   displayName: 'NuGet install Microsoft.Windows.CppWinRT'
   inputs:
     command: custom
-    arguments: 'install Microsoft.Windows.CppWinRT -Version 2.0.190417.3 -ExcludeVersion -OutputDirectory _tools'
+    arguments: 'install Microsoft.Windows.CppWinRT -ExcludeVersion -OutputDirectory _tools'
 
 - script: _tools\Microsoft.Windows.CppWinRT\bin\cppwinrt.exe -input 10.0.17763.0 -output src/package/pywinrt/projection/cppwinrt -verbose
   displayName: 'Generate C++/WinRT Projection'

--- a/src/package/pywinrt/projection/generate.ps1
+++ b/src/package/pywinrt/projection/generate.ps1
@@ -18,7 +18,7 @@ if (-not $pywinrt_exe) {
     exit
 }
 
-nuget install Microsoft.Windows.CppWinRT -Version 2.0.190417.3 -ExcludeVersion -OutputDirectory "$repoRootPath/_build/tools"
+nuget install Microsoft.Windows.CppWinRT -ExcludeVersion -OutputDirectory "$repoRootPath/_build/tools"
 
 $cppwinrt_exe = "$repoRootPath/_build/tools/Microsoft.Windows.CppWinRT\bin\cppwinrt.exe"
 

--- a/src/tool/python/strings/pybase.h
+++ b/src/tool/python/strings/pybase.h
@@ -817,7 +817,7 @@ namespace py
     };
 
     template <typename T>
-    struct python_iterable final :
+    struct python_iterable :
         winrt::implements<python_iterable<T>, winrt::Windows::Foundation::Collections::IIterable<T>>
     {
         pyobj_handle _iterable;
@@ -833,7 +833,7 @@ namespace py
         }
 
     private:
-        struct iterator final : winrt::implements<iterator, winrt::Windows::Foundation::Collections::IIterator<T>>
+        struct iterator : winrt::implements<iterator, winrt::Windows::Foundation::Collections::IIterator<T>>
         {
             pyobj_handle _iterator;
             std::optional<T> _current_value;


### PR DESCRIPTION
* removed "final" from python_iterable as per https://kennykerr.ca/2019/05/08/cppwinrt-diagnosing-direct-allocations/
* unpinned cppwinrt version used in building python/winrt