### PR TITLE
Remove confusing C++/WinRT command line behavior

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/main.cpp
+++ b/src/tool/cppwinrt/cppwinrt/main.cpp
@@ -273,22 +273,6 @@ Where <spec> is one or more of:
                 }
             }
 
-            if (settings.component && settings.component_name.empty())
-            {
-                auto& values = args.values("input");
-
-                if (!values.empty())
-                {
-                    // In C++/WinRT 1.0, the component name defaults to the *first* input, hence
-                    // the use of args.values() that will return the args in input order.
-
-                    auto compat_name = path(values[0]).filename().replace_extension().string();
-
-                    w.write(" warning: Use '-name %' to specify the explicit name for component files.\n",
-                        compat_name);
-                }
-            }
-
             w.flush_to_console();
             task_group group;
 
@@ -348,6 +332,22 @@ Where <spec> is one or more of:
             if (settings.verbose)
             {
                 w.write(" time:  %ms\n", get_elapsed_time(start));
+            }
+
+            if (settings.component && settings.component_name.empty())
+            {
+                auto& values = args.values("input");
+
+                if (!values.empty())
+                {
+                    // In C++/WinRT 1.0, the component name defaults to the *first* input, hence
+                    // the use of args.values() that will return the args in input order.
+
+                    auto compat_name = path(values[0]).filename().replace_extension().string();
+
+                    w.write("\n warning: Use '-name %' to specify the explicit name for component files.\n",
+                        compat_name);
+                }
             }
         }
         catch (usage_exception const&)

--- a/src/tool/cppwinrt/old_tests/Component/Component.vcxproj
+++ b/src/tool/cppwinrt/old_tests/Component/Component.vcxproj
@@ -97,7 +97,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <CustomBuildStep>
-      <Command>$(OutputPath)cppwinrt.exe -in $(OutputPath)Component.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk $(OutputPath)Composable.winmd -verbose</Command>
+      <Command>$(OutputPath)cppwinrt.exe -in $(OutputPath)Component.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk $(OutputPath)Composable.winmd -verbose -name Component</Command>
       <Message>C++/WinRT compiler</Message>
       <Outputs>Generated Files\module.g.cpp</Outputs>
       <Inputs>$(OutputPath)Component.winmd</Inputs>

--- a/src/tool/cppwinrt/old_tests/Composable/Composable.vcxproj
+++ b/src/tool/cppwinrt/old_tests/Composable/Composable.vcxproj
@@ -97,7 +97,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <CustomBuildStep>
-      <Command>$(OutputPath)cppwinrt.exe -in $(OutputPath)Composable.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -pch precomp.hpp</Command>
+      <Command>$(OutputPath)cppwinrt.exe -in $(OutputPath)Composable.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -pch precomp.hpp -name Composable</Command>
       <Message>C++/WinRT compiler</Message>
       <Outputs>Generated Files\module.g.cpp</Outputs>
       <Inputs>$(OutputDir)Composable.winmd</Inputs>

--- a/src/tool/cppwinrt/test_component/test_component.vcxproj
+++ b/src/tool/cppwinrt/test_component/test_component.vcxproj
@@ -121,7 +121,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -include test_component -ref sdk -verbose -prefix -opt -lib test -fastabi -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -include test_component -ref sdk -verbose -prefix -opt -lib test -fastabi -overwrite -name test_component</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -168,7 +168,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -include test_component -ref sdk -verbose -prefix -opt -lib test -fastabi -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -include test_component -ref sdk -verbose -prefix -opt -lib test -fastabi -overwrite -name test_component</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -219,7 +219,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -include test_component -ref sdk -verbose -prefix -opt -lib test -fastabi -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -include test_component -ref sdk -verbose -prefix -opt -lib test -fastabi -overwrite -name test_component</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -270,7 +270,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -include test_component -ref sdk -verbose -prefix -opt -lib test -fastabi -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -include test_component -ref sdk -verbose -prefix -opt -lib test -fastabi -overwrite -name test_component</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />

--- a/src/tool/cppwinrt/test_component_base/test_component_base.vcxproj
+++ b/src/tool/cppwinrt/test_component_base/test_component_base.vcxproj
@@ -121,7 +121,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -name test_component_base</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -168,7 +168,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -name test_component_base</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -219,7 +219,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -name test_component_base</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -270,7 +270,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -name test_component_base</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />

--- a/src/tool/cppwinrt/test_component_derived/test_component_derived.vcxproj
+++ b/src/tool/cppwinrt/test_component_derived/test_component_derived.vcxproj
@@ -122,7 +122,7 @@
       <AdditionalIncludeDirectories>..\test_component_base</AdditionalIncludeDirectories>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_derived.winmd -ref $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_derived.winmd -ref $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -name test_component_derived</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -170,7 +170,7 @@
       <AdditionalIncludeDirectories>..\test_component_base</AdditionalIncludeDirectories>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_derived.winmd -ref $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_derived.winmd -ref $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -name test_component_derived</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -222,7 +222,7 @@
       <AdditionalIncludeDirectories>..\test_component_base</AdditionalIncludeDirectories>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_derived.winmd -ref $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_derived.winmd -ref $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -name test_component_derived</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -274,7 +274,7 @@
       <AdditionalIncludeDirectories>..\test_component_base</AdditionalIncludeDirectories>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_derived.winmd -ref $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_derived.winmd -ref $(OutputPath)test_component_base.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -name test_component_derived</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />

--- a/src/tool/cppwinrt/test_component_fast/test_component_fast.vcxproj
+++ b/src/tool/cppwinrt/test_component_fast/test_component_fast.vcxproj
@@ -123,7 +123,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_fast.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_fast.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt -name test_component_fast</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -171,7 +171,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_fast.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_fast.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt -name test_component_fast</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -223,7 +223,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_fast.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_fast.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt -name test_component_fast</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -275,7 +275,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_fast.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_fast.winmd -comp $(ProjectDir) -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt -name test_component_fast</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />

--- a/src/tool/cppwinrt/test_component_folders/test_component_folders.vcxproj
+++ b/src/tool/cppwinrt/test_component_folders/test_component_folders.vcxproj
@@ -121,7 +121,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -name test_component_folders</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -168,7 +168,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -name test_component_folders</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -219,7 +219,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -name test_component_folders</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -270,7 +270,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_folders.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -name test_component_folders</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />

--- a/src/tool/cppwinrt/test_component_no_pch/test_component_no_pch.vcxproj
+++ b/src/tool/cppwinrt/test_component_no_pch/test_component_no_pch.vcxproj
@@ -122,7 +122,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch . -name test_component_no_pch</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -170,7 +170,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch . -name test_component_no_pch</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -222,7 +222,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch . -name test_component_no_pch</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />
@@ -274,7 +274,7 @@
       <PrependWithABINamepsace>true</PrependWithABINamepsace>
     </Midl>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch .</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)test_component_no_pch.winmd -comp -out "$(ProjectDir)Generated Files" -ref sdk -verbose -overwrite -pch . -name test_component_no_pch</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />

--- a/src/tool/cppwinrt/test_fast_fwd/test_fast_fwd.vcxproj
+++ b/src/tool/cppwinrt/test_fast_fwd/test_fast_fwd.vcxproj
@@ -312,7 +312,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <CustomBuildStep>
-      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)FastForwarderTest.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt</Command>
+      <Command>$(CppWinRTDir)cppwinrt -input $(OutputPath)FastForwarderTest.winmd -comp "$(ProjectDir)Generated Files" -out "$(ProjectDir)Generated Files" -ref sdk -verbose -fastabi -prefix -opt -name FastForwarderTest</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message />


### PR DESCRIPTION
In C++/WinRT 1.0, there was a subtle - and it turns out rather confusing - command line behavior where the component name (used to derive generated component file names) was itself derived from the first `-input` argument and only if the `-name` option was not also specified. This is confusing as the winmd name is not guaranteed to match the namespace name and particularly so when you consider that the file system is not case sensitive but C++ is.

This behavior has now been removed and replaced with a warning to help diagnose any build failures. For example:

```
> cppwinrt.exe -in C:\windows\system32\WinMetadata\Windows.Management.winmd -ref local -component

warning: Use '-name Windows.Management' to specify the explicit name for component files.
```

Fixes #309 