### PR TITLE
Optimize C++/WinRT implementation signatures

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -924,7 +924,7 @@ namespace xlang
     static void write_consume_declaration(writer& w, MethodDef const& method)
     {
         method_signature signature{ method };
-        w.async_types = is_async(method, signature);
+        w.async_types = signature.is_async();
         auto method_name = get_name(method);
         auto type = method.Parent();
 
@@ -1060,7 +1060,7 @@ namespace xlang
     {
         auto method_name = get_name(method);
         method_signature signature{ method };
-        w.async_types = is_async(method, signature);
+        w.async_types = signature.is_async();
 
         std::string_view format;
 
@@ -1120,7 +1120,7 @@ namespace xlang
     {
         auto method_name = get_name(method);
         method_signature signature{ method };
-        w.async_types = is_async(method, signature);
+        w.async_types = signature.is_async();
 
         //
         // Note: this use of a lambda is a workaround for a Visual C++ compiler bug:
@@ -1737,7 +1737,7 @@ namespace xlang
         }
 
         method_signature signature{ method };
-        w.async_types = is_async(method, signature);
+        w.async_types = signature.is_async();
         std::string upcall = "this->shim().";
         upcall += get_name(method);
 
@@ -2805,7 +2805,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         {
             method_signature signature{ method };
             auto method_name = get_name(method);
-            w.async_types = is_async(method, signature);
+            w.async_types = signature.is_async();
 
             if (settings.component_opt && settings.component_filter.includes(type))
             {
@@ -2845,7 +2845,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
     {
         method_signature signature{ method };
         auto method_name = get_name(method);
-        w.async_types = is_async(method, signature);
+        w.async_types = signature.is_async();
 
         {
             auto format = R"(    inline auto %::%(%)

--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -899,7 +899,8 @@ namespace xlang
 
                     auto param_type = std::get_if<ElementType>(&param_signature->Type().Type());
 
-                    if (w.async_types || (param_type && *param_type != ElementType::String && *param_type != ElementType::Object))
+                    if ((!is_put_overload(method_signature.method()) && w.async_types) ||
+                        (param_type && *param_type != ElementType::String && *param_type != ElementType::Object))
                     {
                         w.write("%", param_signature->Type());
                     }

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -474,7 +474,7 @@ catch (...) { return winrt::to_hresult(); }
                 {
                     method_signature signature{ method };
                     auto method_name = get_name(method);
-                    w.async_types = is_async(method, signature);
+                    w.async_types = signature.is_async();
 
                     if (is_add_overload(method) || is_remove_overload(method))
                     {
@@ -950,7 +950,7 @@ namespace winrt::@::implementation
                 for (auto&& method : factory.type.MethodList())
                 {
                     method_signature signature{ method };
-                    w.async_types = is_async(method, signature);
+                    w.async_types = signature.is_async();
                     auto method_name = get_name(method);
 
                     w.write("        static % %(%)%;\n",
@@ -974,7 +974,7 @@ namespace winrt::@::implementation
             for (auto&& method : info.type.MethodList())
             {
                 method_signature signature{ method };
-                w.async_types = is_async(method, signature);
+                w.async_types = signature.is_async();
                 auto method_name = get_name(method);
 
                 w.write("        % %(%)%;\n",
@@ -1105,7 +1105,7 @@ namespace winrt::@::implementation
                 for (auto&& method : factory.type.MethodList())
                 {
                     method_signature signature{ method };
-                    w.async_types = is_async(method, signature);
+                    w.async_types = signature.is_async();
                     auto method_name = get_name(method);
 
                     w.write(format,
@@ -1136,7 +1136,7 @@ namespace winrt::@::implementation
 )";
 
                 method_signature signature{ method };
-                w.async_types = is_async(method, signature);
+                w.async_types = signature.is_async();
                 auto method_name = get_name(method);
 
                 w.write(format,

--- a/src/tool/cppwinrt/cppwinrt/helpers.h
+++ b/src/tool/cppwinrt/cppwinrt/helpers.h
@@ -68,10 +68,10 @@ namespace xlang
             return name;
         }
 
-        //MethodDef const& method() const
-        //{
-        //    return m_method;
-        //}
+        MethodDef const& method() const
+        {
+            return m_method;
+        }
 
         bool is_async() const
         {

--- a/src/tool/cppwinrt/cppwinrt/helpers.h
+++ b/src/tool/cppwinrt/cppwinrt/helpers.h
@@ -12,22 +12,28 @@ namespace xlang
         return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count();
     }
 
+    static bool is_put_overload(MethodDef const& method)
+    {
+        return method.SpecialName() && starts_with(method.Name(), "put_");
+    }
+
     struct method_signature
     {
         explicit method_signature(MethodDef const& method) :
-            m_method(method.Signature())
+            m_method(method),
+            m_signature(method.Signature())
         {
             auto params = method.ParamList();
 
-            if (m_method.ReturnType() && params.first != params.second && params.first.Sequence() == 0)
+            if (m_signature.ReturnType() && params.first != params.second && params.first.Sequence() == 0)
             {
                 m_return = params.first;
                 ++params.first;
             }
 
-            for (uint32_t i{}; i != size(m_method.Params()); ++i)
+            for (uint32_t i{}; i != size(m_signature.Params()); ++i)
             {
-                m_params.emplace_back(params.first + i, &m_method.Params().first[i]);
+                m_params.emplace_back(params.first + i, &m_signature.Params().first[i]);
             }
         }
 
@@ -43,7 +49,7 @@ namespace xlang
 
         auto const& return_signature() const
         {
-            return m_method.ReturnType();
+            return m_signature.ReturnType();
         }
 
         auto return_param_name() const
@@ -62,9 +68,52 @@ namespace xlang
             return name;
         }
 
+        //MethodDef const& method() const
+        //{
+        //    return m_method;
+        //}
+
+        bool is_async() const
+        {
+            if (is_put_overload(m_method))
+            {
+                return true;
+            }
+
+            if (!m_signature.ReturnType())
+            {
+                return false;
+            }
+
+            bool async{};
+
+            call(m_signature.ReturnType().Type().Type(),
+                [&](coded_index<TypeDefOrRef> const& type)
+                {
+                    auto const& [type_namespace, type_name] = get_type_namespace_and_name(type);
+                    async = type_namespace == "Windows.Foundation" && type_name == "IAsyncAction";
+                },
+                [&](GenericTypeInstSig const& type)
+                {
+                    auto const& [type_namespace, type_name] = get_type_namespace_and_name(type.GenericType());
+
+                    if (type_namespace == "Windows.Foundation")
+                    {
+                        async =
+                            type_name == "IAsyncOperation`1" ||
+                            type_name == "IAsyncActionWithProgress`1" ||
+                            type_name == "IAsyncOperationWithProgress`2";
+                    }
+                },
+                    [](auto&&) {});
+
+            return async;
+        }
+
     private:
 
-        MethodDefSig m_method;
+        MethodDef m_method;
+        MethodDefSig m_signature;
         std::vector<std::pair<Param, ParamSig const*>> m_params;
         Param m_return;
     };
@@ -133,11 +182,6 @@ namespace xlang
         return method.SpecialName() && starts_with(method.Name(), "add_");
     }
 
-    static bool is_put_overload(MethodDef const& method)
-    {
-        return method.SpecialName() && starts_with(method.Name(), "put_");
-    }
-
     static bool is_get_overload(MethodDef const& method)
     {
         return method.SpecialName() && starts_with(method.Name(), "get_");
@@ -202,43 +246,6 @@ namespace xlang
         }
 
         return {};
-    }
-
-    static bool is_async(MethodDef const& method, method_signature const& method_signature)
-    {
-        if (is_put_overload(method))
-        {
-            return true;
-        }
-
-        if (!method_signature.return_signature())
-        {
-            return false;
-        }
-
-        bool async{};
-
-        call(method_signature.return_signature().Type().Type(),
-            [&](coded_index<TypeDefOrRef> const& type)
-            {
-                auto const& [type_namespace, type_name] = get_type_namespace_and_name(type);
-                async = type_namespace == "Windows.Foundation" && type_name == "IAsyncAction";
-            },
-            [&](GenericTypeInstSig const& type)
-            {
-                auto const& [type_namespace, type_name] = get_type_namespace_and_name(type.GenericType());
-
-                if (type_namespace == "Windows.Foundation")
-                {
-                    async =
-                        type_name == "IAsyncOperation`1" ||
-                        type_name == "IAsyncActionWithProgress`1" ||
-                        type_name == "IAsyncOperationWithProgress`2";
-                }
-            },
-            [](auto&&) {});
-
-        return async;
     }
 
     static TypeDef get_base_class(TypeDef const& derived)

--- a/src/tool/cppwinrt/cppwinrt/helpers.h
+++ b/src/tool/cppwinrt/cppwinrt/helpers.h
@@ -75,6 +75,12 @@ namespace xlang
 
         bool is_async() const
         {
+            // WinRT parameter passing conventions include the notion that input parameters of collection types may be read
+            // or copied but should not be stored directly since this would lead to instability as the collection is shared
+            // by the caller and callee. The exception to this rule is property setters where the callee may simply store a
+            // reference to the collection. The collection thus becomes async in the sense that it is expected to remain
+            // valid beyond the duration of the call.
+            
             if (is_put_overload(m_method))
             {
                 return true;


### PR DESCRIPTION
The default implementation signatures generated by cppwinrt for a component weren't always ideal. Specifically, properties always took their single argument by value thus forcing a copy. Developers can easily fix this in their implementation but many not think to do so. This update fixes that, but I'll add a bit of an explanation for the internal logic in case it's not that obvious.

The `is_async` helper decides whether a given method (or property) is async. Primarily this is about detecting whether the method returns one of the WinRT async interfaces, but it is also used under certain conditions for properties, which are not async in that sense. The reason for the former is obvious, but for the latter it can be a little subtle. 

WinRT parameter passing conventions include the notion that input parameters of collection types may be read or copied but should not be stored directly since this would lead to instability as the collection is shared by the caller and callee. The exception to this rule is property setters where the callee may simply store a reference to the collection. The collection thus becomes async in the sense that it is expected to remain valid beyond the duration of the call.

Coming back to C++/WinRT, the language projection optimizes for various input parameter bindings. This allows for things like efficiently calling a WinRT method expecting an `IVector<int>` with a local `std::vector<int>`. This is possible because the implementation of `IVector<int>` produced in these cases has special invalidation logic that will prevent the `IVector<int>` from being used beyond the duration of the call. Of course, if the method is known to be async then this logic should not be provided and the caller should instead be required to provide an implementation that is not locally bound. All of this is handled automatically by C++/WinRT under the hood and relies on this `is_async` function to determine when to apply this policy. 

The update here simply ensures that this policy of treating properties as async is not applied to an implementation since the optimization only affects the call site. The callee doesn't know anything about how the caller created the argument and can simply following the normal rules for lifetime. 

The implementation continues to treat all async methods the same way to ensure that parameters are passed by value under the expectation that they will be implemented as coroutines.