### PR TITLE
Add fast reverse iterators to C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/strings/base_collections.h
+++ b/src/tool/cppwinrt/strings/base_collections.h
@@ -41,8 +41,50 @@ namespace winrt::impl
 
     private:
 
-        T const* m_collection = nullptr;
-        uint32_t m_index = 0;
+        T const* m_collection{};
+        uint32_t m_index{};
+    };
+
+    template <typename T>
+    struct rfast_iterator
+    {
+        using iterator_category = std::input_iterator_tag;
+        using value_type = T;
+        using difference_type = ptrdiff_t;
+        using pointer = T *;
+        using reference = T &;
+
+        rfast_iterator(T const& collection, int64_t const index) noexcept :
+            m_collection(&collection),
+            m_index(index)
+        {}
+
+        rfast_iterator& operator++() noexcept
+        {
+            --m_index;
+            return*this;
+        }
+
+        auto operator*() const
+        {
+            return m_collection->GetAt(static_cast<uint32_t>(m_index));
+        }
+
+        bool operator==(rfast_iterator const& other) const noexcept
+        {
+            WINRT_ASSERT(m_collection == other.m_collection);
+            return m_index == other.m_index;
+        }
+
+        bool operator!=(rfast_iterator const& other) const noexcept
+        {
+            return !(*this == other);
+        }
+
+    private:
+
+        T const* m_collection{};
+        int64_t m_index{};
     };
 
     template <typename T>
@@ -78,13 +120,25 @@ namespace winrt::impl
     template <typename T, std::enable_if_t<has_GetAt<T>::value>* = nullptr>
     fast_iterator<T> begin(T const& collection) noexcept
     {
-        return fast_iterator<T>(collection, 0);
+        return { collection, 0 };
     }
 
     template <typename T, std::enable_if_t<has_GetAt<T>::value>* = nullptr>
     fast_iterator<T> end(T const& collection)
     {
-        return fast_iterator<T>(collection, collection.Size());
+        return { collection, collection.Size() };
+    }
+
+    template <typename T, std::enable_if_t<has_GetAt<T>::value>* = nullptr>
+    rfast_iterator<T> rbegin(T const& collection) noexcept
+    {
+        return { collection, collection.Size() - 1 };
+    }
+
+    template <typename T, std::enable_if_t<has_GetAt<T>::value>* = nullptr>
+    rfast_iterator<T> rend(T const& collection)
+    {
+        return { collection, -1 };
     }
 
     template <typename T>

--- a/src/tool/cppwinrt/test/fast_iterator.cpp
+++ b/src/tool/cppwinrt/test/fast_iterator.cpp
@@ -1,0 +1,23 @@
+#include "pch.h"
+
+TEST_CASE("fast_iterator")
+{
+    {
+        auto v = winrt::single_threaded_vector<int>({ 1, 2, 3 });
+
+        std::vector<int> result;
+
+        std::copy(begin(v), end(v), std::back_inserter(result));
+
+        REQUIRE((result == std::vector{ 1, 2, 3 }));
+    }
+    {
+        auto v = winrt::single_threaded_vector<int>({ 1, 2, 3 });
+
+        std::vector<int> result;
+
+        std::copy(rbegin(v), rend(v), std::back_inserter(result));
+
+        REQUIRE((result == std::vector{ 3, 2, 1 }));
+    }
+}

--- a/src/tool/cppwinrt/test/test.vcxproj
+++ b/src/tool/cppwinrt/test/test.vcxproj
@@ -188,6 +188,7 @@
     <ClCompile Include="delegates.cpp" />
     <ClCompile Include="disconnected.cpp" />
     <ClCompile Include="enum.cpp" />
+    <ClCompile Include="fast_iterator.cpp" />
     <ClCompile Include="final_release.cpp" />
     <ClCompile Include="GetMany.cpp" />
     <ClCompile Include="iid_ppv_args.cpp" />


### PR DESCRIPTION
Add `rbegin` and `rend` ADL functions to complement `begin` and `end` and provide reverse iterators for `IVector<T>` and `IVectorView<T>`. 

Fixes #141 