### PR TITLE
Add C++/WinRT when_all async helper

### DIFF
--- a/src/tool/cppwinrt/strings/base_coroutine_foundation.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_foundation.h
@@ -663,3 +663,12 @@ namespace std::experimental
         };
     };
 }
+
+namespace winrt
+{
+    template <typename... Args>
+    Windows::Foundation::IAsyncAction when_all(Args&&... args)
+    {
+        (co_await args, ...);
+    }
+}

--- a/src/tool/cppwinrt/test/test.vcxproj
+++ b/src/tool/cppwinrt/test/test.vcxproj
@@ -221,6 +221,7 @@
     <ClCompile Include="uniform_in_params.cpp" />
     <ClCompile Include="variadic_delegate.cpp" />
     <ClCompile Include="velocity.cpp" />
+    <ClCompile Include="when_all.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/tool/cppwinrt/test/when_all.cpp
+++ b/src/tool/cppwinrt/test/when_all.cpp
@@ -1,0 +1,29 @@
+#include "pch.h"
+#include <pplawait.h>
+
+using namespace concurrency;
+using namespace winrt;
+using namespace Windows::Foundation;
+
+task<void> ppl(bool& done)
+{
+    co_await resume_background();
+    done = true;
+}
+
+IAsyncAction async(bool& done)
+{
+    co_await resume_background();
+    done = true;
+}
+
+TEST_CASE("when_all")
+{
+    bool ppl_done = false;
+    bool async_done = false;
+
+    winrt::when_all(ppl(ppl_done), async(async_done)).get();
+
+    REQUIRE(ppl_done);
+    REQUIRE(async_done);
+}


### PR DESCRIPTION
The `winrt::when_all` helper function creates an `IAsyncAction` object that will complete when all of the supplied awaitable objects have completed. The resulting async object can then either be waited upon using `co_await when_all(...)` or `when_all(...).get()`.

While this is easy to implement in C++/WinRT, it turns out not to be too obvious to many developers and is helpful for developers particularly coming from a C# or PPL background that are accustomed to using `Task.WhenAll` in C# or `concurrency::when_all` in C++.