### PR TITLE
CppWinRTMakeProjection is missing DependsOn for CppWinRTCalculateEnabledProjections.

### DIFF
--- a/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.targets
@@ -503,7 +503,7 @@ $(XamlMetaDataProviderPch)
         <Exec Command="$(CppWinRTCommand)" Condition="'@(_CppwinrtCompInputs)' != ''"/>
     </Target>
 
-    <Target Name="CppWinRTMakeProjections" DependsOnTargets="CppWinRTMakePlatformProjection;CppWinRTMakeReferenceProjection;CppWinRTMakeComponentProjection;$(CppWinRTMakeProjectionsDependsOn)" />
+    <Target Name="CppWinRTMakeProjections" DependsOnTargets="CppWinRTCalculateEnabledProjections;CppWinRTMakePlatformProjection;CppWinRTMakeReferenceProjection;CppWinRTMakeComponentProjection;$(CppWinRTMakeProjectionsDependsOn)" />
 
     <!--Add references to all merged project WinMD files for Xaml Compiler-->
     <Target Name="CppWinRTAddXamlReferences" DependsOnTargets="$(CppWinRTAddXamlReferencesDependsOn)">


### PR DESCRIPTION
Fix regression from #585 where the DependsOn for CppWinRTCalculateEnabledProjections was dropped.