### PR TITLE
C++/WinRT factory cache optimizations

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -2964,7 +2964,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                     if (has_fastabi(type))
                     {
                         format = R"(    inline %::%() :
-        %(impl::call_factory<%>([](Windows::Foundation::IActivationFactory const& f) { return impl::fast_activate<%>(f); }))
+        %(impl::call_factory_cast<%(*)(Windows::Foundation::IActivationFactory const&), %>([](Windows::Foundation::IActivationFactory const& f) { return impl::fast_activate<%>(f); }))
     {
     }
 )";
@@ -2972,13 +2972,14 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                     else
                     {
                         format = R"(    inline %::%() :
-        %(impl::call_factory<%>([](Windows::Foundation::IActivationFactory const& f) { return f.template ActivateInstance<%>(); }))
+        %(impl::call_factory_cast<%(*)(Windows::Foundation::IActivationFactory const&), %>([](Windows::Foundation::IActivationFactory const& f) { return f.template ActivateInstance<%>(); }))
     {
     }
 )";
                     }
 
                     w.write(format,
+                        type_name,
                         type_name,
                         type_name,
                         type_name,

--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -1974,6 +1974,44 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             factory_name);
     }
 
+    static void write_optimized_call_factory(writer& w, TypeDef const& type, TypeDef const& factory, method_signature const& signature)
+    {
+        std::string factory_name;
+
+        if (type.TypeNamespace() == factory.TypeNamespace())
+        {
+            factory_name = factory.TypeName();
+        }
+        else
+        {
+            factory_name = w.write_temp("%", factory);
+        }
+
+        if (signature.params().empty())
+        {
+            auto format = "impl::call_factory_cast<%(*)(% const&), %, %>([](% const& f) { return f.%(); })";
+
+            w.write(format,
+                signature.return_signature(),
+                factory_name,
+                type.TypeName(),
+                factory_name,
+                factory_name,
+                get_name(signature.method()));
+        }
+        else
+        {
+            auto format = "impl::call_factory<%, %>([&](% const& f) { return f.%(%); })";
+
+            w.write(format,
+                type.TypeName(),
+                factory_name,
+                factory_name,
+                get_name(signature.method()),
+                bind<write_consume_args>(signature));
+        }
+    }
+
     static void write_class_override_constructors(writer& w, TypeDef const& type, std::map<std::string, factory_info> const& factories)
     {
         auto type_name = type.TypeName();
@@ -2770,7 +2808,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         method_signature signature{ method };
 
         auto format = R"(    inline %::%(%) :
-        %(% { return f.%(%); }))
+        %(%)
     {
     }
 )";
@@ -2780,9 +2818,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             type_name,
             bind<write_consume_params>(signature),
             type_name,
-            bind<write_call_factory>(type, factory),
-            get_name(method),
-            bind<write_consume_args>(signature));
+            bind<write_optimized_call_factory>(type, factory, signature));
     }
 
     static void write_composable_constructor_definition(writer& w, MethodDef const& method, TypeDef const& type, TypeDef const& factory)
@@ -2874,7 +2910,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         {
             auto format = R"(    inline auto %::%(%)
     {
-        %% { return f.%(%); });
+        %%;
     }
 )";
 
@@ -2883,9 +2919,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                 method_name,
                 bind<write_consume_params>(signature),
                 signature.return_signature() ? "return " : "",
-                bind<write_call_factory>(type, factory),
-                method_name,
-                bind<write_consume_args>(signature));
+                bind<write_optimized_call_factory>(type, factory, signature));
         }
 
         if (is_add_overload(method))

--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -241,15 +241,6 @@ namespace winrt::impl
             get_diagnostics_info().add_factory<Class>();
 #endif
 
-            {
-                factory_count_guard const guard(m_value.count);
-
-                if (m_value.object)
-                {
-                    return callback(*reinterpret_cast<com_ref<Interface> const*>(&m_value.object));
-                }
-            }
-
             auto object = get_activation_factory<Interface>(name_of<Class>());
 
             if (!object.template try_as<IAgileObject>())
@@ -280,6 +271,16 @@ namespace winrt::impl
     auto call_factory(F&& callback)
     {
         static factory_cache_entry<Class, Interface> factory;
+
+        {
+            factory_count_guard const guard(factory.m_value.count);
+
+            if (factory.m_value.object)
+            {
+                return callback(*reinterpret_cast<com_ref<Interface> const*>(&factory.m_value.object));
+            }
+        }
+
         return factory.call(callback);
     }
 

--- a/src/tool/cppwinrt/strings/base_activation.h
+++ b/src/tool/cppwinrt/strings/base_activation.h
@@ -235,7 +235,7 @@ namespace winrt::impl
     struct factory_cache_entry : factory_cache_entry_base
     {
         template <typename F>
-        auto call(F&& callback)
+        __declspec(noinline) auto call(F&& callback)
         {
 #ifdef WINRT_DIAGNOSTICS
             get_diagnostics_info().add_factory<Class>();
@@ -266,11 +266,13 @@ namespace winrt::impl
         }
     };
 
+    template <typename Class, typename Interface>
+    factory_cache_entry<Class, Interface> factory_cache_entry_v{};
 
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory, typename F>
     auto call_factory(F&& callback)
     {
-        static factory_cache_entry<Class, Interface> factory;
+        auto& factory = factory_cache_entry_v<Class, Interface>;
 
         {
             factory_count_guard const guard(factory.m_value.count);
@@ -282,6 +284,23 @@ namespace winrt::impl
         }
 
         return factory.call(callback);
+    }
+
+    template <typename CastType, typename Class, typename Interface = Windows::Foundation::IActivationFactory, typename F>
+    auto call_factory_cast(F&& callback)
+    {
+        auto& factory = factory_cache_entry_v<Class, Interface>;
+
+        {
+            factory_count_guard const guard(factory.m_value.count);
+
+            if (factory.m_value.object)
+            {
+                return callback(*reinterpret_cast<com_ref<Interface> const*>(&factory.m_value.object));
+            }
+        }
+
+        return factory.call(static_cast<CastType>(callback));
     }
 
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>


### PR DESCRIPTION
More optimizations following research with the C++ team's Xiang Fan that achieve two things:

1. Help the optimizer favor inlining the hot path in the factory cache and never inline the cold path. This amounts to a 25% increase in call speed through the factory cache (constructors and statics).

2. Collapse stateless lambdas (that inherently have unique types) into function pointers to reduce the number of specializations the compiler stores in a PCH. This shaves another 80MB off the test PCH.

