### PR TITLE
Use get_category consistently in cppwinrt implementation

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -675,23 +675,20 @@ namespace xlang
         if (method_signature.return_signature())
         {
             s();
-            auto const& type = method_signature.return_signature().Type();
             auto param_name = method_signature.return_param_name();
+            auto category = get_category(method_signature.return_signature().Type());
 
-            if (type.is_szarray())
+            if (category == param_category::array_type)
             {
                 w.write("&%_impl_size, &%", param_name, param_name);
             }
+            else if (category == param_category::struct_type || category == param_category::enum_type || category == param_category::generic_type)
+            {
+                w.write("put_abi(%)", param_name);
+            }
             else
             {
-                if (!can_take_ownership_of_return_type(method_signature) && wrap_abi(type))
-                {
-                    w.write("put_abi(%)", param_name);
-                }
-                else
-                {
-                    w.write("&%", param_name);
-                }
+                w.write("&%", param_name);
             }
         }
     }

--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -1073,19 +1073,25 @@ namespace xlang
             return;
         }
 
-        if (signature.return_signature().Type().is_szarray())
+        auto category = get_category(signature.return_signature().Type());
+
+        switch (category)
         {
+        case param_category::array_type:
             w.write("\n        return { %, %_impl_size, take_ownership_from_abi };",
                 signature.return_param_name(),
                 signature.return_param_name());
-        }
-        else if (can_take_ownership_of_return_type(signature))
-        {
+            break;
+        case param_category::object_type:
+        case param_category::string_type:
             w.write("\n        return { %, take_ownership_from_abi };", signature.return_param_name());
-        }
-        else
-        {
+            break;
+        case param_category::enum_type:
+        case param_category::fundamental_type:
+        case param_category::generic_type:
+        case param_category::struct_type:
             w.write("\n        return %;", signature.return_param_name());
+            break;
         }
     }
 

--- a/src/tool/cppwinrt/cppwinrt/helpers.h
+++ b/src/tool/cppwinrt/cppwinrt/helpers.h
@@ -605,23 +605,6 @@ namespace xlang
         return result;
     }
 
-    static bool wrap_abi(TypeSig const& signature)
-    {
-        bool wrap{};
-
-        call(signature.Type(),
-            [&](ElementType type)
-            {
-                wrap = type == ElementType::String || type == ElementType::Object;
-            },
-            [&](auto&&)
-            {
-                wrap = true;
-            });
-
-        return wrap;
-    }
-
     enum class param_category
     {
         generic_type,


### PR DESCRIPTION
Some time back I introduced the `get_category` helper to solve some more challenging parameter categorization issues in the cppwinrt compiler. This made the clunky `can_take_ownership_of_return_type` and `wrap_abi` helper functions redundant. This update just removes those functions and makes use of `get_category` throughout. Internal bug #21214501.