### PR TITLE
winrt::params::hstring optimizes empty strings

### DIFF
--- a/src/tool/cppwinrt/strings/base_string_input.h
+++ b/src/tool/cppwinrt/strings/base_string_input.h
@@ -16,7 +16,7 @@ namespace winrt::param
 
         hstring(std::wstring_view const& value) noexcept
         {
-            if (impl::error_ok != WINRT_WindowsCreateStringReference(value.data(), static_cast<uint32_t>(value.size()), &m_header, &m_handle))
+            if (impl::error_ok != create_string_reference(value.data(), value.size()))
             {
                 std::terminate();
             }
@@ -24,12 +24,12 @@ namespace winrt::param
 
         hstring(std::wstring const& value) noexcept
         {
-            WINRT_VERIFY_(impl::error_ok, WINRT_WindowsCreateStringReference(value.data(), static_cast<uint32_t>(value.size()), &m_header, &m_handle));
+            WINRT_VERIFY_(impl::error_ok, create_string_reference(value.data(), value.size()));
         }
 
         hstring(wchar_t const* const value) noexcept
         {
-            WINRT_VERIFY_(impl::error_ok, WINRT_WindowsCreateStringReference(value, static_cast<uint32_t>(wcslen(value)), &m_header, &m_handle));
+            WINRT_VERIFY_(impl::error_ok, create_string_reference(value, wcslen(value)));
         }
 
         operator winrt::hstring const&() const noexcept
@@ -38,6 +38,19 @@ namespace winrt::param
         }
 
     private:
+        int32_t create_string_reference(wchar_t const* const data, size_t size) noexcept
+        {
+            auto size32 = static_cast<uint32_t>(size);
+            if (size32 == 0)
+            {
+                m_handle = nullptr;
+                return impl::error_ok;
+            }
+            else
+            {
+                return WINRT_WindowsCreateStringReference(data, size32, &m_header, &m_handle);
+            }
+        }
 
         struct header
         {

--- a/src/tool/cppwinrt/test/in_params.cpp
+++ b/src/tool/cppwinrt/test/in_params.cpp
@@ -43,4 +43,10 @@ TEST_CASE("in_params")
     REQUIRE(object.InStringableArray({ make<Value>(1), make<Value>(2) }) == L"12");
     REQUIRE(object.InStructArray({ {L"1",L"2"}, {L"3",L"4"} }) == L"1234");
     REQUIRE(object.InEnumArray({ Signed::First, Signed::Second }) == L"FirstSecond");
+
+    // params::hstring optimizations
+    REQUIRE(object.InString(L"") == L"");
+    REQUIRE(object.InString({}) == L"");
+    wchar_t non_const_string[1] = { L'\0' };
+    REQUIRE(object.InString(non_const_string) == L"");
 }


### PR DESCRIPTION
If the string is empty, then go straight to `nullptr`. This avoids a call to `WindowsCreateString` when the app passes a literal like `L""`, which is much more natural than passing `{}`.

Fixes issue #556 