### PR TITLE
Improve scalability of co_await apartment_context

### DIFF
--- a/src/tool/cppwinrt/test/thread_pool.cpp
+++ b/src/tool/cppwinrt/test/thread_pool.cpp
@@ -31,8 +31,9 @@ namespace
         {
             results.push_back(queue.Async([&]
                 {
-                    Sleep(10); // Induce thread pool to use more threads if available
-                    ++counter;
+                    auto value = counter + 1;
+                    Sleep(10); // Induce thread pool to use more threads if available, also force race condition
+                    counter = value;
                 }));
         }
 


### PR DESCRIPTION
When we fixed throughput of coroutine resumption in #546, we failed to update the corresponding code in apartment_context.  Refactored the logic into a common function and have everybody use it.

Also make the thread_pool test more reliable. Sometimes fails spuriously because the envisioned race condition fails to materialize. Make the race condition far more likely to occur.