### PR TITLE
Revert "Use return type deduction in generated C++/WinRT headers (#427)"

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -949,7 +949,8 @@ namespace xlang
         auto method_name = get_name(method);
         auto type = method.Parent();
 
-        w.write("        auto %(%) const%;\n",
+        w.write("        % %(%) const%;\n",
+            signature.return_signature(),
             method_name,
             bind<write_consume_params>(signature),
             is_noexcept(method) ? " noexcept" : "");
@@ -1044,16 +1045,13 @@ namespace xlang
 
         if (signature.return_signature().Type().is_szarray())
         {
-            w.write("\n        return %{ %, %_impl_size, take_ownership_from_abi };",
-                signature.return_signature(),
+            w.write("\n        return { %, %_impl_size, take_ownership_from_abi };",
                 signature.return_param_name(),
                 signature.return_param_name());
         }
         else if (can_take_ownership_of_return_type(signature))
         {
-            w.write("\n        return %{ %, take_ownership_from_abi };",
-                signature.return_signature(),
-                signature.return_param_name());
+            w.write("\n        return { %, take_ownership_from_abi };", signature.return_param_name());
         }
         else
         {
@@ -1082,7 +1080,7 @@ namespace xlang
 
         if (is_noexcept(method))
         {
-            format = R"(    template <typename D%> auto consume_%<D%>::%(%) const noexcept
+            format = R"(    template <typename D%> % consume_%<D%>::%(%) const noexcept
     {%
         WINRT_VERIFY_(0, WINRT_SHIM(%)->%(%));%
     }
@@ -1090,7 +1088,7 @@ namespace xlang
         }
         else
         {
-            format = R"(    template <typename D%> auto consume_%<D%>::%(%) const
+            format = R"(    template <typename D%> % consume_%<D%>::%(%) const
     {%
         check_hresult(WINRT_SHIM(%)->%(%));%
     }
@@ -1099,6 +1097,7 @@ namespace xlang
 
         w.write(format,
             bind<write_comma_generic_typenames>(generics),
+            signature.return_signature(),
             type_impl_name,
             bind<write_comma_generic_types>(generics),
             method_name,
@@ -1146,13 +1145,14 @@ namespace xlang
         // return static_cast<% const&>(*this).%(%);
         //
 
-        std::string_view format = R"(    inline auto %::%(%) const%
+        std::string_view format = R"(    inline % %::%(%) const%
     {
         return [&](% const& winrt_impl_base) { return winrt_impl_base.%(%); }(*this);
     }
 )";
 
         w.write(format,
+            signature.return_signature(),
             class_type.TypeName(),
             method_name,
             bind<write_consume_params>(signature),
@@ -1851,7 +1851,7 @@ namespace xlang
 
     static void write_dispatch_overridable_method(writer& w, MethodDef const& method)
     {
-        auto format = R"(    auto %(%)
+        auto format = R"(    % %(%)
     {
         if (auto overridable = this->shim_overridable())
         {
@@ -1865,6 +1865,7 @@ namespace xlang
         method_signature signature{ method };
 
         w.write(format,
+            signature.return_signature(),
             get_name(method),
             bind<write_implementation_params>(signature),
             get_name(method),
@@ -1895,7 +1896,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
 
     static void write_interface_override_method(writer& w, MethodDef const& method, std::string_view const& interface_name)
     {
-        auto format = R"(    template <typename D> auto %T<D>::%(%) const
+        auto format = R"(    template <typename D> % %T<D>::%(%) const
     {
         return shim().template try_as<%>().%(%);
     }
@@ -1905,6 +1906,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         auto method_name = get_name(method);
 
         w.write(format,
+            signature.return_signature(),
             interface_name,
             method_name,
             bind<write_consume_params>(signature),
@@ -2303,7 +2305,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         template <typename O, typename M> %(O* object, M method);
         template <typename O, typename M> %(com_ptr<O>&& object, M method);
         template <typename O, typename M> %(weak_ref<O>&& object, M method);
-        auto operator()(%) const;
+        % operator()(%) const;
     };
 )";
 
@@ -2319,6 +2321,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
             type_name,
             type_name,
             type_name,
+            signature.return_signature(),
             bind<write_consume_params>(signature));
     }
 
@@ -2381,7 +2384,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         %([o = std::move(object), method](auto&&... args) { if (auto s = o.get()) { ((*s).*(method))(args...); } })
     {
     }
-    template <%> auto %<%>::operator()(%) const
+    template <%> % %<%>::operator()(%) const
     {%
         check_hresult((*(impl::abi_t<%<%>>**)this)->Invoke(%));%
     }
@@ -2418,6 +2421,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
                 type_name,
                 type_name,
                 bind<write_generic_typenames>(generics),
+                signature.return_signature(),
                 type_name,
                 bind_list(", ", generics),
                 bind<write_consume_params>(signature),
@@ -2449,7 +2453,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         %([o = std::move(object), method](auto&&... args) { if (auto s = o.get()) { ((*s).*(method))(args...); } })
     {
     }
-    inline auto %::operator()(%) const
+    inline % %::operator()(%) const
     {%
         check_hresult((*(impl::abi_t<%>**)this)->Invoke(%));%
     }
@@ -2472,6 +2476,7 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
                 type_name,
                 type_name,
                 type_name,
+                signature.return_signature(),
                 type_name,
                 bind<write_consume_params>(signature),
                 bind<write_consume_return_type>(signature),
@@ -2845,7 +2850,8 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
             auto method_name = get_name(method);
             w.async_types = is_async(method, signature);
 
-            w.write("        static auto %(%);\n",
+            w.write("        static % %(%);\n",
+                signature.return_signature(),
                 method_name,
                 bind<write_consume_params>(signature));
 
@@ -2874,13 +2880,14 @@ struct WINRT_EBO produce_dispatch_to_overridable<T, D, %>
         w.async_types = is_async(method, signature);
 
         {
-            auto format = R"(    inline auto %::%(%)
+            auto format = R"(    inline % %::%(%)
     {
         %impl::call_factory<%, %>([&](auto&& f) { return f.%(%); });
     }
 )";
 
             w.write(format,
+                signature.return_signature(),
                 type_name,
                 method_name,
                 bind<write_consume_params>(signature),

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -255,7 +255,7 @@ catch (...) { return winrt::to_hresult(); }
 
     static void write_component_composable_forwarder(writer& w, MethodDef const& method)
     {
-        auto format = R"(        auto %(%)
+        auto format = R"(        % %(%)
         {
             return impl::composable_factory<T>::template CreateInstance<%>(%);
         }
@@ -268,6 +268,7 @@ catch (...) { return winrt::to_hresult(); }
         w.param_names = true;
 
         w.write(format,
+            signature.return_signature(),
             get_name(method),
             bind<write_implementation_params>(signature),
             signature.return_signature(),
@@ -276,7 +277,7 @@ catch (...) { return winrt::to_hresult(); }
 
     static void write_component_constructor_forwarder(writer& w, MethodDef const& method)
     {
-        auto format = R"(        auto %(%)
+        auto format = R"(        % %(%)
         {
             return make<T>(%);
         }
@@ -286,6 +287,7 @@ catch (...) { return winrt::to_hresult(); }
         w.param_names = true;
 
         w.write(format,
+            signature.return_signature(),
             get_name(method),
             bind<write_implementation_params>(signature),
             bind<write_consume_args>(signature));
@@ -293,7 +295,7 @@ catch (...) { return winrt::to_hresult(); }
 
     void write_component_static_forwarder(writer& w, MethodDef const& method)
     {
-        auto format = R"(        auto %(%)
+        auto format = R"(        % %(%)
         {
             return T::%(%);
         }
@@ -303,6 +305,7 @@ catch (...) { return winrt::to_hresult(); }
         w.param_names = true;
 
         w.write(format,
+            signature.return_signature(),
             get_name(method),
             bind<write_implementation_params>(signature),
             get_name(method),
@@ -478,7 +481,7 @@ catch (...) { return winrt::to_hresult(); }
 
                     if (is_add_overload(method) || is_remove_overload(method))
                     {
-                        auto format = R"(    auto %::%(%)
+                        auto format = R"(    % %::%(%)
     {
         auto f = make<winrt::@::factory_implementation::%>().as<%>();
         return f.%(%);
@@ -487,6 +490,7 @@ catch (...) { return winrt::to_hresult(); }
 
 
                         w.write(format,
+                            signature.return_signature(),
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),
@@ -498,7 +502,7 @@ catch (...) { return winrt::to_hresult(); }
                     }
                     else
                     {
-                        auto format = R"(    auto %::%(%)
+                        auto format = R"(    % %::%(%)
     {
         return @::implementation::%::%(%);
     }
@@ -506,6 +510,7 @@ catch (...) { return winrt::to_hresult(); }
 
 
                         w.write(format,
+                            signature.return_signature(),
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),


### PR DESCRIPTION
Reverting this improvement temporarily as the LKG7 compiler (used to compile the Windows OS) has a bug where it does not handle return type deduction correctly. Will revert *this* revert once LKG8 is available.

This bug is not present in either the VS 2017 or VS 2019 compilers.