### PR TITLE
Improve error for implementing interface without namespace header file

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -746,6 +746,14 @@ namespace xlang
         w.write(R"(        };
     };
 )");
+
+        w.abi_types = false;
+        auto forward_produce_format = R"(    template <typename D%> struct produce<D, %>;
+)";
+
+        w.write(forward_produce_format,
+            bind<write_comma_generic_typenames>(generics),
+            type);
     }
 
     static void write_delegate_abi(writer& w, TypeDef const& type)


### PR DESCRIPTION
If you forget to include the relevant namespace header file, you get a weird error:

```c++
// Forgot to #include <winrt/Namespace.h>
struct Oops : implements<Oops, winrt::Namespace::ISomething>
{
   void DoSomething();
};
```

The resulting error is
```
error C2259:  'winrt::impl::produce<D,I>': cannot instantiate abstract class
error C2259:         with
error C2259:         [
error C2259:             D=Oops,
error C2259:             I=winrt::Namespace::ISomething
error C2259:         ]
message :  due to following members:
message :  'int32_t winrt::impl::abi<winrt::Namespace::ISomething,void>::type::DoSomething(void *) noexcept': is abstract
```

This leads people on a wild goose chase trying to implement the ABI themselves and failing.

After this fix, the error message tells you that you're using something that hasn't been defined:

```
error C2079:  'winrt::impl::producer<D,winrt::Namespace::ISomething,void>::vtable' uses undefined struct 'winrt::impl::produce<D,I>'
error C2079:         with
error C2079:         [
error C2079:             D=Oops
error C2079:         ]
```

which is a slightly clearer clue that you are missing a header file.