### PR TITLE
Handle most Clang warnings in C++/WinRT unit tests

### DIFF
--- a/src/tool/cppwinrt/cppwinrt.props
+++ b/src/tool/cppwinrt/cppwinrt.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <!--
-    Can use used as follows.
+    Can be used as follows.
 
     Compile with Visual C++:
 

--- a/src/tool/cppwinrt/cppwinrt.props
+++ b/src/tool/cppwinrt/cppwinrt.props
@@ -13,9 +13,21 @@
   </PropertyGroup>
 
   <!--
-    Can use used as follows:
-    msbuild /p:Clang=1,Configuration=Debug,Platform=x64 cppwinrt.sln /t:cppwinrt
+    Can use used as follows.
+
+    Compile with Visual C++:
+
+        msbuild /m /p:Configuration=Debug,Platform=x64 cppwinrt.sln
+
+    Compile with Clang:
+
+        msbuild /m /p:Configuration=Debug,Platform=x64,Clang=1 cppwinrt.sln
+
+    Optionally add /t:<project> to only build a given a solution project:
+
+        msbuild /m /p:Configuration=Debug,Platform=x64,Clang=1 cppwinrt.sln /t:cppwinrt
   -->
+
   <PropertyGroup Condition="'$(Clang)'=='1'">
     <CLToolExe>clang-cl.exe</CLToolExe>
     <CLToolPath>C:\Program Files\LLVM\bin</CLToolPath>

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -723,7 +723,7 @@ catch (...) { return winrt::to_hresult(); }
         auto format = R"(
         auto base_%() const noexcept
         {
-            return static_cast<D const&>(*this).get_abi<%>();
+            return static_cast<D const&>(*this).template get_abi<%>();
         }
 )";
 

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -630,7 +630,7 @@ catch (...) { return winrt::to_hresult(); }
         auto format = R"(
             if (is_guid_of<%>(id))
             {
-                *result = make_fast_abi_forwarder(static_cast<D const&>(*this).get_abi<class_type>(), guid_of<%>(), %);
+                *result = make_fast_abi_forwarder(static_cast<D const&>(*this).template get_abi<class_type>(), guid_of<%>(), %);
                 return 0;
             }
 )";

--- a/src/tool/cppwinrt/old_tests/UnitTests/Boxing2.cpp
+++ b/src/tool/cppwinrt/old_tests/UnitTests/Boxing2.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Boxing")
         IInspectable object = box_value(SimpleStructure{ 123, {}, {}, {} });
         REQUIRE(unbox_value<SimpleStructure>(object) == SimpleStructure{ 123, {}, {}, {} });
         REQUIRE(unbox_value_or<SimpleStructure>(object, { 321, {}, {}, {} }) == SimpleStructure{ 123, {}, {}, {} });
-        REQUIRE(unbox_value_or<SimpleStructure>(nullptr, { 321, {}, {}, {} }) == SimpleStructure{ 123, {}, {}, {} });
+        REQUIRE(unbox_value_or<SimpleStructure>(nullptr, { 321, {}, {}, {} }) == SimpleStructure{ 321, {}, {}, {} });
 
         // Covers all failure paths for non-IInspectable types.
         REQUIRE_THROWS_AS(unbox_value<int>(object), hresult_no_interface);

--- a/src/tool/cppwinrt/old_tests/UnitTests/Boxing2.cpp
+++ b/src/tool/cppwinrt/old_tests/UnitTests/Boxing2.cpp
@@ -10,10 +10,10 @@ using namespace std::chrono;
 TEST_CASE("Boxing")
 {
     {
-        IInspectable object = box_value(SimpleStructure{ 123 });
-        REQUIRE(unbox_value<SimpleStructure>(object) == SimpleStructure{ 123 });
-        REQUIRE(unbox_value_or<SimpleStructure>(object, { 321 }) == SimpleStructure{ 123 });
-        REQUIRE(unbox_value_or<SimpleStructure>(nullptr, { 321 }) == SimpleStructure{ 321 });
+        IInspectable object = box_value(SimpleStructure{ 123, {}, {}, {} });
+        REQUIRE(unbox_value<SimpleStructure>(object) == SimpleStructure{ 123, {}, {}, {} });
+        REQUIRE(unbox_value_or<SimpleStructure>(object, { 321, {}, {}, {} }) == SimpleStructure{ 123, {}, {}, {} });
+        REQUIRE(unbox_value_or<SimpleStructure>(nullptr, { 321, {}, {}, {} }) == SimpleStructure{ 123, {}, {}, {} });
 
         // Covers all failure paths for non-IInspectable types.
         REQUIRE_THROWS_AS(unbox_value<int>(object), hresult_no_interface);

--- a/src/tool/cppwinrt/old_tests/UnitTests/Security.cpp
+++ b/src/tool/cppwinrt/old_tests/UnitTests/Security.cpp
@@ -14,7 +14,8 @@ namespace
         access_token duplicate;
         check_bool(DuplicateTokenEx(token.get(), TOKEN_ADJUST_PRIVILEGES | TOKEN_IMPERSONATE, nullptr, SecurityImpersonation, TokenImpersonation, duplicate.put()));
 
-        TOKEN_PRIVILEGES privileges{ 1 };
+        TOKEN_PRIVILEGES privileges{};
+        privileges.PrivilegeCount = 1;
         privileges.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
         check_bool(LookupPrivilegeValueW(nullptr, L"SeShutdownPrivilege", &privileges.Privileges[0].Luid));
         check_bool(AdjustTokenPrivileges(duplicate.get(), FALSE, &privileges, sizeof(TOKEN_PRIVILEGES), nullptr, nullptr));
@@ -33,7 +34,8 @@ namespace
             return false;
         }
 
-        PRIVILEGE_SET privileges{ 1 };
+        PRIVILEGE_SET privileges{};
+        privileges.PrivilegeCount = 1;
         privileges.Privilege[0].Attributes = SE_PRIVILEGE_ENABLED;
         check_bool(LookupPrivilegeValueW(nullptr, L"SeShutdownPrivilege", &privileges.Privilege[0].Luid));
 

--- a/src/tool/cppwinrt/old_tests/UnitTests/delegate_lambda.cpp
+++ b/src/tool/cppwinrt/old_tests/UnitTests/delegate_lambda.cpp
@@ -39,6 +39,7 @@ struct Movable
     {
         Value = other.Value;
         other.Value = 0;
+        return *this;
     }
 };
 

--- a/src/tool/cppwinrt/old_tests/UnitTests/single_threaded_map.cpp
+++ b/src/tool/cppwinrt/old_tests/UnitTests/single_threaded_map.cpp
@@ -29,8 +29,7 @@ namespace
         values.Insert(3,30);
         IIterator<IKeyValuePair<int, int>> first = values.First();
         REQUIRE(first.HasCurrent());
-        auto pair = first.Current();
-        pair;
+        [[maybe_unused]] auto pair = first.Current();
         REQUIRE(first.MoveNext());
         REQUIRE(first.GetMany(array) == 2);
 


### PR DESCRIPTION
The only remaining warnings are related to the implicit overrides in winrt::implements that I will deal with separately as they are especially tricky.