### PR TITLE
Update linux docker image to Ubuntu 18.10 (cosmic) with Clang/Libc++ 7

### DIFF
--- a/src/scripts/ubuntu/Dockerfile
+++ b/src/scripts/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.10
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/scripts/ubuntu/Dockerfile
+++ b/src/scripts/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:19.04
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/scripts/ubuntu/Dockerfile
+++ b/src/scripts/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.10
 
 RUN apt-get update \
     && apt-get install -y \
@@ -26,5 +26,5 @@ RUN apt-get install -y \
         clang \
         cmake \
         ninja-build \
-        libc++-dev \
-        libc++abi-dev
+        libc++-7-dev \
+        libc++abi-7-dev


### PR DESCRIPTION
This is needed to fix the breaks from #85.  However, that also introduces new breaks which need to be fixed:  
https://dev.azure.com/msft-xlang/public/_build/results?buildId=2379

Waiting for those fixes before completing this PR