### PR TITLE
C++/WinRT support for non-WinRT error information

### DIFF
--- a/src/tool/cppwinrt/strings/base_abi.h
+++ b/src/tool/cppwinrt/strings/base_abi.h
@@ -132,6 +132,23 @@ namespace winrt::impl
         virtual int32_t __stdcall GetErrorDetails(bstr* description, int32_t* error, bstr* restrictedDescription, bstr* capabilitySid) noexcept = 0;
         virtual int32_t __stdcall GetReference(bstr* reference) noexcept = 0;
     };
+    template <> struct guid_storage<IRestrictedErrorInfo>
+    {
+        static constexpr guid value{ 0x82BA7092,0x4C88,0x427D,{ 0xA7,0xBC,0x16,0xDD,0x93,0xFE,0xB6,0x7E } };
+    };
+
+    struct __declspec(novtable) IErrorInfo : unknown_abi
+    {
+        virtual int32_t __stdcall GetGUID(guid* value) noexcept = 0;
+        virtual int32_t __stdcall GetSource(bstr* value) noexcept = 0;
+        virtual int32_t __stdcall GetDescription(bstr* value) noexcept = 0;
+        virtual int32_t __stdcall GetHelpFile(bstr* value) noexcept = 0;
+        virtual int32_t __stdcall GetHelpContext(uint32_t* value) noexcept = 0;
+    };
+    template <> struct guid_storage<IErrorInfo>
+    {
+        static constexpr guid value{ 0x1CF2B120,0x547D,0x101B,{ 0x8E,0x65,0x08,0x00,0x2B,0x2B,0xD1,0x19 } };
+    };
 
     struct __declspec(novtable) ILanguageExceptionErrorInfo2 : unknown_abi
     {

--- a/src/tool/cppwinrt/strings/base_extern.h
+++ b/src/tool/cppwinrt/strings/base_extern.h
@@ -2,6 +2,7 @@
 extern "C"
 {
     int32_t __stdcall WINRT_GetRestrictedErrorInfo(void** info) noexcept;
+    int32_t __stdcall WINRT_GetErrorInfo(uint32_t reserved, void** info) noexcept;
     int32_t __stdcall WINRT_RoGetActivationFactory(void* classId, winrt::guid const& iid, void** factory) noexcept;
     int32_t __stdcall WINRT_RoInitialize(uint32_t type) noexcept;
     int32_t __stdcall WINRT_RoOriginateLanguageException(int32_t error, void* message, void* exception) noexcept;
@@ -96,6 +97,7 @@ extern "C"
 #endif
 
 WINRT_IMPL_LINK(GetRestrictedErrorInfo, 4)
+WINRT_IMPL_LINK(GetErrorInfo, 8)
 WINRT_IMPL_LINK(RoGetActivationFactory, 12)
 WINRT_IMPL_LINK(RoInitialize, 4)
 WINRT_IMPL_LINK(RoOriginateLanguageException, 12)

--- a/src/tool/cppwinrt/test/error_info.cpp
+++ b/src/tool/cppwinrt/test/error_info.cpp
@@ -1,0 +1,87 @@
+#include "pch.h"
+#include "winrt/Windows.Data.Xml.Dom.h"
+
+using namespace winrt;
+
+namespace
+{
+    HRESULT winrt_error_info() noexcept
+    {
+        return hresult_invalid_argument(L"winrt_error_info").to_abi();
+    }
+
+    HRESULT com_error_info() noexcept
+    {
+        com_ptr<ICreateErrorInfo> creator;
+        CreateErrorInfo(creator.put());
+        creator->SetDescription(const_cast<wchar_t*>(L"com_error_info"));
+
+        SetErrorInfo(0, creator.as<IErrorInfo>().get());
+        return E_INVALIDARG;
+    }
+
+    HRESULT no_error_info() noexcept
+    {
+        // This just makes sure there's no error info connected to the thread.
+        com_ptr<IErrorInfo> info;
+        GetErrorInfo(0, info.put());
+
+        return E_INVALIDARG;
+    }
+}
+
+TEST_CASE("error_info")
+{
+    try
+    {
+        check_hresult(winrt_error_info());
+        FAIL(L"Previous line should throw");
+    }
+    catch (hresult_invalid_argument const& e)
+    {
+        REQUIRE(e.message() == L"winrt_error_info");
+    }
+
+    try
+    {
+        check_hresult(com_error_info());
+        FAIL(L"Previous line should throw");
+    }
+    catch (hresult_invalid_argument const& e)
+    {
+        REQUIRE(e.message() == L"com_error_info");
+    }
+
+    try
+    {
+        check_hresult(no_error_info());
+        FAIL(L"Previous line should throw");
+    }
+    catch (hresult_invalid_argument const& e)
+    {
+        REQUIRE(e.message() == L"The parameter is incorrect.");
+    }
+
+    try
+    {
+        // This API reports using WinRT error info.
+        Windows::Foundation::Uri(L"bad");
+        FAIL(L"Previous line should throw");
+    }
+    catch (hresult_invalid_argument const& e)
+    {
+        REQUIRE(e.message() == L"bad is not a valid absolute URI.");
+    }
+
+    try
+    {
+        // This API reports using COM error info.
+        Windows::Data::Xml::Dom::XmlDocument doc;
+        doc.LoadXml(L"bad");
+        FAIL(L"Previous line should throw");
+    }
+    catch (hresult_error const& e)
+    {
+        REQUIRE(e.message() == L"Invalid at the top level of the document.");
+    }
+}

--- a/src/tool/cppwinrt/test/test.vcxproj
+++ b/src/tool/cppwinrt/test/test.vcxproj
@@ -161,6 +161,7 @@
     <ClCompile Include="async_auto_cancel.cpp" />
     <ClCompile Include="async_cancel_callback.cpp" />
     <ClCompile Include="async_check_cancel.cpp" />
+    <ClCompile Include="error_info.cpp" />
     <ClCompile Include="event_deferral.cpp" />
     <ClCompile Include="async_local.cpp" />
     <ClCompile Include="async_no_suspend.cpp" />


### PR DESCRIPTION
Fixes #580 

C++/WinRT assumes error information is propagated using WinRT error origination APIs. This update ensures that APIs that only use the older `IErrorInfo` interface for error reporting still get their error messages reported by C++/WinRT.