### PR TITLE
Update C++/WinRT to avoid the defunct std::experimental::filesystem namespace and use std::filesystem instead

### DIFF
--- a/src/library/cmd_reader.h
+++ b/src/library/cmd_reader.h
@@ -112,9 +112,9 @@ namespace xlang::cmd
 
             auto add_directory = [&](auto&& path)
             {
-                for (auto&& file : std::experimental::filesystem::directory_iterator(path))
+                for (auto&& file : std::filesystem::directory_iterator(path))
                 {
-                    if (std::experimental::filesystem::is_regular_file(file))
+                    if (std::filesystem::is_regular_file(file))
                     {
                         auto filename = canonical(file.path()).string();
 
@@ -128,15 +128,15 @@ namespace xlang::cmd
 
             for (auto&& path : values(name))
             {
-                auto canonical = std::experimental::filesystem::canonical(path);
+                auto canonical = std::filesystem::canonical(path);
 
-                if (std::experimental::filesystem::is_directory(canonical))
+                if (std::filesystem::is_directory(canonical))
                 {
                     add_directory(canonical);
                     continue;
                 }
 
-                if (std::experimental::filesystem::is_regular_file(canonical))
+                if (std::filesystem::is_regular_file(canonical))
                 {
                     files.insert(canonical.string());
                     continue;
@@ -186,7 +186,7 @@ namespace xlang::cmd
                         continue;
                     }
 
-                    for (auto&& item : std::experimental::filesystem::directory_iterator(sdk_path / L"Extension SDKs"))
+                    for (auto&& item : std::filesystem::directory_iterator(sdk_path / L"Extension SDKs"))
                     {
                         xml_path = item.path() / sdk_version;
                         xml_path /= L"SDKManifest.xml";
@@ -259,7 +259,7 @@ namespace xlang::cmd
         template<typename O, typename L>
         void extract_response_file(std::string_view const& arg, O const& options, L& last)
         {
-            std::experimental::filesystem::path response_path{ std::string{ arg } };
+            std::filesystem::path response_path{ std::string{ arg } };
             std::string extension = response_path.extension().generic_string();
             std::transform(extension.begin(), extension.end(), extension.begin(),
                 [](auto c) { return static_cast<unsigned char>(::tolower(c)); });

--- a/src/library/impl/base.h
+++ b/src/library/impl/base.h
@@ -32,7 +32,7 @@
 #include <variant>
 #include <vector>
 #include <set>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #if defined(_DEBUG)
 #define XLANG_DEBUG

--- a/src/library/impl/cmd_reader_windows.h
+++ b/src/library/impl/cmd_reader_windows.h
@@ -54,8 +54,8 @@ namespace xlang::impl
     inline void add_files_from_xml(
         std::set<std::string>& files,
         std::string const& sdk_version,
-        std::experimental::filesystem::path const& xml_path,
-        std::experimental::filesystem::path const& sdk_path)
+        std::filesystem::path const& xml_path,
+        std::filesystem::path const& sdk_path)
     {
         com_ptr<IStream> stream;
 
@@ -126,7 +126,7 @@ namespace xlang::impl
         return { key };
     }
 
-    inline std::experimental::filesystem::path get_sdk_path()
+    inline std::filesystem::path get_sdk_path()
     {
         auto key = open_sdk();
 
@@ -189,7 +189,7 @@ namespace xlang::impl
         {
             auto path = get_sdk_path() / "Platforms\\UAP" / match[1].str() / "Platform.xml";
 
-            if (std::experimental::filesystem::exists(path))
+            if (std::filesystem::exists(path))
             {
                 return match[1].str();
             }

--- a/src/library/text_writer.h
+++ b/src/library/text_writer.h
@@ -158,7 +158,7 @@ namespace xlang::text
             m_second.clear();
         }
 
-        void flush_to_file(std::experimental::filesystem::path const& filename)
+        void flush_to_file(std::filesystem::path const& filename)
         {
             flush_to_file(filename.string());
         }
@@ -181,7 +181,7 @@ namespace xlang::text
 
         bool file_equal(std::string const& filename) const
         {
-            if (!std::experimental::filesystem::exists(filename))
+            if (!std::filesystem::exists(filename))
             {
                 return false;
             }

--- a/src/package/cppwinrt/natvis/cppwinrt_visualizer.cpp
+++ b/src/package/cppwinrt/natvis/cppwinrt_visualizer.cpp
@@ -6,7 +6,7 @@
 using namespace Microsoft::VisualStudio::Debugger;
 using namespace Microsoft::VisualStudio::Debugger::Evaluation;
 using namespace Microsoft::VisualStudio::Debugger::Telemetry;
-using namespace std::experimental::filesystem;
+using namespace std::filesystem;
 using namespace winrt;
 using namespace xlang;
 using namespace xlang::meta;
@@ -78,9 +78,9 @@ cppwinrt_visualizer::cppwinrt_visualizer()
 #else
         ExpandEnvironmentStringsA("%windir%\\SysNative\\WinMetadata", local.data(), static_cast<DWORD>(local.size()));
 #endif
-        for (auto&& file : std::experimental::filesystem::directory_iterator(local.data()))
+        for (auto&& file : std::filesystem::directory_iterator(local.data()))
         {
-            if (std::experimental::filesystem::is_regular_file(file))
+            if (std::filesystem::is_regular_file(file))
             {
                 db_files.push_back(file.path().string());
             }

--- a/src/tool/abi/main.cpp
+++ b/src/tool/abi/main.cpp
@@ -6,7 +6,7 @@
 #include "strings.h"
 
 using namespace std::chrono;
-using namespace std::experimental::filesystem;
+using namespace std::filesystem;
 using namespace std::literals;
 using namespace xlang;
 using namespace xlang::meta::reader;

--- a/src/tool/abi/pch.h
+++ b/src/tool/abi/pch.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "cmd_reader.h"
 #include "meta_reader.h"

--- a/src/tool/cppwinrt/cppwinrt/type_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/type_writers.h
@@ -2,7 +2,7 @@
 
 namespace xlang
 {
-    using namespace std::experimental::filesystem;
+    using namespace std::filesystem;
     using namespace text;
     using namespace meta::reader;
 

--- a/src/tool/cppwinrt/prebuild/main.cpp
+++ b/src/tool/cppwinrt/prebuild/main.cpp
@@ -26,9 +26,9 @@ namespace xlang::strings {
 namespace xlang::strings {
 )");
 
-    for (auto&& file : std::experimental::filesystem::directory_iterator(argv[1]))
+    for (auto&& file : std::filesystem::directory_iterator(argv[1]))
     {
-        if (!std::experimental::filesystem::is_regular_file(file))
+        if (!std::filesystem::is_regular_file(file))
         {
             continue;
         }
@@ -112,8 +112,8 @@ END
 )",
     XLANG_VERSION_STRING);
 
-    auto const output = std::experimental::filesystem::canonical(argv[2]);
-    std::experimental::filesystem::create_directories(output);
+    auto const output = std::filesystem::canonical(argv[2]);
+    std::filesystem::create_directories(output);
     strings_h.flush_to_file(output / "strings.h");
     strings_cpp.flush_to_file(output / "strings.cpp");
     version_rc.flush_to_file(output / "version.rc");

--- a/src/tool/cppxlang/type_writers.h
+++ b/src/tool/cppxlang/type_writers.h
@@ -2,7 +2,7 @@
 
 namespace xlang
 {
-    using namespace std::experimental::filesystem;
+    using namespace std::filesystem;
     using namespace text;
     using namespace meta::reader;
 

--- a/src/tool/python/file_writers.h
+++ b/src/tool/python/file_writers.h
@@ -2,7 +2,7 @@
 
 namespace pywinrt
 {
-    namespace stdfs = std::experimental::filesystem;
+    namespace stdfs = std::filesystem;
 
     inline void write_pch_cpp(stdfs::path const& folder)
     {

--- a/src/tool/python/settings.h
+++ b/src/tool/python/settings.h
@@ -6,7 +6,7 @@ namespace pywinrt
     {
         std::set<std::string> input;
 
-        std::experimental::filesystem::path output_folder;
+        std::filesystem::path output_folder;
         std::string module{ "pyrt" };
         bool verbose{};
 

--- a/src/tool/python/type_writers.h
+++ b/src/tool/python/type_writers.h
@@ -3,7 +3,7 @@
 namespace pywinrt
 {
     using namespace std::literals;
-    using namespace std::experimental::filesystem;
+    using namespace std::filesystem;
     using namespace xlang;
     using namespace xlang::meta::reader;
     using namespace xlang::text;


### PR DESCRIPTION
Note this is only within the C++/WinRT compiler - the C++/WinRT library does not use filesystem at all.