### PR TITLE
Remove Clang workaround for directxmath.h in C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/strings/base_dependencies.h
+++ b/src/tool/cppwinrt/strings/base_dependencies.h
@@ -27,13 +27,7 @@
 #define _WINDOWS_NUMERICS_NAMESPACE_ winrt::Windows::Foundation::Numerics
 #define _WINDOWS_NUMERICS_BEGIN_NAMESPACE_ namespace winrt::Windows::Foundation::Numerics
 #define _WINDOWS_NUMERICS_END_NAMESPACE_
-#ifdef __clang__
-#define _XM_NO_INTRINSICS_
-#endif
 #include <WindowsNumerics.impl.h>
-#ifdef __clang__
-#undef _XM_NO_INTRINSICS_
-#endif
 #undef _WINDOWS_NUMERICS_NAMESPACE_
 #undef _WINDOWS_NUMERICS_BEGIN_NAMESPACE_
 #undef _WINDOWS_NUMERICS_END_NAMESPACE_

--- a/src/tool/cppwinrt/test/numerics.cpp
+++ b/src/tool/cppwinrt/test/numerics.cpp
@@ -1,0 +1,13 @@
+#include "pch.h"
+
+using namespace winrt;
+using namespace Windows::Foundation::Numerics;
+
+TEST_CASE("numerics")
+{
+    // Basic smoke test exercising SIMD intrinsics used by numerics.
+
+    auto one = float4::one();
+
+    REQUIRE(one * one == one);
+}

--- a/src/tool/cppwinrt/test/test.vcxproj
+++ b/src/tool/cppwinrt/test/test.vcxproj
@@ -203,6 +203,7 @@
     <ClCompile Include="no_make_detection.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="numerics.cpp" />
     <ClCompile Include="out_params.cpp" />
     <ClCompile Include="out_params_abi.cpp" />
     <ClCompile Include="out_params_bad.cpp" />


### PR DESCRIPTION
The directxmath.h header used by numerics now supports Clang so there's no longer any need for the C++/WinRT workaround.