### PR TITLE
Fixed "local" regression with std::filesystem::canonical

### DIFF
--- a/src/library/cmd_reader.h
+++ b/src/library/cmd_reader.h
@@ -116,7 +116,7 @@ namespace xlang::cmd
                 {
                     if (std::filesystem::is_regular_file(file))
                     {
-                        auto filename = std::filesystem::canonical(file.path()).string();
+                        auto filename = file.path().string();
 
                         if (directory_filter(filename))
                         {


### PR DESCRIPTION
unlike std::experimental::filesystem::canonical, std::filesystem::canonical does not maintain the path c:\windows\SysNative\WinMetadata but redirects it to c:\windows\system32\WinMetadata, which is inaccessible to syswow64 processes.  Note that both calls to add_directory already supply canonical paths, so canonicalizing their contents is redundant.