### PR TITLE
Improve C++/WinRT's call_factory compile speed

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -2741,33 +2741,6 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         }
     }
 
-    static void write_call_factory(writer& w, std::string_view const& class_name, TypeDef const& factory, method_signature const& signature)
-    {
-        if (signature.params().empty())
-        {
-            auto format = "impl::call_factory<%, %>(static_cast<%(*)(% const&)>([](% const& f) { return f.%(); }))";
-
-            w.write(format,
-                class_name,
-                factory,
-                signature.return_signature(),
-                factory,
-                factory,
-                get_name(signature.method()));
-        }
-        else
-        {
-            auto format = "impl::call_factory<%, %>([&](% const& f) { return f.%(%); })";
-
-            w.write(format,
-                class_name,
-                factory,
-                factory,
-                get_name(signature.method()),
-                bind<write_consume_args>(signature));
-        }
-    }
-
     static void write_constructor_definition(writer& w, MethodDef const& method, std::string_view const& type_name, TypeDef const& factory)
     {
         w.async_types = false;
@@ -2775,7 +2748,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         method_signature signature{ method };
 
         auto format = R"(    inline %::%(%) :
-        %(%)
+        %(impl::call_factory<%, %>([&](% const& f) { return f.%(%); }))
     {
     }
 )";
@@ -2785,7 +2758,11 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             type_name,
             bind<write_consume_params>(signature),
             type_name,
-            bind<write_call_factory>(type_name, factory, signature));
+            type_name,
+            factory,
+            factory,
+            get_name(method),
+            bind<write_consume_args>(signature));
     }
 
     static void write_composable_constructor_definition(writer& w, MethodDef const& method, std::string_view const& type_name, TypeDef const& factory)
@@ -2877,7 +2854,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         {
             auto format = R"(    inline auto %::%(%)
     {
-        %%;
+        %impl::call_factory<%, %>([&](% const& f) { return f.%(%); });
     }
 )";
 
@@ -2886,7 +2863,11 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                 method_name,
                 bind<write_consume_params>(signature),
                 signature.return_signature() ? "return " : "",
-                bind<write_call_factory>(type_name, factory, signature));
+                type_name,
+                factory,
+                factory,
+                method_name,
+                bind<write_consume_args>(signature));
         }
 
         if (is_add_overload(method))
@@ -2931,7 +2912,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                     if (has_fastabi(type))
                     {
                         format = R"(    inline %::%() :
-        %(impl::call_factory<%>(static_cast<%(*)(Windows::Foundation::IActivationFactory const&)>([](Windows::Foundation::IActivationFactory const& f) { return impl::fast_activate<%>(f); })))
+        %(impl::call_factory<%>([](Windows::Foundation::IActivationFactory const& f) { return impl::fast_activate<%>(f); }))
     {
     }
 )";
@@ -2939,14 +2920,13 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                     else
                     {
                         format = R"(    inline %::%() :
-        %(impl::call_factory<%>(static_cast<%(*)(Windows::Foundation::IActivationFactory const&)>([](Windows::Foundation::IActivationFactory const& f) { return f.template ActivateInstance<%>(); })))
+        %(impl::call_factory<%>([](Windows::Foundation::IActivationFactory const& f) { return f.template ActivateInstance<%>(); }))
     {
     }
 )";
                     }
 
                     w.write(format,
-                        type_name,
                         type_name,
                         type_name,
                         type_name,

--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -1957,7 +1957,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
     {
         auto format = R"(        %T(%)
         {
-            impl::call_factory<%, %>([&](auto&& f) { f.%(%%*this, this->m_inner); });
+            impl::call_factory<%, %>([&](% const& f) { f.%(%%*this, this->m_inner); });
         }
 )";
 
@@ -1978,6 +1978,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                     type_name,
                     bind<write_consume_params>(signature),
                     type_name,
+                    factory_name,
                     factory_name,
                     get_name(method),
                     bind<write_consume_args>(signature),
@@ -2747,7 +2748,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         method_signature signature{ method };
 
         auto format = R"(    inline %::%(%) :
-        %(impl::call_factory<%, %>([&](auto&& f) { return f.%(%); }))
+        %(impl::call_factory<%, %>([&](% const& f) { return f.%(%); }))
     {
     }
 )";
@@ -2758,6 +2759,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             bind<write_consume_params>(signature),
             type_name,
             type_name,
+            factory,
             factory,
             get_name(method),
             bind<write_consume_args>(signature));
@@ -2775,7 +2777,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         auto format = R"(    inline %::%(%)
     {
         Windows::Foundation::IInspectable %, %;
-        *this = impl::call_factory<%, %>([&](auto&& f) { return f.%(%%%, %); });
+        *this = impl::call_factory<%, %>([&](% const& f) { return f.%(%%%, %); });
     }
 )";
 
@@ -2786,6 +2788,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             base_param,
             inner_param,
             type_name,
+            factory,
             factory,
             get_name(method),
             bind<write_consume_args>(signature),
@@ -2851,7 +2854,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         {
             auto format = R"(    inline auto %::%(%)
     {
-        %impl::call_factory<%, %>([&](auto&& f) { return f.%(%); });
+        %impl::call_factory<%, %>([&](% const& f) { return f.%(%); });
     }
 )";
 
@@ -2861,6 +2864,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                 bind<write_consume_params>(signature),
                 signature.return_signature() ? "return " : "",
                 type_name,
+                factory,
                 factory,
                 method_name,
                 bind<write_consume_args>(signature));
@@ -2908,7 +2912,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                     if (has_fastabi(type))
                     {
                         format = R"(    inline %::%() :
-        %(impl::call_factory<%>([](auto&& f) { return impl::fast_activate<%>(f); }))
+        %(impl::call_factory<%>([](Windows::Foundation::IActivationFactory const& f) { return impl::fast_activate<%>(f); }))
     {
     }
 )";
@@ -2916,7 +2920,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                     else
                     {
                         format = R"(    inline %::%() :
-        %(impl::call_factory<%>([](auto&& f) { return f.template ActivateInstance<%>(); }))
+        %(impl::call_factory<%>([](Windows::Foundation::IActivationFactory const& f) { return f.template ActivateInstance<%>(); }))
     {
     }
 )";

--- a/src/tool/cppwinrt/cppwinrt/component_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/component_writers.h
@@ -609,7 +609,7 @@ catch (...) { return winrt::to_hresult(); }
 
                 auto format = R"(        %_base(%)
         {
-            impl::call_factory<%, %>([&](auto&& f) { f.%(%%*this, this->m_inner); });
+            impl::call_factory<%, %>([&](% const& f) { f.%(%%*this, this->m_inner); });
         }
 )";
 
@@ -617,6 +617,7 @@ catch (...) { return winrt::to_hresult(); }
                     type_name,
                     bind<write_consume_params>(signature),
                     base_type,
+                    factory_name,
                     factory_name,
                     get_name(method),
                     bind<write_consume_args>(signature),

--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -360,10 +360,10 @@ namespace winrt
         // Normally, the callback avoids having to return a ref-counted object and the resulting AddRef/Release bump.
         // In this case we do want a unique reference, so we use the lambda to return one and thus produce an
         // AddRef'd object that is returned to the caller. 
-        return impl::call_factory<Class, Interface>([](Interface const& factory)
+        return impl::call_factory<Class, Interface>(static_cast<Interface(*)(Interface const&)>([](Interface const& factory)
         {
             return factory;
-        });
+        }));
     }
 
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>

--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -363,7 +363,7 @@ namespace winrt
         // Normally, the callback avoids having to return a ref-counted object and the resulting AddRef/Release bump.
         // In this case we do want a unique reference, so we use the lambda to return one and thus produce an
         // AddRef'd object that is returned to the caller. 
-        return impl::call_factory<Class, Interface>([](auto&& factory)
+        return impl::call_factory<Class, Interface>([](Interface const& factory)
         {
             return factory;
         });

--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -360,10 +360,10 @@ namespace winrt
         // Normally, the callback avoids having to return a ref-counted object and the resulting AddRef/Release bump.
         // In this case we do want a unique reference, so we use the lambda to return one and thus produce an
         // AddRef'd object that is returned to the caller. 
-        return impl::call_factory<Class, Interface>(static_cast<Interface(*)(Interface const&)>([](Interface const& factory)
+        return impl::call_factory<Class, Interface>([](Interface const& factory)
         {
             return factory;
-        }));
+        });
     }
 
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>


### PR DESCRIPTION
The Visual C++ team pointed out that since `winrt::impl::call_factory` is the most heavily specialized function template, there are some tweaks that can be made to optimize build performance.

1. Avoid generic lambdas, which require more time and space to compile. 
2. ~~Cast stateless lambdas to function pointers to avoid additional specializations of the `factory_cache_entry::call` function template.~~
3. Move much of `factory_cache_entry` into a non-template base class as much of it does not depend on template arguments.

These changes shave a few more seconds off the time it takes to compile a large PCH and reduces the PCH in my tests by 246MB. This is almost 10% of the size of the PCH so this is a significant win.

Note that while (2) has a big impact on compiler time, it affects inlining/performance so I'm still investigating how to avoid that. Ideally, I wouldn't need to try so hard to "help" the compiler and the compiler could just be smarter and help itself. As it stands, the PR reduces the PCH in my tests by 91MB. 