### PR TITLE
Add assert in `wait_for` that duration is within range

### DIFF
--- a/src/tool/cppwinrt/strings/base_coroutine_foundation.h
+++ b/src/tool/cppwinrt/strings/base_coroutine_foundation.h
@@ -64,7 +64,9 @@ namespace winrt::impl
     auto wait_for(Async const& async, Windows::Foundation::TimeSpan const& timeout)
     {
         check_sta_blocking_wait();
-        wait_for_completed(async, static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count()));
+        auto const milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
+        WINRT_ASSERT((milliseconds >= 0) && (milliseconds < 0xFFFFFFFFull)); // Within uint32_t range and not INFINITE
+        wait_for_completed(async, static_cast<uint32_t>(milliseconds));
         return async.Status();
     }
 


### PR DESCRIPTION
Asserts that the duration is non-negative (which would likely get casted to a large unsigned value) and less than `INFINITE`

fixes #525