### PR TITLE
Remove dynamic project reference condition to permit use by static lib

### DIFF
--- a/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.targets
@@ -169,11 +169,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             DependsOnTargets="ResolvedLinkLib;$(GetCppWinRTDynamicProjectReferencesDependsOn)"
             Returns="@(CppWinRTDynamicProjectReferences)">
         <ItemGroup>
-            <!--Note: only DLL projects that produce import libs have ProjectType == DynamicLibrary.
-            Need to support runtime component projects as well, so we look at the file extension instead.-->
             <CppWinRTDynamicProjectReferences Remove="@(CppWinRTDynamicProjectReferences)"/>
-            <CppWinRTDynamicProjectReferences Include="@(_ResolvedNativeProjectReferencePaths)"
-                Condition= "$([System.String]::Copy('%(Identity)').EndsWith('.dll',true,null))"/>
+            <CppWinRTDynamicProjectReferences Include="@(_ResolvedNativeProjectReferencePaths)"/>
         </ItemGroup>
         <Message Text="CppWinRTDynamicProjectReferences: @(CppWinRTDynamicProjectReferences)" Importance="$(CppWinRTVerbosity)"/>
     </Target>


### PR DESCRIPTION
A static lib project can have a ProjectReference on a dll project, in order to create a projection.  Not a common scenario, but broken with the filter condition on CppWinRTDynamicProjectReferences in place.  This condition can be removed, since a check for !StaticLibrary is being applied later.