### PR TITLE
Optimize C++/WinRT's GetMany implementation

### DIFF
--- a/src/tool/cppwinrt/cppwinrt.sln
+++ b/src/tool/cppwinrt/cppwinrt.sln
@@ -81,6 +81,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_fast_fwd", "test_fast_
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fast_fwd", "fast_fwd\fast_fwd.vcxproj", "{A63B3AD1-AB7B-461E-9FFF-2447F5BCD459}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "scratch", "scratch\scratch.vcxproj", "{E893622C-47DE-4F83-B422-0A26711590A4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -297,6 +299,18 @@ Global
 		{A63B3AD1-AB7B-461E-9FFF-2447F5BCD459}.Release|x64.Build.0 = Release|x64
 		{A63B3AD1-AB7B-461E-9FFF-2447F5BCD459}.Release|x86.ActiveCfg = Release|Win32
 		{A63B3AD1-AB7B-461E-9FFF-2447F5BCD459}.Release|x86.Build.0 = Release|Win32
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Debug|ARM.ActiveCfg = Debug|Win32
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Debug|x64.ActiveCfg = Debug|x64
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Debug|x64.Build.0 = Debug|x64
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Debug|x86.ActiveCfg = Debug|Win32
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Debug|x86.Build.0 = Debug|Win32
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Release|ARM.ActiveCfg = Release|Win32
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Release|ARM64.ActiveCfg = Release|Win32
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Release|x64.ActiveCfg = Release|x64
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Release|x64.Build.0 = Release|x64
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Release|x86.ActiveCfg = Release|Win32
+		{E893622C-47DE-4F83-B422-0A26711590A4}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/tool/cppwinrt/scratch/main.cpp
+++ b/src/tool/cppwinrt/scratch/main.cpp
@@ -2,6 +2,6 @@
 
 using namespace winrt;
 
-TEST_CASE("scratch")
+int main()
 {
 }

--- a/src/tool/cppwinrt/scratch/pch.cpp
+++ b/src/tool/cppwinrt/scratch/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/tool/cppwinrt/scratch/pch.h
+++ b/src/tool/cppwinrt/scratch/pch.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "winrt/Windows.Foundation.Collections.h"

--- a/src/tool/cppwinrt/scratch/scratch.vcxproj
+++ b/src/tool/cppwinrt/scratch/scratch.vcxproj
@@ -20,9 +20,9 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
-    <ProjectGuid>{D2961EA1-A8CA-4A62-B760-948403DC8494}</ProjectGuid>
-    <RootNamespace>unittests</RootNamespace>
-    <ProjectName>test</ProjectName>
+    <ProjectGuid>{E893622C-47DE-4F83-B422-0A26711590A4}</ProjectGuid>
+    <RootNamespace>scratch</RootNamespace>
+    <ProjectName>scratch</ProjectName>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\cppwinrt.props" />
@@ -88,7 +88,8 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>$(OutputPath)cppwinrt -in $(OutputPath)test_component.winmd $(OutputPath)test_component_no_pch.winmd -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -105,7 +106,8 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PreBuildEvent>
-      <Command>$(OutputPath)cppwinrt -in $(OutputPath)test_component.winmd $(OutputPath)test_component_no_pch.winmd -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -122,7 +124,8 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PreBuildEvent>
-      <Command>$(OutputPath)cppwinrt -in $(OutputPath)test_component.winmd $(OutputPath)test_component_no_pch.winmd -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -143,7 +146,8 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>$(OutputPath)cppwinrt -in $(OutputPath)test_component.winmd $(OutputPath)test_component_no_pch.winmd -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
@@ -151,74 +155,18 @@
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="pch.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="abi_args.cpp" />
-    <ClCompile Include="abi_guard.cpp" />
-    <ClCompile Include="agile_ref.cpp" />
-    <ClCompile Include="agility.cpp" />
-    <ClCompile Include="async_auto_cancel.cpp" />
-    <ClCompile Include="async_cancel_callback.cpp" />
-    <ClCompile Include="async_check_cancel.cpp" />
-    <ClCompile Include="async_local.cpp" />
-    <ClCompile Include="async_no_suspend.cpp" />
-    <ClCompile Include="async_progress.cpp" />
-    <ClCompile Include="async_result.cpp" />
-    <ClCompile Include="async_return.cpp" />
-    <ClCompile Include="async_suspend.cpp" />
-    <ClCompile Include="async_throw.cpp" />
-    <ClCompile Include="async_wait_for.cpp" />
-    <ClCompile Include="capture.cpp" />
-    <ClCompile Include="cmd_reader.cpp" />
-    <ClCompile Include="coro_foundation.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="coro_system.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="coro_threadpool.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="coro_ui_core.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="custom_error.cpp" />
-    <ClCompile Include="delegate.cpp" />
-    <ClCompile Include="delegates.cpp" />
-    <ClCompile Include="disconnected.cpp" />
-    <ClCompile Include="enum.cpp" />
-    <ClCompile Include="final_release.cpp" />
-    <ClCompile Include="GetMany.cpp" />
-    <ClCompile Include="iid_ppv_args.cpp" />
-    <ClCompile Include="interop.cpp" />
-    <ClCompile Include="invalid_events.cpp" />
-    <ClCompile Include="in_params.cpp" />
-    <ClCompile Include="in_params_abi.cpp" />
     <ClCompile Include="main.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="names.cpp" />
-    <ClCompile Include="noexcept.cpp" />
-    <ClCompile Include="no_make_detection.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="out_params.cpp" />
-    <ClCompile Include="out_params_abi.cpp" />
-    <ClCompile Include="out_params_bad.cpp" />
-    <ClCompile Include="parent_includes.cpp" />
     <ClCompile Include="pch.cpp">
-      <PrecompiledHeader>Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="return_params.cpp" />
-    <ClCompile Include="return_params_abi.cpp" />
-    <ClCompile Include="single_threaded_observable_vector.cpp" />
-    <ClCompile Include="structs.cpp" />
-    <ClCompile Include="tearoff.cpp" />
-    <ClCompile Include="thread_pool.cpp" />
-    <ClCompile Include="uniform_in_params.cpp" />
-    <ClCompile Include="variadic_delegate.cpp" />
-    <ClCompile Include="velocity.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/tool/cppwinrt/scratch/scratch.vcxproj
+++ b/src/tool/cppwinrt/scratch/scratch.vcxproj
@@ -157,6 +157,10 @@
   <ItemGroup>
     <ClCompile Include="main.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/src/tool/cppwinrt/strings/base_collections_base.h
+++ b/src/tool/cppwinrt/strings/base_collections_base.h
@@ -103,7 +103,7 @@ namespace winrt
 
             uint32_t GetMany(array_view<T> values)
             {
-                if constexpr (std::is_same_v<decltype(std::iterator_traits<iterator_type>::iterator_category()), std::random_access_iterator_tag>)
+                if constexpr (std::is_same_v<decltype(typename std::iterator_traits<iterator_type>::iterator_category()), std::random_access_iterator_tag>)
                 {
                     uint32_t const actual = (std::min)(static_cast<uint32_t>(m_end - m_current), values.size());
                     m_owner->copy_n(m_current, actual, values.begin());

--- a/src/tool/cppwinrt/strings/base_collections_base.h
+++ b/src/tool/cppwinrt/strings/base_collections_base.h
@@ -26,7 +26,7 @@ namespace winrt
         template<typename InputIt, typename Size, typename OutputIt>
         auto copy_n(InputIt first, Size count, OutputIt result) const
         {
-            if constexpr (std::is_same_v<T, decltype(*std::declval<D const>().get_container().begin())> && !impl::is_key_value_pair<T>::value)
+            if constexpr (std::is_same_v<T, std::decay_t<decltype(*std::declval<D const>().get_container().begin())>> && !impl::is_key_value_pair<T>::value)
             {
                 std::copy_n(first, count, result);
             }

--- a/src/tool/cppwinrt/test/GetMany.cpp
+++ b/src/tool/cppwinrt/test/GetMany.cpp
@@ -342,4 +342,21 @@ TEST_CASE("GetMany")
         REQUIRE(buffer[2] == L"3");
         REQUIRE(buffer[3] == L"");
     }
+
+    // Pair
+    {
+        auto m = single_threaded_map<int, hstring>();
+        m.Insert(1, L"1");
+        m.Insert(2, L"2");
+        m.Insert(3, L"3");
+        m.Insert(4, L"4");
+        std::array<IKeyValuePair<int, hstring>, 3> buffer;
+        REQUIRE(3 == m.First().GetMany(buffer));
+        REQUIRE(buffer[0].Key() == 1);
+        REQUIRE(buffer[1].Key() == 2);
+        REQUIRE(buffer[2].Key() == 3);
+        REQUIRE(buffer[0].Value() == L"1");
+        REQUIRE(buffer[1].Value() == L"2");
+        REQUIRE(buffer[2].Value() == L"3");
+    }
 }

--- a/src/tool/cppwinrt/test/GetMany.cpp
+++ b/src/tool/cppwinrt/test/GetMany.cpp
@@ -13,6 +13,38 @@ using namespace Windows::Foundation::Collections;
 // covered.
 //
 
+namespace
+{
+    template <typename T>
+    IIterable<T> single_threaded_list(std::list<T>&& values = {})
+    {
+        struct list :
+            implements<list, IIterable<T>>,
+            iterable_base<list, T>
+        {
+            explicit list(std::list<T>&& values) : m_values(std::forward<std::list<T>>(values))
+            {
+            }
+
+            auto& get_container() noexcept
+            {
+                return m_values;
+            }
+
+            auto& get_container() const noexcept
+            {
+                return m_values;
+            }
+
+        private:
+
+            std::list<T> m_values;
+        };
+
+        return make<list>(std::move(values));
+    }
+}
+
 TEST_CASE("GetMany")
 {
     // All
@@ -202,6 +234,112 @@ TEST_CASE("GetMany")
         REQUIRE(buffer[0] == L"2");
         REQUIRE(buffer[1] == L"3");
         REQUIRE(buffer[2] == L"");
+        REQUIRE(buffer[3] == L"");
+    }
+
+    // Similar tests but with a list to ensure optimal code gen for containers that don't offer random access.
+
+    // All
+    {
+        auto v = single_threaded_list<int>({ 1,2,3 });
+        std::array<int, 3> buffer{ 0xCC, 0xCC, 0xCC };
+        REQUIRE(3 == v.First().GetMany(buffer));
+        REQUIRE(buffer[0] == 1);
+        REQUIRE(buffer[1] == 2);
+        REQUIRE(buffer[2] == 3);
+    }
+
+    // None
+    {
+        auto v = single_threaded_list<int>({ 1,2,3,4 });
+        auto pos = v.First();
+        std::array<int, 3> buffer{ 0xCC, 0xCC, 0xCC };
+        REQUIRE(3 == pos.GetMany(buffer));
+        REQUIRE(buffer[0] == 1);
+        REQUIRE(buffer[1] == 2);
+        REQUIRE(buffer[2] == 3);
+        buffer = { 0xCC, 0xCC, 0xCC };
+        REQUIRE(1 == pos.GetMany(buffer));
+        REQUIRE(buffer[0] == 4);
+        REQUIRE(buffer[1] == 0xCC);
+        REQUIRE(buffer[2] == 0xCC);
+        buffer = { 0xCC, 0xCC, 0xCC };
+        REQUIRE(0 == pos.GetMany(buffer));
+        REQUIRE(buffer[0] == 0xCC);
+        REQUIRE(buffer[1] == 0xCC);
+        REQUIRE(buffer[2] == 0xCC);
+    }
+
+    // Less
+    {
+        auto v = single_threaded_list<int>({ 1,2,3 });
+        std::array<int, 2> buffer{ 0xCC, 0xCC };
+        REQUIRE(2 == v.First().GetMany(buffer));
+        REQUIRE(buffer[0] == 1);
+        REQUIRE(buffer[1] == 2);
+    }
+
+    // More
+    {
+        auto v = single_threaded_list<int>({ 1,2,3 });
+        std::array<int, 4> buffer{ 0xCC, 0xCC, 0xCC, 0xCC };
+        REQUIRE(3 == v.First().GetMany(buffer));
+        REQUIRE(buffer[0] == 1);
+        REQUIRE(buffer[1] == 2);
+        REQUIRE(buffer[2] == 3);
+        REQUIRE(buffer[3] == 0xCC);
+    }
+
+    // The same tests but with a non-trivially destructible type...
+
+    // All
+    {
+        auto v = single_threaded_list<hstring>({ L"1",L"2",L"3" });
+        std::array<hstring, 3> buffer{ L"old", L"old", L"old" };
+        REQUIRE(3 == v.First().GetMany(buffer));
+        REQUIRE(buffer[0] == L"1");
+        REQUIRE(buffer[1] == L"2");
+        REQUIRE(buffer[2] == L"3");
+    }
+
+    // None
+    {
+        auto v = single_threaded_list<hstring>({ L"1",L"2",L"3",L"4" });
+        auto pos = v.First();
+        std::array<hstring, 3> buffer{ L"old", L"old", L"old" };
+        REQUIRE(3 == pos.GetMany(buffer));
+        REQUIRE(buffer[0] == L"1");
+        REQUIRE(buffer[1] == L"2");
+        REQUIRE(buffer[2] == L"3");
+        buffer = { L"old", L"old", L"old" };
+        REQUIRE(1 == pos.GetMany(buffer));
+        REQUIRE(buffer[0] == L"4");
+        REQUIRE(buffer[1] == L"");
+        REQUIRE(buffer[2] == L"");
+        buffer = { L"old", L"old", L"old" };
+        REQUIRE(0 == pos.GetMany(buffer));
+        REQUIRE(buffer[0] == L"");
+        REQUIRE(buffer[1] == L"");
+        REQUIRE(buffer[2] == L"");
+    }
+
+    // Less
+    {
+        auto v = single_threaded_list<hstring>({ L"1",L"2",L"3" });
+        std::array<hstring, 2> buffer{ L"old", L"old" };
+        REQUIRE(2 == v.First().GetMany(buffer));
+        REQUIRE(buffer[0] == L"1");
+        REQUIRE(buffer[1] == L"2");
+    }
+
+    // More
+    {
+        auto v = single_threaded_list<hstring>({ L"1",L"2",L"3" });
+        std::array<hstring, 4> buffer{ L"old", L"old", L"old", L"old" };
+        REQUIRE(3 == v.First().GetMany(buffer));
+        REQUIRE(buffer[0] == L"1");
+        REQUIRE(buffer[1] == L"2");
+        REQUIRE(buffer[2] == L"3");
         REQUIRE(buffer[3] == L"");
     }
 }


### PR DESCRIPTION
The `GetMany` implementation for `IIterable<T>` was performing multiple traversals of the range when random access iterators weren't available. This update ensures that only a single traversal occurs in all cases and memcpy is used in more cases when the range offers random access.

I've also moved the scratch test into a separate project as the tests have become too extensive.