### PR TITLE
Remove WINRT_EXTERNAL_CATCH_CLAUSE now that last OS usage has been removed

### DIFF
--- a/src/tool/cppwinrt/strings/base_error.h
+++ b/src/tool/cppwinrt/strings/base_error.h
@@ -363,7 +363,6 @@ namespace winrt
         {
             return e.to_abi();
         }
-        WINRT_EXTERNAL_CATCH_CLAUSE
         catch (std::bad_alloc const&)
         {
             return impl::error_bad_alloc;

--- a/src/tool/cppwinrt/strings/base_macros.h
+++ b/src/tool/cppwinrt/strings/base_macros.h
@@ -15,9 +15,5 @@
 
 #define WINRT_IMPL_SHIM(...) (*(abi_t<__VA_ARGS__>**)&static_cast<__VA_ARGS__ const&>(static_cast<D const&>(*this)))
 
-#ifndef WINRT_EXTERNAL_CATCH_CLAUSE
-#define WINRT_EXTERNAL_CATCH_CLAUSE
-#endif
-
 // Note: this is a workaround for a false-positive warning produced by the Visual C++ 15.9 compiler.
 #pragma warning(disable : 5046)


### PR DESCRIPTION
WIL has been updated to use `winrt_to_hresult_handler` and the only other use of this macro has finally been removed from the OS repo (vso pr 3418869).