### PR TITLE
Reduce the build time for C++/WinRT's std::hash specializations

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -3034,9 +3034,8 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
     {
         auto generics = type.GenericParam();
 
-        w.write("    template<%> struct hash<winrt::%> : winrt::impl::hash_base<winrt::%> {};\n",
+        w.write("    template<%> struct hash<winrt::%> : winrt::impl::hash_base {};\n",
             bind<write_generic_typenames>(generics),
-            type,
             type);
     }
 

--- a/src/tool/cppwinrt/strings/base_std_hash.h
+++ b/src/tool/cppwinrt/strings/base_std_hash.h
@@ -22,18 +22,12 @@ namespace winrt::impl
         return result;
     }
 
-    inline size_t hash_unknown(Windows::Foundation::IUnknown const& value) noexcept
-    {
-        void* const abi_value = get_abi(value.try_as<Windows::Foundation::IUnknown>());
-        return std::hash<void*>{}(abi_value);
-    }
-
-    template<typename T>
     struct hash_base
     {
-        size_t operator()(T const& value) const noexcept
+        size_t operator()(Windows::Foundation::IUnknown const& value) const noexcept
         {
-            return hash_unknown(value);
+            void* const abi_value = get_abi(value.try_as<Windows::Foundation::IUnknown>());
+            return std::hash<void*>{}(abi_value);
         }
     };
 }
@@ -50,7 +44,7 @@ namespace std
         }
     };
 
-    template<> struct hash<winrt::Windows::Foundation::IUnknown> : winrt::impl::hash_base<winrt::Windows::Foundation::IUnknown> {};
-    template<> struct hash<winrt::Windows::Foundation::IInspectable> : winrt::impl::hash_base<winrt::Windows::Foundation::IInspectable> {};
-    template<> struct hash<winrt::Windows::Foundation::IActivationFactory> : winrt::impl::hash_base<winrt::Windows::Foundation::IActivationFactory> {};
+    template<> struct hash<winrt::Windows::Foundation::IUnknown> : winrt::impl::hash_base {};
+    template<> struct hash<winrt::Windows::Foundation::IInspectable> : winrt::impl::hash_base {};
+    template<> struct hash<winrt::Windows::Foundation::IActivationFactory> : winrt::impl::hash_base {};
 }


### PR DESCRIPTION
A minor tweak to the way C++/WinRT hash specializations are defined reduces (worst case for all namespace headers) the number of class template specializations by 11,417, reducing build time by a few seconds and reducing PCH size by around 73MB. Modest but good.