### PR TITLE
Update linux docker image to Ubuntu 19.40 (disco) with Clang/Libc++ 8

### DIFF
--- a/src/scripts/ubuntu/Dockerfile
+++ b/src/scripts/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:19.04
 
 RUN apt-get update \
     && apt-get install -y \

--- a/src/scripts/ubuntu/Dockerfile
+++ b/src/scripts/ubuntu/Dockerfile
@@ -26,5 +26,5 @@ RUN apt-get install -y \
         clang \
         cmake \
         ninja-build \
-        libc++-dev \
-        libc++abi-dev
+        libc++-8-dev \
+        libc++abi-8-dev


### PR DESCRIPTION
This may be needed if PR #486 is not sufficient. 
