### PR TITLE
deferrable_event_args<T> for deferrable events

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -3047,6 +3047,10 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             {
                 w.write(strings::base_reference_produce);
             }
+            if (c.find("Windows.Foundation.Deferral"))
+            {
+                w.write(strings::base_deferral);
+            }
 
             w.write(strings::base_coroutine_foundation);
         }

--- a/src/tool/cppwinrt/cppwinrt/cppwinrt.vcxproj
+++ b/src/tool/cppwinrt/cppwinrt/cppwinrt.vcxproj
@@ -40,6 +40,7 @@
     <ClInclude Include="..\strings\base_coroutine_system.h" />
     <ClInclude Include="..\strings\base_coroutine_threadpool.h" />
     <ClInclude Include="..\strings\base_coroutine_ui_core.h" />
+    <ClInclude Include="..\strings\base_deferral.h" />
     <ClInclude Include="..\strings\base_delegate.h" />
     <ClInclude Include="..\strings\base_dependencies.h" />
     <ClInclude Include="..\strings\base_error.h" />

--- a/src/tool/cppwinrt/cppwinrt/cppwinrt.vcxproj.filters
+++ b/src/tool/cppwinrt/cppwinrt/cppwinrt.vcxproj.filters
@@ -154,6 +154,9 @@
     <ClInclude Include="..\strings\base_coroutine.h">
       <Filter>strings</Filter>
     </ClInclude>
+    <ClInclude Include="..\strings\base_deferral.h">
+      <Filter>strings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="$(OutDir)version.rc" />

--- a/src/tool/cppwinrt/strings/base_deferral.h
+++ b/src/tool/cppwinrt/strings/base_deferral.h
@@ -56,16 +56,15 @@ namespace winrt
             }
         }
 
-        bool await_suspend(coroutine_handle handle)
+        bool await_suspend(coroutine_handle handle) noexcept
         {
             slim_lock_guard const guard(m_lock);
             m_handle = handle;
             return m_outstanding_deferrals > 0;
         }
 
-    private:
         slim_mutex m_lock;
-        long m_outstanding_deferrals = 0;
+        int32_t m_outstanding_deferrals = 0;
         coroutine_handle m_handle = nullptr;
     };
 #endif

--- a/src/tool/cppwinrt/strings/base_deferral.h
+++ b/src/tool/cppwinrt/strings/base_deferral.h
@@ -46,7 +46,7 @@ namespace winrt
                 }
                 if (--m_outstanding_deferrals == 0)
                 {
-                    resume = std::exchange(m_handle, nullptr);
+                    resume = m_handle;
                 }
             }
 

--- a/src/tool/cppwinrt/strings/base_deferral.h
+++ b/src/tool/cppwinrt/strings/base_deferral.h
@@ -1,0 +1,72 @@
+namespace winrt
+{
+#ifdef __cpp_coroutines
+    template<typename D>
+    struct deferrable_event_args
+    {
+        Windows::Foundation::Deferral GetDeferral()
+        {
+            slim_lock_guard const guard(m_lock);
+            if (m_handle)
+            {
+                // Cannot ask for deferral after the event handler returned.
+                throw hresult_illegal_method_call();
+            }
+
+            Windows::Foundation::Deferral deferral{ {static_cast<D&>(*this).get_strong(), &deferrable_event_args::one_deferral_completed } };
+            ++m_outstanding_deferrals;
+            return deferral;
+        }
+
+        [[nodiscard]] Windows::Foundation::IAsyncAction wait_for_deferrals()
+        {
+            struct awaitable : std::experimental::suspend_always
+            {
+                bool await_suspend(coroutine_handle handle)
+                {
+                    return m_deferrable.await_suspend(handle);
+                }
+
+                deferrable_event_args& m_deferrable;
+            };
+            co_await awaitable{ {}, *this };
+        }
+
+    private:
+        using coroutine_handle = std::experimental::coroutine_handle<>;
+
+        void one_deferral_completed()
+        {
+            coroutine_handle resume = nullptr;
+            {
+                slim_lock_guard const guard(m_lock);
+                if (m_outstanding_deferrals <= 0)
+                {
+                    throw hresult_illegal_method_call();
+                }
+                if (--m_outstanding_deferrals == 0)
+                {
+                    resume = std::exchange(m_handle, nullptr);
+                }
+            }
+
+            if (resume)
+            {
+                resume_background().await_suspend(resume);
+            }
+        }
+
+        bool await_suspend(coroutine_handle handle)
+        {
+            slim_lock_guard const guard(m_lock);
+            m_handle = handle;
+            return m_outstanding_deferrals > 0;
+        }
+
+    private:
+        slim_mutex m_lock;
+        long m_outstanding_deferrals = 0;
+        coroutine_handle m_handle = nullptr;
+    };
+#endif
+}

--- a/src/tool/cppwinrt/test/async_check_cancel.cpp
+++ b/src/tool/cppwinrt/test/async_check_cancel.cpp
@@ -98,7 +98,7 @@ namespace
     }
 }
 
-TEST_CASE("asycn_check_cancel")
+TEST_CASE("async_check_cancel")
 {
     Check(Action);
     Check(ActionWithProgress);

--- a/src/tool/cppwinrt/test/event_deferral.cpp
+++ b/src/tool/cppwinrt/test/event_deferral.cpp
@@ -1,0 +1,126 @@
+#include "pch.h"
+#include "winrt/test_component.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+using namespace test_component;
+
+namespace
+{
+    //
+    // Checks that deferrable events work.
+    //
+
+    // This structure lets us coordinate multiple coroutines
+    // so the fragments run in a specific order. We start in state 0.
+    struct sequence
+    {
+        Class c;
+
+        void go_to_state(int n)
+        {
+            slim_lock_guard guard(m_lock);
+            m_state = n;
+            m_cv.notify_all();
+        }
+
+        void wait_for_state(int n)
+        {
+            slim_lock_guard guard(m_lock);
+            m_cv.wait(m_lock, [&] { return n == m_state; });
+        }
+
+        slim_condition_variable m_cv;
+        slim_mutex m_lock;
+        int m_state = 0;
+
+        // This event handler does the work without a deferral.
+        // This exercises the short-circuit logic in deferrable_event_args.
+        auto NoDeferralHandler()
+        {
+            return [=](Class const& sender, DeferrableEventArgs const& args)
+            {
+                REQUIRE(sender == c);
+                args.IncrementCounter();
+            };
+        }
+
+        // This event handler takes a deferral but completes the work synchronously.
+        // The deferral was unnecessary. This exercises the short-circuit logic in
+        // deferrable_event_args.
+        auto PointlessDeferralHandler()
+        {
+            return [=](Class const& sender, DeferrableEventArgs const& args)
+            {
+                REQUIRE(sender == c);
+                auto deferral = args.GetDeferral();
+                args.IncrementCounter();
+                deferral.Complete();
+            };
+        }
+
+        auto TakeDeferralHandler(int startState, int finishState)
+        {
+            return [=](Class sender, DeferrableEventArgs args) -> fire_and_forget
+            {
+                REQUIRE(sender == c);
+                auto deferral = args.GetDeferral();
+                co_await resume_background();
+                wait_for_state(startState);
+                args.IncrementCounter();
+                deferral.Complete();
+                go_to_state(finishState);
+            };
+        }
+    };
+
+    IAsyncAction TestNoDeferral()
+    {
+        sequence seq;
+        seq.c.DeferrableEvent(seq.NoDeferralHandler());
+        auto counter = co_await seq.c.RaiseDeferrableEventAsync();
+        REQUIRE(counter == 1);
+    }
+
+    IAsyncAction TestPointlessDeferral()
+    {
+        sequence seq;
+        seq.c.DeferrableEvent(seq.PointlessDeferralHandler());
+        auto counter = co_await seq.c.RaiseDeferrableEventAsync();
+        REQUIRE(counter == 1);
+    }
+
+    IAsyncAction TestTakenDeferral()
+    {
+        sequence seq;
+        seq.c.DeferrableEvent(seq.TakeDeferralHandler(1, 2));
+        auto operation = seq.c.RaiseDeferrableEventAsync();
+        seq.go_to_state(1); // tell handler to do work and complete the deferral
+        auto counter = co_await operation;
+        REQUIRE(counter == 1);
+        seq.wait_for_state(2); // make sure handler is finished
+    }
+
+    IAsyncAction TestTwoDeferrals()
+    {
+        sequence seq;
+        seq.c.DeferrableEvent(seq.TakeDeferralHandler(1, 2));
+        seq.c.DeferrableEvent(seq.TakeDeferralHandler(2, 3));
+        auto operation = seq.c.RaiseDeferrableEventAsync();
+        seq.go_to_state(1); // tell first handler to do work and complete the deferral
+        // when first handler completes, it will go to state 2, which tells second handler to do work and complete its deferral.
+        auto counter = co_await operation;
+        REQUIRE(counter == 2);
+        seq.wait_for_state(3); // make sure second handler is finished
+    }
+}
+
+TEST_CASE("event_deferral")
+{
+    TestNoDeferral().get();
+    TestPointlessDeferral().get();
+    TestTakenDeferral().get();
+    TestTwoDeferrals().get();
+}
+
+

--- a/src/tool/cppwinrt/test/test.vcxproj
+++ b/src/tool/cppwinrt/test/test.vcxproj
@@ -161,6 +161,7 @@
     <ClCompile Include="async_auto_cancel.cpp" />
     <ClCompile Include="async_cancel_callback.cpp" />
     <ClCompile Include="async_check_cancel.cpp" />
+    <ClCompile Include="event_deferral.cpp" />
     <ClCompile Include="async_local.cpp" />
     <ClCompile Include="async_no_suspend.cpp" />
     <ClCompile Include="async_progress.cpp" />

--- a/src/tool/cppwinrt/test_component/Class.cpp
+++ b/src/tool/cppwinrt/test_component/Class.cpp
@@ -411,4 +411,22 @@ namespace winrt::test_component::implementation
     {
         return L"123";
     }
+
+    event_token Class::DeferrableEvent(TypedEventHandler<test_component::Class, test_component::DeferrableEventArgs> const& handler)
+    {
+        return m_deferrableEvent.add(handler);
+    }
+
+    void Class::DeferrableEvent(event_token const& token)
+    {
+        return m_deferrableEvent.remove(token);
+    }
+
+    IAsyncOperation<int32_t> Class::RaiseDeferrableEventAsync()
+    {
+        auto args = make_self<DeferrableEventArgs>();
+        m_deferrableEvent(*this, *args);
+        co_await args->wait_for_deferrals();
+        co_return args->m_counter;
+    }
 }

--- a/src/tool/cppwinrt/test_component/Class.h
+++ b/src/tool/cppwinrt/test_component/Class.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include "Class.g.h"
+#include "DeferrableEventArgs.g.h"
 
 namespace winrt::test_component::implementation
 {
@@ -107,10 +108,22 @@ namespace winrt::test_component::implementation
         int32_t NoexceptInt32() noexcept;
         hstring NoexceptString() noexcept;
 
+        event_token DeferrableEvent(Windows::Foundation::TypedEventHandler<test_component::Class, test_component::DeferrableEventArgs> const& handler);
+        void DeferrableEvent(event_token const& token);
+        Windows::Foundation::IAsyncOperation<int> RaiseDeferrableEventAsync();
     private:
 
         bool m_fail{};
+        event<Windows::Foundation::TypedEventHandler<test_component::Class, test_component::DeferrableEventArgs>> m_deferrableEvent;
     };
+
+    struct DeferrableEventArgs : DeferrableEventArgsT<DeferrableEventArgs>, deferrable_event_args<DeferrableEventArgs>
+    {
+        DeferrableEventArgs() = default;
+        void IncrementCounter() { ++m_counter; }
+        std::atomic<int> m_counter = 0;
+    };
+
 }
 namespace winrt::test_component::factory_implementation
 {

--- a/src/tool/cppwinrt/test_component/test_component.idl
+++ b/src/tool/cppwinrt/test_component/test_component.idl
@@ -56,6 +56,12 @@ namespace test_component
         Object Object(Windows.Foundation.DateTime value);
     }
 
+    runtimeclass DeferrableEventArgs
+    {
+        Windows.Foundation.Deferral GetDeferral();
+        void IncrementCounter();
+    }
+
     runtimeclass Class
     {
         Class();
@@ -137,6 +143,9 @@ namespace test_component
         [noexcept2] void NoexceptVoid();
         [noexcept2] Int32 NoexceptInt32();
         [noexcept2] String NoexceptString();
+
+        event Windows.Foundation.TypedEventHandler<Class, DeferrableEventArgs> DeferrableEvent;
+        Windows.Foundation.IAsyncOperation<Int32> RaiseDeferrableEventAsync();
     }
 
     namespace Structs


### PR DESCRIPTION
## Introduction

A common pattern in the Windows Runtime is the deferrable event. An event handler "takes a deferral" by calling the event argument's `GetDeferral()` method. Doing so indicates to the event source that post-event activities should be postponed until the deferral is completed. This allows an event handler to perform asynchronous actions in response to an event.

The `deferrable_event_args<T>` template class simplifies implementation of deferrable events.

## Example

```cs
// Widget.idl

namespace Sample
{
    runtimeclass WidgetStartingEventArgs
    {
        Windows.Foundation.Deferral GetDeferral();
        Boolean Cancel;
    };

    runtimeclass Widget
    {
        event Windows.Foundation.TypedEventHandler<
            Widget, WidgetStartingEventArgs> Starting;
    };
}
```
```cpp
// Widget.h

namespace winrt::Sample::implementation
{
    struct Widget : WidgetT<Widget>
    {
        Widget() = default;

        event_token Starting(Windows::Foundation::TypedEventHandler<
            Sample::Widget, Sample::WidgetStartingEventArgs> const& handler)
        {
            return m_starting.add(handler);
        }
        void Starting(event_token const& token) noexcept
        {
            m_starting.remove(token);
        }

    private:
        event<Windows::Foundation::TypedEventHandler<
            Sample::Widget, Sample::WidgetStartingEventArgs>> m_starting;
    };

    struct WidgetStartingEventArgs : WidgetStartingEventArgsT<WidgetStartingEventArgs>,
                                     deferrable_event_args<WidgetStartingEventArgs>
    //                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    {
        bool Cancel() const noexcept { return m_cancel; }
        void Cancel(bool value) noexcept { m_cancel = value; }
        bool m_cancel = false;
    };
}
```

Consuming the deferrable event pattern:

```cpp
widget.Starting([](auto sender, auto args) -> fire_and_forget
{
    auto deferral = args.GetDeferral();
    if (!co_await CanWidgetStartAsync(sender))
    {
        // Do not allow the widget to start.
        args.Cancel(true);
    }
    deferral.Complete();
});
```

Producing the deferrable event pattern is made easier with the `deferrable_event_args<T>` base class. The `deferrable_event_args<T>` implements `T::GetDeferral` and exposes a new helper method `wait_for_deferrals()` which completes when all outstanding deferrals have completed. (If no deferrals were taken, then it completes immediately.)

```cpp
IAsyncOperation<bool> TryStartWidget(Widget const& widget)
{
    auto args = make_self<WidgetStartingEventArgs>();
    // Raise the event to let people know that the widget is starting
    // and give them a chance to prevent it.
    m_starting(widget, *args);
    // Wait for deferrals to complete.
    co_await args->wait_for_deferrals();
    // Use the results.
    bool started = false;
    if (!args->Cancel())
    {
        widget.InsertBattery();
        widget.FlipPowerSwitch();
        started = true;
    }
    co_return started;
}
```

## Implementation notes

The `deferrable_event_args<T>::wait_for_deferrals()` method returns `IAsyncAction` so that the caller's `co_await` will preserve apartment context. 

When the last deferral completes, we queue the continuation on a background thread so as to release the caller of `deferral.Complete()`. We don't want to commandeer the event handler's thread for our post-event activities.

This addresses #412