### PR TITLE
Simpler version of forcing improved error messages for undefined interfaces in C++/WinRT

### DIFF
--- a/src/tool/cppwinrt/cppwinrt/code_writers.h
+++ b/src/tool/cppwinrt/cppwinrt/code_writers.h
@@ -746,14 +746,6 @@ namespace xlang
         w.write(R"(        };
     };
 )");
-
-        w.abi_types = false;
-        auto forward_produce_format = R"(    template <typename D%> struct produce<D, %>;
-)";
-
-        w.write(forward_produce_format,
-            bind<write_comma_generic_typenames>(generics),
-            type);
     }
 
     static void write_delegate_abi(writer& w, TypeDef const& type)

--- a/src/tool/cppwinrt/strings/base_meta.h
+++ b/src/tool/cppwinrt/strings/base_meta.h
@@ -225,7 +225,10 @@ namespace winrt::impl
     struct produce_base;
 
     template <typename D, typename I>
-    struct produce : produce_base<D, I>
+    struct produce;
+
+    template <typename D>
+    struct produce<D, Windows::Foundation::IInspectable> : produce_base<D, Windows::Foundation::IInspectable>
     {
     };
 


### PR DESCRIPTION
#595 produces a less confusing error message when a developer mistakenly attempts to implement an interface that has not been defined. However, it requires that specializations of the `produce` class template are declared for all interfaces in the widely included `xxx.0.h` headers. This adds an undesirable burden on the C++ compiler.

This update achieves the same end without requiring all of these specializations. Note that the base `produce` class template is only used for implementations of `IInspectable` so we can simply specialize this one case and leave the base class template undefined. 