### PR TITLE
Add rules file containing RootNamespace property editor

### DIFF
--- a/src/package/cppwinrt/nuget/CppWinrtRules.Project.xml
+++ b/src/package/cppwinrt/nuget/CppWinrtRules.Project.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Rule Name="CppWinRT" DisplayName="C++/WinRT" Order="75" PageTemplate="generic" xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.Categories>
+    <Category Name="General" DisplayName="General" />
+  </Rule.Categories>
+
+  <Rule.DataSource>
+    <DataSource Persistence="ProjectFile" HasConfigurationCondition="false" Label="Globals" />
+  </Rule.DataSource>
+
+  <StringProperty Name="RootNamespace"
+                  DisplayName="Root Namespace"
+                  Description="Specifies the namespace to be used by default for new IDL files created in this project."
+                  Category="General" />
+</Rule>

--- a/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.nuspec
+++ b/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.nuspec
@@ -24,6 +24,7 @@
     <file src="$cppwinrt_fast_fwd_arm64$" target="build\native\lib\arm64"/>
     <file src="Microsoft.Windows.CppWinRT.props" target="build\native"/>
     <file src="Microsoft.Windows.CppWinRT.targets" target="build\native"/>
+    <file src="CppWinrtRules.Project.xml" target="build\native"/>
     <file src="readme.txt"/>
   </files>
 </package>

--- a/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.props
+++ b/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.props
@@ -41,4 +41,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         </Link>
     </ItemDefinitionGroup>
 
+    <ItemGroup>
+        <PropertyPageSchema Include="$(MSBuildThisFileDirectory)\CppWinrtRules.Project.xml" Context="Project" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This property is used by the default item templates to populate the namespace of newly generated IDL files. I have no clue why this isn't already provided by the core C++ project infrastructure, seeing as it is (apparently) not C++/WinRT-specific.