### PR TITLE
Avoid use of magic static in C++/WinRT factory cache

### DIFF
--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -160,6 +160,10 @@ namespace winrt::impl
         }
     };
 
+#if !defined _M_IX86 && !defined _M_X64 && !defined _M_ARM && !defined _M_ARM64
+#error Unsupported architecture: verify that zero-initialization of SLIST_HEADER is still safe
+#endif
+
     struct factory_cache
     {
         factory_cache(factory_cache const&) = delete;

--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -164,11 +164,7 @@ namespace winrt::impl
     {
         factory_cache(factory_cache const&) = delete;
         factory_cache& operator=(factory_cache const&) = delete;
-
-        factory_cache() noexcept
-        {
-            WINRT_InitializeSListHead(&m_list);
-        }
+        factory_cache() noexcept = default;
 
         void add(factory_cache_typeless_entry* const entry) noexcept
         {
@@ -284,14 +280,6 @@ namespace winrt::impl
         alignas(memory_allocation_alignment) slist_entry m_next;
     };
 
-    template <typename Class, typename Interface>
-    struct factory_storage
-    {
-        static factory_cache_entry<Class, Interface> factory;
-    };
-
-    template <typename Class, typename Interface>
-    factory_cache_entry<Class, Interface> factory_storage<Class, Interface>::factory;
 
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory, typename F>
     auto call_factory(F&& callback)
@@ -301,7 +289,8 @@ namespace winrt::impl
         static_assert(std::is_standard_layout_v<factory_cache_typeless_entry>);
         static_assert(std::is_standard_layout_v<factory_cache_entry<Class, Interface>>);
 
-        return factory_storage<Class, Interface>::factory.call(callback);
+        static factory_cache_entry<Class, Interface> factory;
+        return factory.call(callback);
     }
 
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>

--- a/src/tool/cppwinrt/strings/base_extern.h
+++ b/src/tool/cppwinrt/strings/base_extern.h
@@ -58,7 +58,6 @@ extern "C"
     int32_t __stdcall WINRT_SleepConditionVariableSRW(winrt::impl::condition_variable* cv, winrt::impl::srwlock* lock, uint32_t milliseconds, uint32_t flags) noexcept;
     void    __stdcall WINRT_WakeConditionVariable(winrt::impl::condition_variable* cv) noexcept;
     void    __stdcall WINRT_WakeAllConditionVariable(winrt::impl::condition_variable* cv) noexcept;
-    void    __stdcall WINRT_InitializeSListHead(void* head) noexcept;
     void*   __stdcall WINRT_InterlockedPushEntrySList(void* head, void* entry) noexcept;
     void*   __stdcall WINRT_InterlockedFlushSList(void* head) noexcept;
 
@@ -152,7 +151,6 @@ WINRT_IMPL_LINK(ReleaseSRWLockShared, 4)
 WINRT_IMPL_LINK(SleepConditionVariableSRW, 16)
 WINRT_IMPL_LINK(WakeConditionVariable, 4)
 WINRT_IMPL_LINK(WakeAllConditionVariable, 4)
-WINRT_IMPL_LINK(InitializeSListHead, 4)
 WINRT_IMPL_LINK(InterlockedPushEntrySList, 8)
 WINRT_IMPL_LINK(InterlockedFlushSList, 4)
 


### PR DESCRIPTION
The use of magic statics can impact the performance of system DLLs due to frequent `THREAD_ATTACH`/`THREAD_DETATCH` calls. Fortunately, a magic static is not required in this case because `InitializeSListHead` just zero-initializes the `SLIST_HEADER` on all supported platforms. 

Tested with: `cl /Zc:threadSafeInit- /we4640`

OS bug: 21988886