### PR TITLE
Use return type deduction in generated C++/WinRT headers

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -2849,8 +2849,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
             auto method_name = get_name(method);
             w.async_types = is_async(method, signature);
 
-            w.write("        static % %(%);\n",
-                signature.return_signature(),
+            w.write("        static auto %(%);\n",
                 method_name,
                 bind<write_consume_params>(signature));
 
@@ -2879,14 +2878,13 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         w.async_types = is_async(method, signature);
 
         {
-            auto format = R"(    inline % %::%(%)
+            auto format = R"(    inline auto %::%(%)
     {
         %impl::call_factory<%, %>([&](auto&& f) { return f.%(%); });
     }
 )";
 
             w.write(format,
-                signature.return_signature(),
                 type_name,
                 method_name,
                 bind<write_consume_params>(signature),

--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -1851,7 +1851,7 @@ namespace xlang
 
     static void write_dispatch_overridable_method(writer& w, MethodDef const& method)
     {
-        auto format = R"(    % %(%)
+        auto format = R"(    auto %(%)
     {
         if (auto overridable = this->shim_overridable())
         {
@@ -1865,7 +1865,6 @@ namespace xlang
         method_signature signature{ method };
 
         w.write(format,
-            signature.return_signature(),
             get_name(method),
             bind<write_implementation_params>(signature),
             get_name(method),
@@ -2304,7 +2303,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         template <typename O, typename M> %(O* object, M method);
         template <typename O, typename M> %(com_ptr<O>&& object, M method);
         template <typename O, typename M> %(weak_ref<O>&& object, M method);
-        % operator()(%) const;
+        auto operator()(%) const;
     };
 )";
 
@@ -2320,7 +2319,6 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
             type_name,
             type_name,
             type_name,
-            signature.return_signature(),
             bind<write_consume_params>(signature));
     }
 
@@ -2383,7 +2381,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         %([o = std::move(object), method](auto&&... args) { if (auto s = o.get()) { ((*s).*(method))(args...); } })
     {
     }
-    template <%> % %<%>::operator()(%) const
+    template <%> auto %<%>::operator()(%) const
     {%
         check_hresult((*(impl::abi_t<%<%>>**)this)->Invoke(%));%
     }
@@ -2420,7 +2418,6 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
                 type_name,
                 type_name,
                 bind<write_generic_typenames>(generics),
-                signature.return_signature(),
                 type_name,
                 bind_list(", ", generics),
                 bind<write_consume_params>(signature),
@@ -2452,7 +2449,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         %([o = std::move(object), method](auto&&... args) { if (auto s = o.get()) { ((*s).*(method))(args...); } })
     {
     }
-    inline % %::operator()(%) const
+    inline auto %::operator()(%) const
     {%
         check_hresult((*(impl::abi_t<%>**)this)->Invoke(%));%
     }
@@ -2475,7 +2472,6 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
                 type_name,
                 type_name,
                 type_name,
-                signature.return_signature(),
                 type_name,
                 bind<write_consume_params>(signature),
                 bind<write_consume_return_type>(signature),

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -255,7 +255,7 @@ catch (...) { return winrt::to_hresult(); }
 
     static void write_component_composable_forwarder(writer& w, MethodDef const& method)
     {
-        auto format = R"(        % %(%)
+        auto format = R"(        auto %(%)
         {
             return impl::composable_factory<T>::template CreateInstance<%>(%);
         }
@@ -268,7 +268,6 @@ catch (...) { return winrt::to_hresult(); }
         w.param_names = true;
 
         w.write(format,
-            signature.return_signature(),
             get_name(method),
             bind<write_implementation_params>(signature),
             signature.return_signature(),
@@ -277,7 +276,7 @@ catch (...) { return winrt::to_hresult(); }
 
     static void write_component_constructor_forwarder(writer& w, MethodDef const& method)
     {
-        auto format = R"(        % %(%)
+        auto format = R"(        auto %(%)
         {
             return make<T>(%);
         }
@@ -287,7 +286,6 @@ catch (...) { return winrt::to_hresult(); }
         w.param_names = true;
 
         w.write(format,
-            signature.return_signature(),
             get_name(method),
             bind<write_implementation_params>(signature),
             bind<write_consume_args>(signature));
@@ -295,7 +293,7 @@ catch (...) { return winrt::to_hresult(); }
 
     void write_component_static_forwarder(writer& w, MethodDef const& method)
     {
-        auto format = R"(        % %(%)
+        auto format = R"(        auto %(%)
         {
             return T::%(%);
         }
@@ -305,7 +303,6 @@ catch (...) { return winrt::to_hresult(); }
         w.param_names = true;
 
         w.write(format,
-            signature.return_signature(),
             get_name(method),
             bind<write_implementation_params>(signature),
             get_name(method),

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -481,7 +481,7 @@ catch (...) { return winrt::to_hresult(); }
 
                     if (is_add_overload(method) || is_remove_overload(method))
                     {
-                        auto format = R"(    % %::%(%)
+                        auto format = R"(    auto %::%(%)
     {
         auto f = make<winrt::@::factory_implementation::%>().as<%>();
         return f.%(%);
@@ -490,7 +490,6 @@ catch (...) { return winrt::to_hresult(); }
 
 
                         w.write(format,
-                            signature.return_signature(),
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),
@@ -502,7 +501,7 @@ catch (...) { return winrt::to_hresult(); }
                     }
                     else
                     {
-                        auto format = R"(    % %::%(%)
+                        auto format = R"(    auto %::%(%)
     {
         return @::implementation::%::%(%);
     }
@@ -510,7 +509,6 @@ catch (...) { return winrt::to_hresult(); }
 
 
                         w.write(format,
-                            signature.return_signature(),
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),


### PR DESCRIPTION
This solves a key usability issue that has dogged C++/WinRT since we originally split the generated library across namespace headers. If a namespace header included the declaration of some dependent interface (via the inclusion of a layered .0.h header) and the caller attempted to call a method on that interface without including its namespace header then a cryptic linker error was presented to the developer. For newcomers, this was quite the stumbling block.

@oldnewthing suggested we might be able to turn the linker error into a compiler error by generating functions that return "auto" since the compiler (rather than the linker) will naturally insist on a definition. 

Consider a simple example:

```C++
C:\link>type test.cpp
#pragma comment(lib, "onecore")
#include "winrt/Windows.UI.Composition.h"

// Oops, failed to include this namespace.
// #include "winrt/Windows.Foundation.Collections.h"

using namespace winrt;
using namespace Windows::UI::Composition;

int main()
{
    SpriteVisual v = nullptr;

    // Oops, using "First" function that is not defined.
    v.Children().First();
}
```

Previously, this produced the following linker error:

```

C:\link>cl /EHsc /std:c++17 /nologo test.cpp
test.cpp
test.obj : error LNK2019: unresolved external symbol "public: struct winrt::Windows::Foundation::Collections::IIterator<struct winrt::Windows::UI::Composition::Visual> __cdecl winrt::impl::consume_Windows_Foundation_Collections_IIterable<struct winrt::Windows::UI::Composition::IVisualCollection,struct winrt::Windows::UI::Composition::Visual>::First(void)const " (?First@?$consume_Windows_Foundation_Collections_IIterable@UIVisualCollection@Composition@UI@Windows@winrt@@UVisual@2345@@impl@winrt@@QEBA?AU?$IIterator@UVisual@Composition@UI@Windows@winrt@@@Collections@Foundation@Windows@3@XZ) referenced in function main
test.exe : fatal error LNK1120: 1 unresolved externals
```

Notice that not only is it rather difficult to spot the problem, but the actual source of the problem is ommited. There is no file and line number. Here's what it looks like with this change:

```
C:\link>cl /EHsc /std:c++17 /nologo test.cpp
test.cpp
test.cpp(15): error C3779: 'winrt::impl::consume_Windows_Foundation_Collections_IIterable<D,winrt::Windows::UI::Composition::Visual>::First': a function that returns 'auto' cannot be used before it is defined
        with
        [
            D=winrt::Windows::UI::Composition::IVisualCollection
        ]
C:\git\xlang\_build\Windows\x64\Debug\tool\cppwinrt\winrt/impl/Windows.Foundation.Collections.0.h(393): note: see declaration of 'winrt::impl::consume_Windows_Foundation_Collections_IIterable<D,winrt::Windows::UI::Composition::Visual>::First'
        with
        [
            D=winrt::Windows::UI::Composition::IVisualCollection
        ]
```

Not only is this a compiler error, meaning it will fail earlier and and produce a generally more readable error message, but now the error message also pinpoints the file and line number that caused the error in the first place. The compiler error message also has the critical phrase "before it is defined" pointing to the fact that a definition is missing. This is really the same thing the linker was trying to tell us but in a way that is more familiar to the average C++ developer.
