### PR TITLE
Introduce the C++/WinRT winrt::terminate function to provide richer crash dumps in the event of a WinRT exception

### DIFF
--- a/src/tool/cppwinrt/strings/base_coroutine_threadpool.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_threadpool.h
@@ -345,7 +345,7 @@ namespace std::experimental
 
             void unhandled_exception() const noexcept
             {
-                std::terminate();
+                winrt::terminate();
             }
         };
     };

--- a/src/tool/cppwinrt/strings/base_error.h
+++ b/src/tool/cppwinrt/strings/base_error.h
@@ -380,10 +380,6 @@ namespace winrt
         {
             return hresult_error(impl::error_fail, to_hstring(e.what())).to_abi();
         }
-        catch (...)
-        {
-            std::terminate();
-        }
     }
 
     [[noreturn]] inline void throw_last_error()
@@ -435,5 +431,10 @@ namespace winrt
         }
 
         return pointer;
+    }
+
+    [[noreturn]] inline void terminate() noexcept
+    {
+        WINRT_RoFailFastWithErrorContext(to_hresult());
     }
 }

--- a/src/tool/cppwinrt/strings/base_extern.h
+++ b/src/tool/cppwinrt/strings/base_extern.h
@@ -9,6 +9,7 @@ extern "C"
     int32_t WINRT_CALL WINRT_SetRestrictedErrorInfo(void* info) noexcept;
     int32_t WINRT_CALL WINRT_RoGetAgileReference(uint32_t options, winrt::guid const& iid, void* object, void** reference) noexcept;
     int32_t WINRT_CALL WINRT_CoIncrementMTAUsage(void** cookie) noexcept;
+    [[noreturn]] void WINRT_CALL WINRT_RoFailFastWithErrorContext(int32_t error) noexcept;
 
     int32_t WINRT_CALL WINRT_WindowsCreateString(wchar_t const* sourceString, uint32_t length, void** string) noexcept;
     int32_t WINRT_CALL WINRT_WindowsCreateStringReference(wchar_t const* sourceString, uint32_t length, void* hstringHeader, void** string) noexcept;
@@ -93,6 +94,7 @@ WINRT_LINK(RoUninitialize, 0)
 WINRT_LINK(SetRestrictedErrorInfo, 4)
 WINRT_LINK(RoGetAgileReference, 16)
 WINRT_LINK(CoIncrementMTAUsage, 4)
+WINRT_LINK(RoFailFastWithErrorContext, 4)
 
 WINRT_LINK(WindowsCreateString, 12)
 WINRT_LINK(WindowsCreateStringReference, 16)


### PR DESCRIPTION
This update introduces the `winrt::terminate` function that may be used in place of `std::terminate` to fail fast without losing rich error information from a WinRT exception in flight. `fire_and_forget` has also been updated to use it instead of `std::terminate` to address debuggability issues reported by OS developers. The `winrt::terminate` function will call `winrt::to_hresult` to rethrow and then release the error information to the ABI. This has the effect of calling `SetRestrictedErrorInfo` with the WinRT exception information before calling `RoFailFastWithErrorContext` to capture this information before terminating.