### PR TITLE
Add [[nodiscard]] to 'get' property overloads in C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -936,7 +936,8 @@ namespace xlang
         auto method_name = get_name(method);
         auto type = method.Parent();
 
-        w.write("        % %(%) const%;\n",
+        w.write("        %% %(%) const%;\n",
+            is_get_overload(method) ? "[[nodiscard]] " : "",
             signature.return_signature(),
             method_name,
             bind<write_consume_params>(signature),

--- a/src/tool/cppwinrt/cppwinrt/helpers.h
+++ b/src/tool/cppwinrt/cppwinrt/helpers.h
@@ -138,6 +138,11 @@ namespace xlang
         return method.SpecialName() && starts_with(method.Name(), "put_");
     }
 
+    static bool is_get_overload(MethodDef const& method)
+    {
+        return method.SpecialName() && starts_with(method.Name(), "get_");
+    }
+
     static bool is_noexcept(MethodDef const& method)
     {
         return is_remove_overload(method) || has_attribute(method, "Windows.Foundation.Metadata", "NoExceptionAttribute");

--- a/src/tool/cppwinrt/old_tests/UnitTests/casts.cpp
+++ b/src/tool/cppwinrt/old_tests/UnitTests/casts.cpp
@@ -33,7 +33,7 @@ namespace
         void CallIFrameworkElementMethod()
         {
             // This is simply a compile test, to verify that we can convert an "overrides" type to one of its "requires" interfaces.
-            this->Width();
+            [[maybe_unused]] auto result = this->Width();
         }
     };
 }

--- a/src/tool/cppwinrt/test/single_threaded_observable_vector.cpp
+++ b/src/tool/cppwinrt/test/single_threaded_observable_vector.cpp
@@ -199,8 +199,8 @@ TEST_CASE("single_threaded_observable_vector")
         IIterator<int> iterator_i = vector_i.First();
         IIterator<IInspectable> iterator_o = vector_o.First();
 
-        iterator_i.HasCurrent();
-        iterator_o.HasCurrent();
+        REQUIRE(iterator_i.HasCurrent());
+        REQUIRE(iterator_o.HasCurrent());
 
         vector_i.Append(3);
 
@@ -328,8 +328,8 @@ TEST_CASE("single_threaded_observable_vector")
             IIterator<int> iterator_i = vector_i.First();
             IIterator<IInspectable> iterator_o = vector_o.First();
 
-            iterator_i.HasCurrent();
-            iterator_o.HasCurrent();
+            REQUIRE(iterator_i.HasCurrent());
+            REQUIRE(iterator_o.HasCurrent());
 
             bool changed_i{};
             bool changed_o{};
@@ -362,8 +362,8 @@ TEST_CASE("single_threaded_observable_vector")
             IIterator<int> iterator_i = vector_i.First();
             IIterator<IInspectable> iterator_o = vector_o.First();
 
-            iterator_i.HasCurrent();
-            iterator_o.HasCurrent();
+            REQUIRE(iterator_i.HasCurrent());
+            REQUIRE(iterator_o.HasCurrent());
 
             bool changed_i{};
             bool changed_o{};


### PR DESCRIPTION
To help catch rookie mistakes confusing WinRT properties and methods in C++/WinRT.