### PR TITLE
Ensure the platform winmds are always referenced.

### DIFF
--- a/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.props
+++ b/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.props
@@ -13,6 +13,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CppWinRTPackage Condition="'$(CppWinRTPackage)' != 'true'">false</CppWinRTPackage>
         <XamlLanguage>CppWinRT</XamlLanguage>
         <IsNativeLanguage>true</IsNativeLanguage>
+        <!-- This causes VS to add the platform WinMD refetrences for the target SDK -->
+        <WinMDAssembly>true</WinMDAssembly>
     </PropertyGroup>
 
     <!-- For a static library we don't want the winmd/lib/pdb to be packaged -->

--- a/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.props
+++ b/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.props
@@ -13,7 +13,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CppWinRTPackage Condition="'$(CppWinRTPackage)' != 'true'">false</CppWinRTPackage>
         <XamlLanguage>CppWinRT</XamlLanguage>
         <IsNativeLanguage>true</IsNativeLanguage>
-        <!-- This causes VS to add the platform WinMD refetrences for the target SDK -->
+        <!-- This causes VS to add the platform WinMD references for the target SDK -->
         <WinMDAssembly>true</WinMDAssembly>
     </PropertyGroup>
 

--- a/src/test/package/nuget/NuGetTest/NuGetTest.sln
+++ b/src/test/package/nuget/NuGetTest/NuGetTest.sln
@@ -29,6 +29,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestRuntimeComponentCX", "T
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestStaticLibrary4", "TestStaticLibrary4\TestStaticLibrary4.vcxproj", "{432068A4-B206-4468-9254-446CCEB15A2C}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestRuntimeComponentEmpty", "TestRuntimeComponentEmpty\TestRuntimeComponentEmpty.vcxproj", "{8456C55F-BF01-4798-B79B-7388681C398F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -171,6 +173,20 @@ Global
 		{432068A4-B206-4468-9254-446CCEB15A2C}.Release|x64.Build.0 = Release|x64
 		{432068A4-B206-4468-9254-446CCEB15A2C}.Release|x86.ActiveCfg = Release|Win32
 		{432068A4-B206-4468-9254-446CCEB15A2C}.Release|x86.Build.0 = Release|Win32
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Debug|ARM.ActiveCfg = Debug|ARM
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Debug|ARM.Build.0 = Debug|ARM
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Debug|x64.ActiveCfg = Debug|x64
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Debug|x64.Build.0 = Debug|x64
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Debug|x86.ActiveCfg = Debug|Win32
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Debug|x86.Build.0 = Debug|Win32
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Release|ARM.ActiveCfg = Release|ARM
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Release|ARM.Build.0 = Release|ARM
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Release|ARM64.ActiveCfg = Release|Win32
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Release|x64.ActiveCfg = Release|x64
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Release|x64.Build.0 = Release|x64
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Release|x86.ActiveCfg = Release|Win32
+		{8456C55F-BF01-4798-B79B-7388681C398F}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/PropertySheet.props
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/PropertySheet.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <!--
+    To customize common C++/WinRT project properties: 
+    * right-click the project node
+    * expand the Common Properties item
+    * select the C++/WinRT property page
+
+    For more advanced scenarios, and complete documentation, please see:
+    https://github.com/Microsoft/xlang/tree/master/src/package/cppwinrt/nuget 
+    -->
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+</Project>

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.def
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.def
@@ -1,0 +1,3 @@
+﻿EXPORTS
+DllCanUnloadNow = WINRT_CanUnloadNow                    PRIVATE
+DllGetActivationFactory = WINRT_GetActivationFactory    PRIVATE

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
@@ -1,19 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <MinimalCoreWin>true</MinimalCoreWin>
-    <ProjectGuid>{a8bdbde9-1a3d-4f5e-8668-9f6e84790d44}</ProjectGuid>
-    <ProjectName>TestApp</ProjectName>
-    <RootNamespace>TestApp</RootNamespace>
+    <ProjectGuid>{8456c55f-bf01-4798-b79b-7388681c398f}</ProjectGuid>
+    <ProjectName>TestRuntimeComponentEmpty</ProjectName>
+    <RootNamespace>TestRuntimeComponentEmpty</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+    <CppWinRTParameters>-lib $(MSBuildProjectName)</CppWinRTParameters>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">
@@ -43,11 +45,12 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -61,6 +64,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -68,6 +73,7 @@
     <Import Project="PropertySheet.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -77,8 +83,15 @@
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
       <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
-      <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <DisableSpecificWarnings>28204</DisableSpecificWarnings>
+      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
+      <ModuleDefinitionFile>TestRuntimeComponentEmpty.def</ModuleDefinitionFile>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
@@ -92,54 +105,16 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
-    <ClInclude Include="App.h">
-      <DependentUpon>App.xaml</DependentUpon>
-    </ClInclude>
-    <ClInclude Include="MainPage.h">
-      <DependentUpon>MainPage.xaml</DependentUpon>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Page Include="MainPage.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest">
-      <SubType>Designer</SubType>
-    </AppxManifest>
-  </ItemGroup>
-  <ItemGroup>
-    <Image Include="Assets\LockScreenLogo.scale-200.png" />
-    <Image Include="Assets\SplashScreen.scale-200.png" />
-    <Image Include="Assets\Square150x150Logo.scale-200.png" />
-    <Image Include="Assets\Square44x44Logo.scale-200.png" />
-    <Image Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
-    <Image Include="Assets\StoreLogo.png" />
-    <Image Include="Assets\Wide310x150Logo.scale-200.png" />
-  </ItemGroup>
-  <ItemGroup>
+    <ClCompile Include="module.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="App.cpp">
-      <DependentUpon>App.xaml</DependentUpon>
-    </ClCompile>
-    <ClCompile Include="MainPage.cpp">
-      <DependentUpon>MainPage.xaml</DependentUpon>
-    </ClCompile>
-    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <Midl Include="App.idl">
-      <DependentUpon>App.xaml</DependentUpon>
-    </Midl>
-    <Midl Include="MainPage.idl">
-      <DependentUpon>MainPage.xaml</DependentUpon>
-    </Midl>
+    <None Include="packages.config" />
+    <None Include="TestRuntimeComponentEmpty.def" />
   </ItemGroup>
   <ItemGroup>
     <None Include="PropertySheet.props" />
@@ -148,24 +123,19 @@
     </Text>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\TestRuntimeComponent1\TestRuntimeComponent1.vcxproj">
-      <Project>{e0ebbe54-c046-4611-b048-3ce893b1df8a}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\TestRuntimeComponent2\TestRuntimeComponent2.vcxproj">
-      <Project>{4bbb2de7-4596-4da6-a923-e65e838363b5}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\TestRuntimeComponentCX\TestRuntimeComponentCX.vcxproj">
-      <Project>{adc53200-b456-4386-9851-5bf69dfb8928}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\TestRuntimeComponentEmpty\TestRuntimeComponentEmpty.vcxproj">
-      <Project>{8456c55f-bf01-4798-b79b-7388681c398f}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\TestStaticLibrary1\TestStaticLibrary1.vcxproj">
-      <Project>{2158f418-ca97-4599-8103-efc133850baa}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\TestStaticLibrary4\TestStaticLibrary4.vcxproj">
       <Project>{432068a4-b206-4468-9254-446cceb15a2c}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190730.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
 </Project>

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj.filters
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resources">
+      <UniqueIdentifier>accd3aa8-1ba0-4223-9bbe-0c431709210b</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tga;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Generated Files">
+      <UniqueIdentifier>{926ab91d-31b4-48c3-b9a4-e681349f27f0}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp" />
+    <ClCompile Include="Class.cpp" />
+    <ClCompile Include="module.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestRuntimeComponentEmpty.def" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="PropertySheet.props" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="readme.txt" />
+  </ItemGroup>
+</Project>

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/module.cpp
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/module.cpp
@@ -1,0 +1,58 @@
+#include "pch.h"
+#include "winrt/base.h"
+
+bool __stdcall winrt_can_unload_now() noexcept
+{
+    if (winrt::get_module_lock())
+    {
+        return false;
+    }
+
+    winrt::clear_factory_cache();
+    return true;
+}
+
+void* __stdcall TestStaticLibrary4_get_activation_factory(std::wstring_view const& name);
+
+void* __stdcall winrt_get_activation_factory(std::wstring_view const& name)
+{
+    void* factory = TestStaticLibrary4_get_activation_factory(name);
+    if (factory)
+    {
+        return factory;
+    }
+
+    return nullptr;
+}
+
+int32_t __stdcall WINRT_CanUnloadNow() noexcept
+{
+#ifdef _WRL_MODULE_H_
+    if (!::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().Terminate())
+    {
+        return 1;
+    }
+#endif
+
+    return winrt_can_unload_now() ? 0 : 1;
+}
+
+int32_t __stdcall WINRT_GetActivationFactory(void* classId, void** factory) noexcept try
+{
+    uint32_t length{};
+    wchar_t const* const buffer = WINRT_WindowsGetStringRawBuffer(classId, &length);
+    std::wstring_view const name{ buffer, length };
+    *factory = winrt_get_activation_factory(name);
+
+    if (*factory)
+    {
+        return 0;
+    }
+
+#ifdef _WRL_MODULE_H_
+    return ::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().GetActivationFactory(static_cast<HSTRING>(classId), reinterpret_cast<::IActivationFactory * *>(factory));
+#else
+    return winrt::hresult_class_not_available(name).to_abi();
+#endif
+}
+catch (...) { return winrt::to_hresult(); }

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/packages.config
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.190730.2" targetFramework="native" />
+</packages>

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/pch.cpp
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/pch.cpp
@@ -1,0 +1,1 @@
+﻿#include "pch.h"

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/pch.h
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/pch.h
@@ -1,0 +1,11 @@
+﻿#pragma once
+#include <unknwn.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Data.h>
+#include <winrt/Windows.UI.Xaml.Interop.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
+#include <winrt/Windows.UI.Xaml.Navigation.h>

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/readme.txt
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/readme.txt
@@ -1,0 +1,23 @@
+========================================================================
+    C++/WinRT TestRuntimeComponentEmpty Project Overview
+========================================================================
+
+This project demonstrates how to get started authoring Windows Runtime 
+classes directly with standard C++, using the C++/WinRT SDK component 
+to generate implementation headers from interface (IDL) files.  The
+generated Windows Runtime component binary and WinMD files should then
+be bundled with the Universal Windows Platform (UWP) app consuming them.
+
+Steps:
+1. Create an interface (IDL) file to define your Windows Runtime class, 
+    its default interface, and any other interfaces it implements.
+2. Build the project once to generate module.g.cpp, module.h.cpp, and
+    implementation templates under the "Generated Files" folder, as 
+    well as skeleton class definitions under "Generated Files\sources".  
+3. Use the skeleton class definitions for reference to implement your
+    Windows Runtime classes.
+
+========================================================================
+Learn more about C++/WinRT here:
+http://aka.ms/cppwinrt/
+========================================================================

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary4/TestStaticLibrary4Class.cpp
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary4/TestStaticLibrary4Class.cpp
@@ -5,10 +5,12 @@
 #endif
 
 using namespace winrt;
+using namespace winrt::Windows::UI::Xaml::Core::Direct;
 
 namespace winrt::TestApp::implementation
 {
-    void TestStaticLibrary4Class::Test()
+    XamlDirect TestStaticLibrary4Class::Test()
     {
+        return XamlDirect::GetDefault();
     }
 }

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary4/TestStaticLibrary4Class.h
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary4/TestStaticLibrary4Class.h
@@ -8,7 +8,7 @@ namespace winrt::TestApp::implementation
     {
         TestStaticLibrary4Class() = default;
 
-        void Test();
+        Windows::UI::Xaml::Core::Direct::XamlDirect Test();
     };
 }
 

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary4/TestStaticLibrary4Class.idl
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary4/TestStaticLibrary4Class.idl
@@ -5,6 +5,6 @@ namespace TestApp
     {
         TestStaticLibrary4Class();
 
-        void Test();
+        Windows.UI.Xaml.Core.Direct.XamlDirect Test();
     }
 }

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary4/pch.h
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary4/pch.h
@@ -7,3 +7,4 @@
 #endif
 
 #include <winrt/base.h>
+#include <winrt/Windows.UI.Xaml.Core.Direct.h>


### PR DESCRIPTION
The VS build targets only add the platform WinMD references if the following result is not empty:

```
@(ClCompile->WithMetadataValue('CompileAsWinRT', 'true'))@(Midl->WithMetadataValue('EnableWindowsRuntime', 'true'))'
```

For projects where the dll project is empty and all idl and code is in a static library, this evaluates to false resulting in missing references. 
Since we always want to reference the platform WinMDs, we set WinMDAssembly to true which causes the VS targets to do the right thing.