### PR TITLE
Add [[nodiscard]] to static C++/WinRT properties as well

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -2844,7 +2844,8 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             auto method_name = get_name(method);
             w.async_types = is_async(method, signature);
 
-            w.write("        static % %(%);\n",
+            w.write("        %static % %(%);\n",
+                is_get_overload(method) ? "[[nodiscard]] " : "",
                 signature.return_signature(),
                 method_name,
                 bind<write_consume_params>(signature));


### PR DESCRIPTION
I missed static properties when adding https://github.com/microsoft/xlang/pull/458.