### PR TITLE
Add C++/WinRT static_assert to prevent compilation of generated source files

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -987,6 +987,17 @@ namespace winrt::@::implementation
         }
     }
 
+    static void write_generated_static_assert(writer& w)
+    {
+        auto format = R"(
+// Note: Remove this static_assert after copying these generated source files to your project.
+// This assertion exists to avoid compiling these generated source files directly.
+static_assert(false, "Do not compile generated C++/WinRT source files directly");
+)";
+
+        w.write(format);
+    }
+
     static void write_component_h(writer& w, TypeDef const& type)
     {
         auto type_name = type.TypeName();
@@ -1001,7 +1012,7 @@ namespace winrt::@::implementation
 
         {
             auto format = R"(#include "%.g.h"
-%
+%%
 namespace winrt::@::implementation
 {
     struct %%
@@ -1015,6 +1026,7 @@ namespace winrt::@::implementation
             w.write(format,
                 get_generated_component_filename(type),
                 base_include,
+                bind<write_generated_static_assert>(),
                 type_namespace,
                 type_name,
                 bind<write_component_base>(type),
@@ -1157,13 +1169,14 @@ namespace winrt::@::implementation
             w.write(format, filename);
         }
 
-        auto format = R"(
+        auto format = R"(%
 namespace winrt::@::implementation
 {
 %}
 )";
 
         w.write(format,
+            bind<write_generated_static_assert>(),
             type.TypeNamespace(),
             bind<write_component_member_definitions>(type));
     }

--- a/src/tool/cppwinrt/test_component/Simple.cpp
+++ b/src/tool/cppwinrt/test_component/Simple.cpp
@@ -1,0 +1,11 @@
+#include "pch.h"
+#include "Simple.h"
+#include "Simple.g.cpp"
+
+namespace winrt::test_component::implementation
+{
+    void Simple::Method()
+    {
+        throw hresult_not_implemented();
+    }
+}

--- a/src/tool/cppwinrt/test_component/Simple.h
+++ b/src/tool/cppwinrt/test_component/Simple.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "Simple.g.h"
+
+namespace winrt::test_component::implementation
+{
+    struct Simple : SimpleT<Simple>
+    {
+        Simple() = default;
+
+        void Method();
+    };
+}
+namespace winrt::test_component::factory_implementation
+{
+    struct Simple : SimpleT<Simple, implementation::Simple>
+    {
+    };
+}

--- a/src/tool/cppwinrt/test_component/test_component.vcxproj
+++ b/src/tool/cppwinrt/test_component/test_component.vcxproj
@@ -321,7 +321,6 @@
   <ItemGroup>
     <ClCompile Include="Class.cpp" />
     <ClCompile Include="Generated Files\module.g.cpp" />
-    <ClCompile Include="Generated Files\Simple.cpp" />
     <ClCompile Include="module.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -329,14 +328,15 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Simple.cpp" />
     <ClCompile Include="Velocity.Class1.cpp" />
     <ClCompile Include="Velocity.Class2.cpp" />
     <ClCompile Include="Velocity.Class4.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Class.h" />
-    <ClInclude Include="Generated Files\Simple.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="Simple.h" />
     <ClInclude Include="Velocity.Class1.h" />
     <ClInclude Include="Velocity.Class2.h" />
     <ClInclude Include="Velocity.Class4.h" />

--- a/src/tool/cppwinrt/test_component_folders/test_component_folders.vcxproj
+++ b/src/tool/cppwinrt/test_component_folders/test_component_folders.vcxproj
@@ -134,7 +134,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -190,7 +190,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -250,7 +250,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -310,7 +310,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />

--- a/src/tool/cppwinrt/test_component_no_pch/test_component_no_pch.vcxproj
+++ b/src/tool/cppwinrt/test_component_no_pch/test_component_no_pch.vcxproj
@@ -135,7 +135,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -192,7 +192,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -253,7 +253,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -314,7 +314,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />


### PR DESCRIPTION
Fixes #416 

Also had to update tests that were intentionally compiling generated sources to avoid doing so. 