### PR TITLE
Improve error message for passing vector<bool> as array_view

### DIFF
--- a/src/tool/cppwinrt/strings/base_array.h
+++ b/src/tool/cppwinrt/strings/base_array.h
@@ -31,6 +31,18 @@ WINRT_EXPORT namespace winrt
             array_view(value, N)
         {}
 
+        template <typename = std::enable_if_t<std::is_same_v<T, bool>>>
+        array_view(std::vector<bool>& value) noexcept
+        {
+            static_assert(false, "Cannot use std::vector<bool> as an array_view. Consider std::array or std::unique_ptr<bool[]>.");
+        }
+
+        template <typename = std::enable_if_t<std::is_same_v<T, bool>>>
+        array_view(std::vector<bool> const& value) noexcept
+        {
+            static_assert(false, "Cannot use std::vector<bool> as an array_view. Consider std::array or std::unique_ptr<bool[]>.");
+        }
+
         template <typename C>
         array_view(std::vector<C>& value) noexcept :
             array_view(value.data(), static_cast<size_type>(value.size()))


### PR DESCRIPTION
`std::vector<bool>` is not a conformant array of `bool`. Passing it to `array_view<bool>` results in a long incomprehensible error message because there is no `data()` member. Add specializations for "constructing `array_view<bool>` from `std::vector<bool>`" so we can provide a clearer error message.

Old error message:

```
error C2039:  'data': is not a member of 'std::vector<T,std::allocator<_Ty>>'
error C2039:         with
error C2039:         [
error C2039:             T=bool,
error C2039:             _Ty=bool
error C2039:         ]
message :  see declaration of 'std::vector<T,std::allocator<_Ty>>'
message :         with
message :         [
message :             T=bool,
message :             _Ty=bool
message :         ]
message :  see reference to function template instantiation 'winrt::array_view<T>::array_view<T>(std::vector<T,std::allocator<_Ty>> &) noexcept' being compiled
message :         with
message :         [
message :             T=bool,
message :             _Ty=bool
message :         ]
message :  see reference to function template instantiation 'winrt::array_view<T>::array_view<T>(std::vector<T,std::allocator<_Ty>> &) noexcept' being compiled
message :         with
message :         [
message :             T=bool,
message :             _Ty=bool
message :         ]
message :  see reference to class template instantiation 'winrt::com_ptr<winrt::impl::IContextCallback>' being compiled
message :  see reference to class template instantiation 'winrt::com_ptr<winrt::impl::IServerSecurity>' being compiled
message :  see reference to class template instantiation 'std::chrono::time_point<winrt::clock,winrt::Windows::Foundation::TimeSpan>' being compiled
message :  see reference to class template instantiation 'winrt::com_ptr<winrt::impl::IMarshal>' being compiled
message :  see reference to class template instantiation 'winrt::com_ptr<To>' being compiled
message :         with
message :         [
message :             To=winrt::impl::ILanguageExceptionErrorInfo2
message :         ]
message :  see reference to function template instantiation 'winrt::com_ptr<To> winrt::com_ptr<winrt::impl::IRestrictedErrorInfo>::try_as<winrt::impl::ILanguageExceptionErrorInfo2>(void) noexcept const' being compiled
message :         with
message :         [
message :             To=winrt::impl::ILanguageExceptionErrorInfo2
message :         ]
message :  see reference to class template instantiation 'winrt::com_ptr<winrt::impl::IRestrictedErrorInfo>' being compiled
message :  see reference to class template instantiation 'std::basic_string_view<wchar_t,std::char_traits<wchar_t>>' being compiled
message :  see reference to class template instantiation 'std::chrono::duration<double,std::ratio<1,1>>' being compiled
message :  see reference to class template instantiation 'std::chrono::duration<__int64,std::nano>' being compiled
message :  see reference to class template instantiation 'std::chrono::time_point<std::chrono::steady_clock,std::chrono::steady_clock::duration>' being compiled
```

New error message;

```
error C2338: Cannot use std::vector<bool> as an array_view. Consider std::array or std::unique_ptr<bool[]>.
note: see reference to function template instantiation 'winrt::array_view<bool>::array_view<void>(std::vector<bool,std::allocator<_Ty>> &) noexcept' being compiled
        with
        [
            _Ty=bool
        ]
note: see reference to function template instantiation 'winrt::array_view<bool>::array_view<void>(std::vector<bool,std::allocator<_Ty>> &) noexcept' being compiled
        with
        [
            _Ty=bool
        ]
```

Note that we specialize only in the case of `array_view<bool>`. That way, if you pass a `std::vector<bool>` to a function expecting `array_view<hstring>` (say), you don't get an error message telling you to use something (`std::array<bool>`) that won't work. (Should we have a separate error message for type mismatch? Maybe this is good enough for now.)

Fixes #568 