### PR TITLE
Fix auto return deduction colliding with uniform construction

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -498,7 +498,7 @@ catch (...) { return winrt::to_hresult(); }
                     }
                     else
                     {
-                        auto format = R"(    auto %::%(%)
+                        auto format = R"(    % %::%(%)
     {
         return @::implementation::%::%(%);
     }
@@ -506,6 +506,7 @@ catch (...) { return winrt::to_hresult(); }
 
 
                         w.write(format,
+                            signature.return_signature(),
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),

--- a/src/tool/cppwinrt/test_component/Class.h
+++ b/src/tool/cppwinrt/test_component/Class.h
@@ -8,6 +8,20 @@ namespace winrt::test_component::implementation
         Class() = default;
         Class(hstring const&) {}
 
+        static void StaticTest()
+        {
+        }
+
+        static int32_t StaticTestReturn()
+        {
+            return 0;
+        }
+
+        static int32_t StaticProperty()
+        {
+            return 0;
+        }
+
         void Fail(bool fail)
         {
             m_fail = fail;

--- a/src/tool/cppwinrt/test_component/test_auto.cpp
+++ b/src/tool/cppwinrt/test_component/test_auto.cpp
@@ -1,0 +1,18 @@
+#include "pch.h"
+#include "winrt/test_component.h"
+
+// Simple compile-only test to validate that static methods may be compiled with -optimize.
+// Previously this wouldn't compile because of return type deduction colliding with -optimize
+// and its use of the linker to support uniform construction.
+
+using namespace winrt;
+using namespace test_component;
+
+void test_auto()
+{
+    Class::StaticTest();
+
+    Class::StaticTestReturn();
+
+    auto discarded = Class::StaticProperty(); discarded;
+}

--- a/src/tool/cppwinrt/test_component/test_component.idl
+++ b/src/tool/cppwinrt/test_component/test_component.idl
@@ -60,6 +60,9 @@ namespace test_component
     {
         Class();
         Class(String name);
+        static void StaticTest();
+        static Int32 StaticTestReturn();
+        static Int32 StaticProperty{ get; };
 
         Class(Windows.Foundation.Collections.IIterable<String> arg, Int32 dummy1);
         Class(Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, String> > arg, Int32 dummy1, Int32 dummy2);

--- a/src/tool/cppwinrt/test_component/test_component.vcxproj
+++ b/src/tool/cppwinrt/test_component/test_component.vcxproj
@@ -329,6 +329,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="Simple.cpp" />
+    <ClCompile Include="test_auto.cpp" />
     <ClCompile Include="Velocity.Class1.cpp" />
     <ClCompile Include="Velocity.Class2.cpp" />
     <ClCompile Include="Velocity.Class4.cpp" />


### PR DESCRIPTION
Uniform construction (-optimize) relies on the linker resolving constructors and statics for calls to locally-implemented classes, but return type deduction relies on the compiler resolving those return types. This update backs off the use of return type deduction only for statics implemented by component itself. 