### PR TITLE
Fix bug in winrt::delegate return call generation

### DIFF
--- a/src/tool/cppwinrt/strings/base_delegate.h
+++ b/src/tool/cppwinrt/strings/base_delegate.h
@@ -182,7 +182,7 @@ namespace winrt::impl
         template <typename H>
         static delegate_base<R, Args...> make(H&& handler)
         {
-            return { static_cast<void*>(new variadic_delegate<H, void, Args...>(std::forward<H>(handler))), take_ownership_from_abi };
+            return { static_cast<void*>(new variadic_delegate<H, R, Args...>(std::forward<H>(handler))), take_ownership_from_abi };
         }
     };
 }


### PR DESCRIPTION
Typo introduced by https://github.com/microsoft/xlang/pull/467.