### PR TITLE
Avoid querying for IReference<T> in C++/WinRT's box_value<T> helper function

### DIFF
--- a/src/tool/cppwinrt/strings/base_identity.h
+++ b/src/tool/cppwinrt/strings/base_identity.h
@@ -573,6 +573,7 @@ namespace winrt::impl
     template <> inline constexpr auto& name_v<Windows::Foundation::IInspectable>{ L"Object" };
     template <> inline constexpr auto& name_v<Windows::Foundation::TimeSpan>{ L"Windows.Foundation.TimeSpan" };
     template <> inline constexpr auto& name_v<Windows::Foundation::DateTime>{ L"Windows.Foundation.DateTime" };
+    template <> inline constexpr auto& name_v<IAgileObject>{ L"IAgileObject" };
 
     template <> struct category<bool> { using type = basic_category; };
     template <> struct category<int8_t> { using type = basic_category; };

--- a/src/tool/cppwinrt/strings/base_reference_produce.h
+++ b/src/tool/cppwinrt/strings/base_reference_produce.h
@@ -269,7 +269,7 @@ WINRT_EXPORT namespace winrt
         }
         else
         {
-            return Windows::Foundation::IReference<T>(value);
+            return impl::reference_traits<T>::make(value);
         }
     }
 

--- a/src/tool/cppwinrt/strings/base_types.h
+++ b/src/tool/cppwinrt/strings/base_types.h
@@ -9,6 +9,7 @@ namespace winrt::impl
     using condition_variable = struct condition_variable_*;
     using bstr = wchar_t*;
     using filetime_period = std::ratio_multiply<std::ratio<100>, std::nano>;
+    struct IAgileObject;
 
     struct com_callback_args
     {
@@ -101,7 +102,6 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
     struct IActivationFactory;
     using TimeSpan = std::chrono::duration<int64_t, impl::filetime_period>;
     using DateTime = std::chrono::time_point<clock, TimeSpan>;
-
 }
 
 namespace winrt::impl

--- a/src/tool/cppwinrt/test_fast/Simple.cpp
+++ b/src/tool/cppwinrt/test_fast/Simple.cpp
@@ -20,5 +20,5 @@ TEST_CASE("Simple")
     REQUIRE(info.factories[name_of<Simple>()].requests == 1);
 
     REQUIRE(info.queries.size() == 1);
-    REQUIRE(info.queries[L"{94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90}"] == 1); // IAgileObject
+    REQUIRE(info.queries[L"IAgileObject"] == 1);
 }

--- a/src/tool/cppwinrt/test_slow/Simple.cpp
+++ b/src/tool/cppwinrt/test_slow/Simple.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Simple")
     REQUIRE(info.factories[name_of<Simple>()].requests == 1);
 
     REQUIRE(info.queries.size() == 4);
-    REQUIRE(info.queries[L"{94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90}"] == 1); // IAgileObject
+    REQUIRE(info.queries[L"IAgileObject"] == 1);
     REQUIRE(info.queries[name_of<Simple>()] == 1);
     REQUIRE(info.queries[name_of<ISimple2>()] == 1);
     REQUIRE(info.queries[name_of<ISimple3>()] == 1);


### PR DESCRIPTION
Fixes #606 

This update simply unrolls the `IReference<T>` constructor. The same set of `reference_traits<T>::make` overloads are invoked. We just avoid forcing the result to be queried for `IReference<T>`.

I also added a `name_v` specialization for IAgileObject as this is the only unnamed interface that C++/WinRT queries for frequently and thus makes QI performance analysis easier to grok via `WINRT_DIAGNOSTICS`.