### PR TITLE
Fix dart build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
+project(xlang)
 
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
     cmake_policy(SET CMP0076 NEW)


### PR DESCRIPTION
The cmake warning about a missing project name seems to be failing the internal build.