### PR TITLE
Use VirtualQuery to validate WINRT_abi_val incoming object pointer and minimize exceptions

### DIFF
--- a/src/package/cppwinrt/natvis/cppwinrt_visualizer.cpp
+++ b/src/package/cppwinrt/natvis/cppwinrt_visualizer.cpp
@@ -91,10 +91,10 @@ bool FindMetadata(DkmProcess* process, std::filesystem::path& winmd_path)
 // If type not indexed, simulate RoGetMetaDataFile's strategy for finding app-local metadata
 // and add to the database dynamically.  RoGetMetaDataFile looks for types in the current process
 // so cannot be called directly.
-void LoadMetadata(DkmProcess* process, WCHAR const* processPath, std::string const& typeName)
+void LoadMetadata(DkmProcess* process, WCHAR const* processPath, std::string_view const& typeName)
 {
     auto winmd_path = path{ processPath };
-    auto probe_file = typeName;
+    auto probe_file = std::string{ typeName };
     do
     {
         winmd_path.replace_filename(probe_file + ".winmd");
@@ -114,7 +114,7 @@ void LoadMetadata(DkmProcess* process, WCHAR const* processPath, std::string con
     db.reset(new cache(db_files));
 }
 
-TypeDef FindType(DkmProcess* process, std::string const& typeName)
+TypeDef FindType(DkmProcess* process, std::string_view const& typeName)
 {
     auto type = db->find(typeName);
     if (!type)

--- a/src/package/cppwinrt/natvis/object_visualizer.h
+++ b/src/package/cppwinrt/natvis/object_visualizer.h
@@ -67,7 +67,7 @@ object_visualizer : winrt::implements<object_visualizer, ::IUnknown>
 
 private:
     void GetPropertyData();
-    void GetTypeProperties(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::string const& type_name);
+    void GetTypeProperties(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::string_view const& type_name);
     winrt::com_ptr<Microsoft::VisualStudio::Debugger::Evaluation::DkmVisualizedExpression> m_pVisualizedExpression;
     bool m_isAbiObject;
     std::vector<PropertyData> m_propertyData;

--- a/src/package/cppwinrt/natvis/pch.h
+++ b/src/package/cppwinrt/natvis/pch.h
@@ -31,7 +31,7 @@ winrt::com_ptr<T> make_com_ptr(T* ptr)
     return result;
 }
 
-xlang::meta::reader::TypeDef FindType(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::string const& typeName);
+xlang::meta::reader::TypeDef FindType(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::string_view const& typeName);
 
 enum class NatvisDiagnosticLevel
 {

--- a/src/tool/cppwinrt/strings/base_extern.h
+++ b/src/tool/cppwinrt/strings/base_extern.h
@@ -41,6 +41,7 @@ extern "C"
     uint32_t __stdcall WINRT_FormatMessageW(uint32_t flags, void const* source, uint32_t code, uint32_t language, wchar_t* buffer, uint32_t size, va_list* arguments) noexcept;
     uint32_t __stdcall WINRT_GetLastError() noexcept;
     void     __stdcall WINRT_GetSystemTimePreciseAsFileTime(void* result) noexcept;
+    uintptr_t __stdcall WINRT_VirtualQuery(void* address, void* buffer, uintptr_t length) noexcept;
 
     int32_t  __stdcall WINRT_OpenProcessToken(void* process, uint32_t access, void** token) noexcept;
     void*    __stdcall WINRT_GetCurrentProcess() noexcept;
@@ -134,6 +135,7 @@ WINRT_IMPL_LINK(GetProcessHeap, 0)
 WINRT_IMPL_LINK(FormatMessageW, 28)
 WINRT_IMPL_LINK(GetLastError, 0)
 WINRT_IMPL_LINK(GetSystemTimePreciseAsFileTime, 4)
+WINRT_IMPL_LINK(VirtualQuery, 12)
 
 WINRT_IMPL_LINK(OpenProcessToken, 12)
 WINRT_IMPL_LINK(GetCurrentProcess, 0)


### PR DESCRIPTION
Fixes #526 

Previously, WINRT_abi_val did no parameter validation and relied on the VS C++ expression evaluator to catch exceptions and propagate them as failures to extension code.  In some environments however (e.g, test host execution), such exceptions still result in a fail fast.  While not foolproof, this change attempts to validate the incoming object pointer to prevent exceptions.