### PR TITLE
Remove unused includes from C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/strings/base_dependencies.h
+++ b/src/tool/cppwinrt/strings/base_dependencies.h
@@ -5,20 +5,16 @@
 #include <charconv>
 #include <chrono>
 #include <cstddef>
-#include <iterator>
-#include <limits>
 #include <map>
 #include <memory>
-#include <new>
 #include <optional>
-#include <shared_mutex>
-#include <string>
-#include <string_view>
 #include <stdexcept>
+#include <string_view>
+#include <string>
 #include <tuple>
 #include <type_traits>
-#include <utility>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #if __has_include(<WindowsNumerics.impl.h>)

--- a/src/tool/cppwinrt/test/pch.h
+++ b/src/tool/cppwinrt/test/pch.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <Windows.h>
-#include <winstring.h>
-
-#include "catch.hpp"
+#include <unknwn.h>
 #include "winrt/Windows.Foundation.Collections.h"
 #include "winrt/Windows.Foundation.Numerics.h"
+#include <winstring.h>
+#include "catch.hpp"
 
 using namespace std::literals;


### PR DESCRIPTION
Avoiding unnecessary includes improves build time (very slightly) but more importantly avoids other projects inadvertently taking dependencies on headers they have not included. This also helps pave the way for C++ module support where includes are not transitive.