### PR TITLE
Make lack of weak-ref support more debuggable in C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/old_tests/UnitTests/weak.cpp
+++ b/src/tool/cppwinrt/old_tests/UnitTests/weak.cpp
@@ -92,20 +92,6 @@ TEST_CASE("weak,source")
     }
 }
 
-TEST_CASE("weak,none")
-{
-    Windows::Foundation::IUnknown s = make<NoWeak>().as<Windows::Foundation::IUnknown>();
-
-    REQUIRE_THROWS_AS(make_weak(s), hresult_no_interface);
-
-    try
-    {
-        weak_ref<Windows::Foundation::IUnknown> w = s;
-        REQUIRE(false);
-    }
-    catch (hresult_no_interface const &) {}
-}
-
 TEST_CASE("weak,nullptr")
 {
     IStringable a = nullptr;

--- a/src/tool/cppwinrt/strings/base_weak_ref.h
+++ b/src/tool/cppwinrt/strings/base_weak_ref.h
@@ -16,7 +16,9 @@ namespace winrt
                 }
                 else
                 {
-                    check_hresult(object.template as<impl::IWeakReferenceSource>()->GetWeakReference(m_ref.put()));
+                    // An access violation (crash) on the following line means that the object does not support weak references.
+                    // Avoid using weak_ref/auto_revoke until the API has been fixed to support weak references.
+                    check_hresult(object.template try_as<impl::IWeakReferenceSource>()->GetWeakReference(m_ref.put()));
                 }
             }
         }

--- a/src/tool/cppwinrt/strings/base_weak_ref.h
+++ b/src/tool/cppwinrt/strings/base_weak_ref.h
@@ -17,7 +17,7 @@ namespace winrt
                 else
                 {
                     // An access violation (crash) on the following line means that the object does not support weak references.
-                    // Avoid using weak_ref/auto_revoke until the API has been fixed to support weak references.
+                    // Avoid using weak_ref/auto_revoke with such objects.
                     check_hresult(object.template try_as<impl::IWeakReferenceSource>()->GetWeakReference(m_ref.put()));
                 }
             }


### PR DESCRIPTION
A few OS APIs (mostly just `Windows.UI.Composition`) still don't support weak references and this causes a lot of pain for developers who don't realize why something so fundamental fails for a small subset of APIs. The problem is hard to diagnose for developers because it is reported as an `E_NOINTERFACE` exception that quickly propagates away from the source of the problem. It is a coding bug (and not a recoverable error) to use `auto_revoke`/`weak_ref` with an object that does not support weak references. This change makes such a failure far easier to debug by turning it into an immediate crash.