### PR TITLE
Component projection command is incorrect when there are multiple inputs.

### DIFF
--- a/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/src/package/cppwinrt/nuget/Microsoft.Windows.CppWinRT.targets
@@ -500,7 +500,7 @@ $(XamlMetaDataProviderPch)
             <_MdMergedOutput Include="$(CppWinRTMergedDir)*.winmd"/>
             <_CppwinrtCompInputs Remove="@(_CppwinrtCompInputs)"/>
             <_CppwinrtCompInputs Include="@(_MdMergedOutput)">
-                <WinMDPath>@(_MdMergedOutput->'%(FullPath)')</WinMDPath>
+                <WinMDPath>%(_MdMergedOutput.FullPath)</WinMDPath>
             </_CppwinrtCompInputs>
             <!-- If this is a static library with static library references,
                  pass the individual static library references to cppwinrt.exe 

--- a/src/test/package/nuget/NuGetTest/NuGetTest.sln
+++ b/src/test/package/nuget/NuGetTest/NuGetTest.sln
@@ -33,6 +33,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestRuntimeComponentEmpty",
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestStaticLibrary5", "TestStaticLibrary5\TestStaticLibrary5.vcxproj", "{DC435C3F-C38E-43D1-B702-DC03F530A3CB}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestStaticLibrary6", "TestStaticLibrary6\TestStaticLibrary6.vcxproj", "{DC435C3F-C38E-43D1-B702-DC03F530A3DD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -203,6 +205,20 @@ Global
 		{DC435C3F-C38E-43D1-B702-DC03F530A3CB}.Release|x64.Build.0 = Release|x64
 		{DC435C3F-C38E-43D1-B702-DC03F530A3CB}.Release|x86.ActiveCfg = Release|Win32
 		{DC435C3F-C38E-43D1-B702-DC03F530A3CB}.Release|x86.Build.0 = Release|Win32
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Debug|ARM.ActiveCfg = Debug|ARM
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Debug|ARM.Build.0 = Debug|ARM
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Debug|x64.ActiveCfg = Debug|x64
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Debug|x64.Build.0 = Debug|x64
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Debug|x86.ActiveCfg = Debug|Win32
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Debug|x86.Build.0 = Debug|Win32
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Release|ARM.ActiveCfg = Release|ARM
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Release|ARM.Build.0 = Release|ARM
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Release|ARM64.ActiveCfg = Release|Win32
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Release|x64.ActiveCfg = Release|x64
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Release|x64.Build.0 = Release|x64
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Release|x86.ActiveCfg = Release|Win32
+		{DC435C3F-C38E-43D1-B702-DC03F530A3DD}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/test/package/nuget/NuGetTest/TestApp/MainPage.cpp
+++ b/src/test/package/nuget/NuGetTest/TestApp/MainPage.cpp
@@ -8,6 +8,8 @@ using namespace Windows::UI::Xaml;
 using namespace winrt::TestRuntimeComponent1;
 using namespace winrt::TestRuntimeComponent2;
 using namespace winrt::TestRuntimeComponentCX;
+using namespace winrt::TestRuntimeComponentEmpty;
+using namespace winrt::TestRuntimeComponentEmpty::SubNamespace1;
 
 namespace winrt::TestApp::implementation
 {
@@ -29,6 +31,12 @@ namespace winrt::TestApp::implementation
 
         TestStaticLibrary4Class cStatic4{};
         cStatic4.Test();
+
+        TestStaticLibrary5Class cStatic5{};
+        cStatic5.Test();
+
+        TestStaticLibrary6Class cStatic6{};
+        cStatic6.Test();
     }
 
     int32_t MainPage::MyProperty()

--- a/src/test/package/nuget/NuGetTest/TestApp/pch.h
+++ b/src/test/package/nuget/NuGetTest/TestApp/pch.h
@@ -17,3 +17,4 @@
 #include <winrt/TestRuntimeComponent1.h>
 #include <winrt/TestRuntimeComponent2.h>
 #include <winrt/TestRuntimeComponentCX.h>
+#include <winrt/TestRuntimeComponentEmpty.SubNamespace1.h>

--- a/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
+++ b/src/test/package/nuget/NuGetTest/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
@@ -124,6 +124,9 @@
     <ProjectReference Include="..\TestStaticLibrary5\TestStaticLibrary5.vcxproj">
       <Project>{dc435c3f-c38e-43d1-b702-dc03f530a3cb}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\TestStaticLibrary6\TestStaticLibrary6.vcxproj">
+      <Project>{dc435c3f-c38e-43d1-b702-dc03f530a3dd}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestNamespace.cpp
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestNamespace.cpp
@@ -1,0 +1,11 @@
+﻿#include "pch.h"
+#include "TestNamespace.h"
+#if __has_include("TestRuntimeComponentNamespace.TestNamespace.g.cpp")
+#include "TestRuntimeComponentNamespace.TestNamespace.g.cpp"
+#endif
+
+using namespace winrt;
+
+namespace winrt::TestRuntimeComponentNamespace::implementation
+{
+}

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestNamespace.h
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestNamespace.h
@@ -1,0 +1,18 @@
+﻿#pragma once
+
+#include "TestRuntimeComponentNamespace.TestNamespace.g.h"
+
+namespace winrt::TestRuntimeComponentNamespace::implementation
+{
+    struct TestNamespace : TestNamespaceT<TestNamespace>
+    {
+        TestNamespace() = default;
+    };
+}
+
+namespace winrt::TestRuntimeComponentNamespace::factory_implementation
+{
+    struct TestNamespace : TestNamespaceT<TestNamespace, implementation::TestNamespace>
+    {
+    };
+}

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestNamespace.idl
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestNamespace.idl
@@ -1,0 +1,9 @@
+namespace TestRuntimeComponentNamespace
+{
+    [bindable]
+    [default_interface]
+    runtimeclass TestNamespace 
+    {
+        TestNamespace();
+    }
+}

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6.vcxproj
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6.vcxproj
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <ProjectGuid>{DC435C3F-C38E-43D1-B702-DC03F530A3DD}</ProjectGuid>
+    <Keyword>StaticLibrary</Keyword>
+    <RootNamespace>TestRuntimeComponentEmpty</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <CppWinRTParameters>-lib $(MSBuildProjectName)</CppWinRTParameters>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="targetver.h" />
+    <ClInclude Include="TestStaticLibrary6Class.h">
+      <DependentUpon>TestStaticLibrary6Class.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+    <ClInclude Include="TestNamespace.h">
+      <DependentUpon>TestNamespace.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="TestStaticLibrary6Class.cpp">
+      <DependentUpon>TestStaticLibrary6Class.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="TestNamespace.cpp">
+      <DependentUpon>TestNamespace.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="TestStaticLibrary6Class.idl">
+      <SubType>Designer</SubType>
+    </Midl>
+    <Midl Include="TestNamespace.idl">
+      <SubType>Designer</SubType>
+    </Midl>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6.vcxproj.filters
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6.vcxproj.filters
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tga;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp" />
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="TestStaticLibrary6Class.idl" />
+    <Midl Include="TestNamespace.idl" />
+  </ItemGroup>
+</Project>

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6Class.cpp
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6Class.cpp
@@ -1,0 +1,16 @@
+﻿#include "pch.h"
+#include "TestStaticLibrary6Class.h"
+#if __has_include("SubNamespace1.TestStaticLibrary6Class.g.cpp")
+#include "SubNamespace1.TestStaticLibrary6Class.g.cpp"
+#endif
+
+using namespace winrt;
+using namespace winrt::Windows::UI::Xaml::Core::Direct;
+
+namespace winrt::TestRuntimeComponentEmpty::SubNamespace1::implementation
+{
+    XamlDirect TestStaticLibrary6Class::Test()
+    {
+        return XamlDirect::GetDefault();
+    }
+}

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6Class.h
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6Class.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+#include "SubNamespace1.TestStaticLibrary6Class.g.h"
+
+namespace winrt::TestRuntimeComponentEmpty::SubNamespace1::implementation
+{
+    struct TestStaticLibrary6Class : TestStaticLibrary6ClassT<TestStaticLibrary6Class>
+    {
+        TestStaticLibrary6Class() = default;
+
+        Windows::UI::Xaml::Core::Direct::XamlDirect Test();
+    };
+}
+
+namespace winrt::TestRuntimeComponentEmpty::SubNamespace1::factory_implementation
+{
+    struct TestStaticLibrary6Class : TestStaticLibrary6ClassT<TestStaticLibrary6Class, implementation::TestStaticLibrary6Class>
+    {
+    };
+}

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6Class.idl
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/TestStaticLibrary6Class.idl
@@ -1,0 +1,10 @@
+namespace TestRuntimeComponentEmpty.SubNamespace1
+{
+    [default_interface]
+    runtimeclass TestStaticLibrary6Class 
+    {
+        TestStaticLibrary6Class();
+
+        Windows.UI.Xaml.Core.Direct.XamlDirect Test();
+    }
+}

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/pch.cpp
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/pch.cpp
@@ -1,0 +1,1 @@
+﻿#include "pch.h"

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/pch.h
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/pch.h
@@ -1,0 +1,10 @@
+﻿#pragma once
+
+#include "targetver.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <winrt/base.h>
+#include <winrt/Windows.UI.Xaml.Core.Direct.h>

--- a/src/test/package/nuget/NuGetTest/TestStaticLibrary6/targetver.h
+++ b/src/test/package/nuget/NuGetTest/TestStaticLibrary6/targetver.h
@@ -1,0 +1,8 @@
+﻿#pragma once
+
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>


### PR DESCRIPTION
This PR fixes a bug where the generation of the component projection fails when there are multiple inputs.

Added a test project to the test solution to cover this case and verified it works with the fix.