### PR TITLE
Use non-type template arguments wherever possible in C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/strings/base_collections.h
+++ b/src/tool/cppwinrt/strings/base_collections.h
@@ -98,7 +98,7 @@ namespace winrt::impl
         static constexpr bool value = get_value<T>(0);
     };
 
-    template <typename T, std::enable_if_t<!has_GetAt<T>::value>* = nullptr>
+    template <typename T, std::enable_if_t<!has_GetAt<T>::value, int> = 0>
     auto begin(T const& collection) -> decltype(collection.First())
     {
         auto result = collection.First();
@@ -111,31 +111,31 @@ namespace winrt::impl
         return result;
     }
 
-    template <typename T, std::enable_if_t<!has_GetAt<T>::value>* = nullptr>
+    template <typename T, std::enable_if_t<!has_GetAt<T>::value, int> = 0>
     auto end([[maybe_unused]] T const& collection) noexcept -> decltype(collection.First())
     {
         return {};
     }
 
-    template <typename T, std::enable_if_t<has_GetAt<T>::value>* = nullptr>
+    template <typename T, std::enable_if_t<has_GetAt<T>::value, int> = 0>
     fast_iterator<T> begin(T const& collection) noexcept
     {
         return { collection, 0 };
     }
 
-    template <typename T, std::enable_if_t<has_GetAt<T>::value>* = nullptr>
+    template <typename T, std::enable_if_t<has_GetAt<T>::value, int> = 0>
     fast_iterator<T> end(T const& collection)
     {
         return { collection, collection.Size() };
     }
 
-    template <typename T, std::enable_if_t<has_GetAt<T>::value>* = nullptr>
+    template <typename T, std::enable_if_t<has_GetAt<T>::value, int> = 0>
     rfast_iterator<T> rbegin(T const& collection) noexcept
     {
         return { collection, collection.Size() - 1 };
     }
 
-    template <typename T, std::enable_if_t<has_GetAt<T>::value>* = nullptr>
+    template <typename T, std::enable_if_t<has_GetAt<T>::value, int> = 0>
     rfast_iterator<T> rend(T const& collection)
     {
         return { collection, -1 };

--- a/src/tool/cppwinrt/strings/base_collections_input_iterable.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_iterable.h
@@ -92,7 +92,7 @@ namespace winrt::param
             attach_abi(m_pair.first, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         iterable(Collection const& values) noexcept
         {
             m_pair.first = values;
@@ -112,7 +112,7 @@ namespace winrt::param
         {
         }
 
-        template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>>* = nullptr>
+        template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>, int> = 0>
         iterable(std::initializer_list<U> values) : m_pair(impl::make_scoped_input_iterable<value_type>(values.begin(), values.end()))
         {
         }
@@ -164,7 +164,7 @@ namespace winrt::param
             attach_abi(m_pair.first, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         iterable(Collection const& values) noexcept
         {
             m_pair.first = values;
@@ -247,7 +247,7 @@ namespace winrt::param
             attach_abi(m_interface, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         async_iterable(Collection const& values) noexcept
         {
             m_interface = values;
@@ -301,7 +301,7 @@ namespace winrt::param
             attach_abi(m_interface, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         async_iterable(Collection const& values) noexcept
         {
             m_interface = values;

--- a/src/tool/cppwinrt/strings/base_collections_input_map.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_map.h
@@ -54,7 +54,7 @@ namespace winrt::param
             attach_abi(m_interface, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         map(Collection const& values) noexcept
         {
             m_interface = values;

--- a/src/tool/cppwinrt/strings/base_collections_input_map_view.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_map_view.h
@@ -91,7 +91,7 @@ namespace winrt::param
             attach_abi(m_pair.first, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         map_view(Collection const& values) noexcept
         {
             m_pair.first = values;
@@ -169,7 +169,7 @@ namespace winrt::param
             attach_abi(m_interface, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         async_map_view(Collection const& values) noexcept
         {
             m_interface = values;

--- a/src/tool/cppwinrt/strings/base_collections_input_vector.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_vector.h
@@ -48,7 +48,7 @@ namespace winrt::param
             attach_abi(m_interface, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         vector(Collection const& values) noexcept
         {
             m_interface = values;

--- a/src/tool/cppwinrt/strings/base_collections_input_vector_view.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_vector_view.h
@@ -86,7 +86,7 @@ namespace winrt::param
             attach_abi(m_pair.first, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         vector_view(Collection const& values) noexcept
         {
             m_pair.first = values;
@@ -106,7 +106,7 @@ namespace winrt::param
         {
         }
 
-        template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>>* = nullptr>
+        template <typename U, std::enable_if_t<std::is_convertible_v<U, value_type>, int> = 0>
         vector_view(std::initializer_list<U> values) : m_pair(impl::make_scoped_input_vector_view<value_type>(values.begin(), values.end()))
         {
         }
@@ -164,7 +164,7 @@ namespace winrt::param
             attach_abi(m_interface, winrt::get_abi(values));
         }
 
-        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>>* = nullptr>
+        template <typename Collection, std::enable_if_t<std::is_convertible_v<Collection, interface_type>, int> = 0>
         async_vector_view(Collection const& values) noexcept
         {
             m_interface = values;

--- a/src/tool/cppwinrt/strings/base_reference_produce.h
+++ b/src/tool/cppwinrt/strings/base_reference_produce.h
@@ -260,7 +260,7 @@ namespace winrt
         return Windows::Foundation::IReference<hstring>(*(hstring*)(&value));
     }
 
-    template <typename T, typename = std::enable_if_t<!std::is_convertible_v<T, param::hstring>>>
+    template <typename T, std::enable_if_t<!std::is_convertible_v<T, param::hstring>, int> = 0>
     Windows::Foundation::IInspectable box_value(T const& value)
     {
         if constexpr (std::is_base_of_v<Windows::Foundation::IInspectable, T>)
@@ -311,7 +311,7 @@ namespace winrt
         return *(hstring*)(&default_value);
     }
 
-    template <typename T, typename = std::enable_if_t<!std::is_same_v<T, hstring>>>
+    template <typename T, std::enable_if_t<!std::is_same_v<T, hstring>, int> = 0>
     T unbox_value_or(Windows::Foundation::IInspectable const& value, T const& default_value)
     {
         if (value)

--- a/src/tool/cppwinrt/strings/base_string.h
+++ b/src/tool/cppwinrt/strings/base_string.h
@@ -452,7 +452,7 @@ namespace winrt
         return value;
     }
 
-    template <typename T, typename = std::enable_if_t<std::is_same_v<T, bool>>>
+    template <typename T, std::enable_if_t<std::is_same_v<T, bool>, int> = 0>
     hstring to_hstring(T const value)
     {
         if (value)
@@ -475,7 +475,7 @@ namespace winrt
         return hstring{ buffer };
     }
 
-    template <typename T, typename = std::enable_if_t<std::is_convertible_v<T, std::string_view>>>
+    template <typename T, std::enable_if_t<std::is_convertible_v<T, std::string_view>, int> = 0>
     hstring to_hstring(T const& value)
     {
         std::string_view const view(value);

--- a/src/tool/cppwinrt/strings/base_windows.h
+++ b/src/tool/cppwinrt/strings/base_windows.h
@@ -240,13 +240,13 @@ namespace winrt::Windows::Foundation
 
 namespace winrt
 {
-    template <typename T, typename = std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>>>
+    template <typename T, std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>, int> = 0>
     auto get_abi(T const& object) noexcept
     {
         return reinterpret_cast<impl::abi_t<T> const&>(object);
     }
 
-    template <typename T, typename = std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>>>
+    template <typename T, std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>, int> = 0>
     auto put_abi(T& object) noexcept
     {
         if constexpr (!std::is_trivially_destructible_v<T>)
@@ -257,19 +257,19 @@ namespace winrt
         return reinterpret_cast<impl::abi_t<T>*>(&object);
     }
 
-    template <typename T, typename V, typename = std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>>>
+    template <typename T, typename V, std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>, int> = 0>
     void copy_from_abi(T& object, V&& value)
     {
         object = reinterpret_cast<T const&>(value);
     }
 
-    template <typename T, typename V, typename = std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>>>
+    template <typename T, typename V, std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>, int> = 0>
     void copy_to_abi(T const& object, V& value)
     {
         reinterpret_cast<T&>(value) = object;
     }
 
-    template <typename T, typename = std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, std::decay_t<T>> && !std::is_convertible_v<T, std::wstring_view>>>
+    template <typename T, std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, std::decay_t<T>> && !std::is_convertible_v<T, std::wstring_view>, int> = 0>
     auto detach_abi(T&& object)
     {
         impl::abi_t<T> result{};


### PR DESCRIPTION
Non-type template arguments eliminates most of the overhead related to re-parsing that currently plagues the Visual C++ compiler. This update simply makes use of non-type template arguments more consistently.