### PR TITLE
Enable C++ module support in C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -118,7 +118,7 @@ namespace xlang
 
     static void write_type_namespace(writer& w, std::string_view const& ns)
     {
-        auto format = R"(namespace winrt::@
+        auto format = R"(WINRT_EXPORT namespace winrt::@
 {
 )";
 

--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename Interface = Windows::Foundation::IActivationFactory>
     impl::com_ref<Interface> get_activation_factory(param::hstring const& name)
@@ -331,7 +331,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     enum class apartment_type : int32_t
     {

--- a/src/tool/cppwinrt/strings/base_agile_ref.h
+++ b/src/tool/cppwinrt/strings/base_agile_ref.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     struct agile_ref

--- a/src/tool/cppwinrt/strings/base_array.h
+++ b/src/tool/cppwinrt/strings/base_array.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     struct array_view
@@ -446,7 +446,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     auto detach_abi(uint32_t* __valueSize, impl::arg_out<T>* value) noexcept

--- a/src/tool/cppwinrt/strings/base_chrono.h
+++ b/src/tool/cppwinrt/strings/base_chrono.h
@@ -4,7 +4,7 @@ namespace winrt::impl
     using filetime_period = std::ratio_multiply<std::ratio<100>, std::nano>;
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct clock;
 
@@ -48,7 +48,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct file_time
     {

--- a/src/tool/cppwinrt/strings/base_collections_base.h
+++ b/src/tool/cppwinrt/strings/base_collections_base.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename D, typename T, typename Version = impl::no_collection_version>
     struct iterable_base : Version

--- a/src/tool/cppwinrt/strings/base_collections_input_iterable.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_iterable.h
@@ -72,7 +72,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt::param
+WINRT_EXPORT namespace winrt::param
 {
     template <typename T>
     struct iterable

--- a/src/tool/cppwinrt/strings/base_collections_input_map.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_map.h
@@ -34,7 +34,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt::param
+WINRT_EXPORT namespace winrt::param
 {
     template <typename K, typename V>
     struct map

--- a/src/tool/cppwinrt/strings/base_collections_input_map_view.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_map_view.h
@@ -71,7 +71,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt::param
+WINRT_EXPORT namespace winrt::param
 {
     template <typename K, typename V>
     struct map_view

--- a/src/tool/cppwinrt/strings/base_collections_input_vector.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_vector.h
@@ -28,7 +28,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt::param
+WINRT_EXPORT namespace winrt::param
 {
     template <typename T>
     struct vector

--- a/src/tool/cppwinrt/strings/base_collections_input_vector_view.h
+++ b/src/tool/cppwinrt/strings/base_collections_input_vector_view.h
@@ -66,7 +66,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt::param
+WINRT_EXPORT namespace winrt::param
 {
     template <typename T>
     struct vector_view

--- a/src/tool/cppwinrt/strings/base_collections_map.h
+++ b/src/tool/cppwinrt/strings/base_collections_map.h
@@ -28,7 +28,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> single_threaded_map()

--- a/src/tool/cppwinrt/strings/base_collections_vector.h
+++ b/src/tool/cppwinrt/strings/base_collections_vector.h
@@ -257,7 +257,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T, typename Allocator = std::allocator<T>>
     Windows::Foundation::Collections::IVector<T> single_threaded_vector(std::vector<T, Allocator>&& values = {})

--- a/src/tool/cppwinrt/strings/base_com_ptr.h
+++ b/src/tool/cppwinrt/strings/base_com_ptr.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     struct com_ptr

--- a/src/tool/cppwinrt/strings/base_coroutine_foundation.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_foundation.h
@@ -177,7 +177,7 @@ namespace winrt::impl
 }
 
 #ifdef __cpp_coroutines
-namespace winrt::Windows::Foundation
+WINRT_EXPORT namespace winrt::Windows::Foundation
 {
     inline impl::await_adapter<IAsyncAction> operator co_await(IAsyncAction const& async)
     {
@@ -204,7 +204,7 @@ namespace winrt::Windows::Foundation
 }
 #endif
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct get_progress_token_t {};
 
@@ -679,7 +679,7 @@ namespace std::experimental
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename... T>
     Windows::Foundation::IAsyncAction when_all(T... async)

--- a/src/tool/cppwinrt/strings/base_coroutine_system.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_system.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     [[nodiscard]] inline auto resume_foreground(
         Windows::System::DispatcherQueue const& dispatcher,

--- a/src/tool/cppwinrt/strings/base_coroutine_threadpool.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_threadpool.h
@@ -15,7 +15,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     [[nodiscard]] inline auto resume_background() noexcept
     {

--- a/src/tool/cppwinrt/strings/base_coroutine_ui_core.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_ui_core.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     [[nodiscard]] inline auto resume_foreground(
         Windows::UI::Core::CoreDispatcher const& dispatcher,

--- a/src/tool/cppwinrt/strings/base_deferral.h
+++ b/src/tool/cppwinrt/strings/base_deferral.h
@@ -1,4 +1,5 @@
-namespace winrt
+
+WINRT_EXPORT namespace winrt
 {
 #ifdef __cpp_coroutines
     template<typename D>
@@ -7,6 +8,7 @@ namespace winrt
         Windows::Foundation::Deferral GetDeferral()
         {
             slim_lock_guard const guard(m_lock);
+
             if (m_handle)
             {
                 // Cannot ask for deferral after the event handler returned.
@@ -29,10 +31,12 @@ namespace winrt
 
                 deferrable_event_args& m_deferrable;
             };
+
             co_await awaitable{ {}, *this };
         }
 
     private:
+
         using coroutine_handle = std::experimental::coroutine_handle<>;
 
         void one_deferral_completed()
@@ -40,10 +44,12 @@ namespace winrt
             coroutine_handle resume = nullptr;
             {
                 slim_lock_guard const guard(m_lock);
+
                 if (m_outstanding_deferrals <= 0)
                 {
                     throw hresult_illegal_method_call();
                 }
+
                 if (--m_outstanding_deferrals == 0)
                 {
                     resume = m_handle;

--- a/src/tool/cppwinrt/strings/base_delegate.h
+++ b/src/tool/cppwinrt/strings/base_delegate.h
@@ -187,16 +187,16 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename... Args>
-    struct __declspec(empty_bases)delegate : impl::delegate_base<void, Args...>
+    struct __declspec(empty_bases) delegate : impl::delegate_base<void, Args...>
     {
         using impl::delegate_base<void, Args...>::delegate_base;
     };
 
     template <typename R, typename... Args>
-    struct __declspec(empty_bases)delegate<R(Args...)> : impl::delegate_base<R, Args...>
+    struct __declspec(empty_bases) delegate<R(Args...)> : impl::delegate_base<R, Args...>
     {
         using impl::delegate_base<R, Args...>::delegate_base;
     };

--- a/src/tool/cppwinrt/strings/base_dependencies.h
+++ b/src/tool/cppwinrt/strings/base_dependencies.h
@@ -18,10 +18,19 @@
 #include <vector>
 
 #if __has_include(<WindowsNumerics.impl.h>)
-#define WINRT_NUMERICS
+#define WINRT_IMPL_NUMERICS
 #include <directxmath.h>
+#endif
+
+#ifndef WINRT_EXPORT
+#define WINRT_EXPORT
+#else
+export module winrt;
+#endif
+
+#ifdef WINRT_IMPL_NUMERICS
 #define _WINDOWS_NUMERICS_NAMESPACE_ winrt::Windows::Foundation::Numerics
-#define _WINDOWS_NUMERICS_BEGIN_NAMESPACE_ namespace winrt::Windows::Foundation::Numerics
+#define _WINDOWS_NUMERICS_BEGIN_NAMESPACE_ WINRT_EXPORT namespace winrt::Windows::Foundation::Numerics
 #define _WINDOWS_NUMERICS_END_NAMESPACE_
 #include <WindowsNumerics.impl.h>
 #undef _WINDOWS_NUMERICS_NAMESPACE_

--- a/src/tool/cppwinrt/strings/base_error.h
+++ b/src/tool/cppwinrt/strings/base_error.h
@@ -59,7 +59,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct hresult_error
     {

--- a/src/tool/cppwinrt/strings/base_events.h
+++ b/src/tool/cppwinrt/strings/base_events.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct event_token
     {
@@ -360,7 +360,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename Delegate>
     struct event

--- a/src/tool/cppwinrt/strings/base_fast_forward.h
+++ b/src/tool/cppwinrt/strings/base_fast_forward.h
@@ -117,7 +117,7 @@ namespace winrt::impl
     static_assert(offsetof(fast_abi_forwarder, m_offset) == sizeof(fast_abi_forwarder::m_vfptr) + sizeof(fast_abi_forwarder::m_owner));
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template<typename TGuid>
     auto make_fast_abi_forwarder(void* owner, TGuid const& guid, size_t offset)

--- a/src/tool/cppwinrt/strings/base_fast_forward.h
+++ b/src/tool/cppwinrt/strings/base_fast_forward.h
@@ -117,7 +117,7 @@ namespace winrt::impl
     static_assert(offsetof(fast_abi_forwarder, m_offset) == sizeof(fast_abi_forwarder::m_vfptr) + sizeof(fast_abi_forwarder::m_owner));
 }
 
-WINRT_EXPORT namespace winrt
+namespace winrt
 {
     template<typename TGuid>
     auto make_fast_abi_forwarder(void* owner, TGuid const& guid, size_t offset)

--- a/src/tool/cppwinrt/strings/base_foundation.h
+++ b/src/tool/cppwinrt/strings/base_foundation.h
@@ -1,5 +1,5 @@
 
-namespace winrt::Windows::Foundation
+WINRT_EXPORT namespace winrt::Windows::Foundation
 {
     struct Point
     {
@@ -12,7 +12,7 @@ namespace winrt::Windows::Foundation
             : X(X), Y(Y)
         {}
 
-#ifdef WINRT_NUMERICS
+#ifdef WINRT_IMPL_NUMERICS
 
         constexpr Point(Numerics::float2 const& value) noexcept
             : X(value.x), Y(value.y)
@@ -47,7 +47,7 @@ namespace winrt::Windows::Foundation
             : Width(Width), Height(Height)
         {}
 
-#ifdef WINRT_NUMERICS
+#ifdef WINRT_IMPL_NUMERICS
 
         constexpr Size(Numerics::float2 const& value) noexcept
             : Width(value.x), Height(value.y)
@@ -132,7 +132,7 @@ namespace winrt::impl
         using type = struct_category<float, float, float, float>;
     };
 
-#ifdef WINRT_NUMERICS
+#ifdef WINRT_IMPL_NUMERICS
 
     template <> struct name<Windows::Foundation::Numerics::float2>
     {

--- a/src/tool/cppwinrt/strings/base_handle.h
+++ b/src/tool/cppwinrt/strings/base_handle.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     struct handle_type

--- a/src/tool/cppwinrt/strings/base_identity.h
+++ b/src/tool/cppwinrt/strings/base_identity.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     using default_interface = typename impl::default_interface<T>::type;
@@ -789,7 +789,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     constexpr auto name_of() noexcept

--- a/src/tool/cppwinrt/strings/base_implements.h
+++ b/src/tool/cppwinrt/strings/base_implements.h
@@ -7,7 +7,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct non_agile : impl::marker {};
     struct no_weak_ref : impl::marker {};
@@ -227,7 +227,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename D, typename I>
     D* get_self(I const& from) noexcept
@@ -1255,7 +1255,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename D, typename... Args>
     auto make(Args&&... args)

--- a/src/tool/cppwinrt/strings/base_lock.h
+++ b/src/tool/cppwinrt/strings/base_lock.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct slim_condition_variable;
 

--- a/src/tool/cppwinrt/strings/base_meta.h
+++ b/src/tool/cppwinrt/strings/base_meta.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     void check_hresult(hresult const result);
     hresult to_hresult() noexcept;

--- a/src/tool/cppwinrt/strings/base_reference_produce.h
+++ b/src/tool/cppwinrt/strings/base_reference_produce.h
@@ -228,7 +228,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt::Windows::Foundation
+WINRT_EXPORT namespace winrt::Windows::Foundation
 {
     template <typename T>
     bool operator==(IReference<T> const& left, IReference<T> const& right)
@@ -253,7 +253,7 @@ namespace winrt::Windows::Foundation
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     inline Windows::Foundation::IInspectable box_value(param::hstring const& value)
     {
@@ -346,10 +346,7 @@ namespace winrt
 
         return default_value;
     }
-}
 
-namespace winrt
-{
     template <typename T>
     using optional = Windows::Foundation::IReference<T>;
 }

--- a/src/tool/cppwinrt/strings/base_security.h
+++ b/src/tool/cppwinrt/strings/base_security.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct access_token : handle
     {

--- a/src/tool/cppwinrt/strings/base_string.h
+++ b/src/tool/cppwinrt/strings/base_string.h
@@ -38,7 +38,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct hstring
     {
@@ -384,7 +384,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     inline bool embedded_null(hstring const& value) noexcept
     {

--- a/src/tool/cppwinrt/strings/base_string_input.h
+++ b/src/tool/cppwinrt/strings/base_string_input.h
@@ -1,5 +1,5 @@
 
-namespace winrt::param
+WINRT_EXPORT namespace winrt::param
 {
     struct hstring
     {

--- a/src/tool/cppwinrt/strings/base_string_operators.h
+++ b/src/tool/cppwinrt/strings/base_string_operators.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     inline bool operator==(hstring const& left, hstring const& right) noexcept
     {
@@ -105,7 +105,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     inline hstring operator+(hstring const& left, hstring const& right)
     {

--- a/src/tool/cppwinrt/strings/base_types.h
+++ b/src/tool/cppwinrt/strings/base_types.h
@@ -19,7 +19,7 @@ namespace winrt::impl
     using bstr = wchar_t*;
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     struct hresult
     {
@@ -84,7 +84,7 @@ namespace winrt
     }
 }
 
-namespace winrt::Windows::Foundation
+WINRT_EXPORT namespace winrt::Windows::Foundation
 {
     enum class TrustLevel : int32_t
     {

--- a/src/tool/cppwinrt/strings/base_version.h
+++ b/src/tool/cppwinrt/strings/base_version.h
@@ -12,7 +12,7 @@ char const * const WINRT_version = "C++/WinRT version:" CPPWINRT_VERSION;
 #pragma comment(linker, "/include:WINRT_version")
 #endif
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <size_t BaseSize, size_t ComponentSize>
     constexpr bool check_version(char const(&base)[BaseSize], char const(&component)[ComponentSize]) noexcept

--- a/src/tool/cppwinrt/strings/base_weak_ref.h
+++ b/src/tool/cppwinrt/strings/base_weak_ref.h
@@ -1,5 +1,5 @@
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     struct weak_ref

--- a/src/tool/cppwinrt/strings/base_windows.h
+++ b/src/tool/cppwinrt/strings/base_windows.h
@@ -116,7 +116,7 @@ namespace winrt::impl
     }
 }
 
-namespace winrt::Windows::Foundation
+WINRT_EXPORT namespace winrt::Windows::Foundation
 {
     struct IUnknown
     {
@@ -238,7 +238,7 @@ namespace winrt::Windows::Foundation
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T, std::enable_if_t<!std::is_base_of_v<Windows::Foundation::IUnknown, T>, int> = 0>
     auto get_abi(T const& object) noexcept
@@ -345,7 +345,7 @@ namespace winrt
 #endif
 }
 
-namespace winrt::Windows::Foundation
+WINRT_EXPORT namespace winrt::Windows::Foundation
 {
     inline bool operator==(IUnknown const& left, IUnknown const& right) noexcept
     {

--- a/src/tool/cppwinrt/strings/base_xaml_typename.h
+++ b/src/tool/cppwinrt/strings/base_xaml_typename.h
@@ -127,7 +127,7 @@ namespace winrt::impl
     };
 }
 
-namespace winrt
+WINRT_EXPORT namespace winrt
 {
     template <typename T>
     inline Windows::UI::Xaml::Interop::TypeName xaml_typename()


### PR DESCRIPTION
This update re-enables C++ module support in the latest version of C++/WinRT. Note that both C++ modules and this support in C++/WinRT is highly experimental and subject to change. In fact, I don't have a compiler that even supports this today. This update is meant to allow the Visual C++ team to better test their compiler.