### PR TITLE
deferrable_event_args resumes coroutine with resume_background

### DIFF
--- a/src/tool/cppwinrt/strings/base_deferral.h
+++ b/src/tool/cppwinrt/strings/base_deferral.h
@@ -52,7 +52,7 @@ namespace winrt
 
             if (resume)
             {
-                resume_background().await_suspend(resume);
+                impl::resume_background(resume);
             }
         }
 


### PR DESCRIPTION
Use the new `winrt::impl::resume_background()` helper function instead of the previous sneaky trick of reaching into the guts of the `winrt::resume_background()` hidden awaiter.

This completes the work begun in #545 