### PR TITLE
Fix RoResolveNamespace not looking at exe directory on RS5 as fallback. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# xlang
-
 This repo is the home of the following projects:
 
 * Undocked RegFree WinRT

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
@@ -140,7 +140,7 @@ HRESULT WinRTLoadComponent(PCWSTR manifest_path)
                             this_component->xmlns = xmlns;
 
                             const WCHAR* activatableClass;
-                            RETURN_IF_FAILED(xmlReader->MoveToAttributeByName(L"clsid", nullptr));
+                            RETURN_IF_FAILED(xmlReader->MoveToAttributeByName(L"name", nullptr));
                             RETURN_IF_FAILED(xmlReader->GetValue(&activatableClass, nullptr));
                             g_types[activatableClass] = this_component;
                         }

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -302,11 +302,12 @@ HRESULT WINAPI RoResolveNamespaceDetour(
     DWORD* subNamespacesCount,
     HSTRING** subNamespaces)
 {
+    HSTRING packageGraphDirectory[1];
+    packageGraphDirectory[0] = Microsoft::WRL::Wrappers::HStringReference(exeFilePath.c_str()).Get();
     HRESULT hr = TrueRoResolveNamespace(name, Microsoft::WRL::Wrappers::HStringReference(exeFilePath.c_str()).Get(),
-        packageGraphDirsCount, packageGraphDirs,
+        1, packageGraphDirectory,
         metaDataFilePathsCount, metaDataFilePaths,
         subNamespacesCount, subNamespaces);
-
     if (FAILED(hr))
     {
         hr = TrueRoResolveNamespace(name, windowsMetaDataDir,

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -304,7 +304,7 @@ HRESULT WINAPI RoResolveNamespaceDetour(
 {
     auto pathReference = Microsoft::WRL::Wrappers::HStringReference(exeFilePath.c_str());
     HSTRING packageGraphDirectories[] = { pathReference.Get() };
-    HRESULT hr = TrueRoResolveNamespace(name, Microsoft::WRL::Wrappers::HStringReference(exeFilePath.c_str()).Get(),
+    HRESULT hr = TrueRoResolveNamespace(name, pathReference.Get(),
         ARRAYSIZE(packageGraphDirectories), packageGraphDirectories,
         metaDataFilePathsCount, metaDataFilePaths,
         subNamespacesCount, subNamespaces);

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -302,10 +302,10 @@ HRESULT WINAPI RoResolveNamespaceDetour(
     DWORD* subNamespacesCount,
     HSTRING** subNamespaces)
 {
-    HSTRING packageGraphDirectory[1];
-    packageGraphDirectory[0] = Microsoft::WRL::Wrappers::HStringReference(exeFilePath.c_str()).Get();
+    auto pathReference = Microsoft::WRL::Wrappers::HStringReference(exeFilePath.c_str());
+    HSTRING packageGraphDirectories[] = { pathReference.Get() };
     HRESULT hr = TrueRoResolveNamespace(name, Microsoft::WRL::Wrappers::HStringReference(exeFilePath.c_str()).Get(),
-        1, packageGraphDirectory,
+        ARRAYSIZE(packageGraphDirectories), packageGraphDirectories,
         metaDataFilePathsCount, metaDataFilePaths,
         subNamespacesCount, subNamespaces);
     if (FAILED(hr))

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTTest/test_files/UndockedRegFreeWinRTTest.exe.manifest
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTTest/test_files/UndockedRegFreeWinRTTest.exe.manifest
@@ -2,15 +2,15 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <file name="TestComponent.dll">
     <activatableClass
-        clsid="TestComponent.ClassBoth"
+        name="TestComponent.ClassBoth"
         threadingModel="Both"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
     <activatableClass
-        clsid="TestComponent.ClassSta"
+        name="TestComponent.ClassSta"
         threadingModel="sta"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
     <activatableClass
-        clsid="TestComponent.ClassMta"
+        name="TestComponent.ClassMta"
         threadingModel="mta"
         xmlns="urn:schemas-microsoft-com:winrt.v1" />
   </file>


### PR DESCRIPTION
Types were failing to resolve on RS5 because RoResolveNamespace did not look at the exe file path as fallback by default. Supplying the exe file path to windowsMetaData dir only looks for types with the Windows prefix. The fix was to also supply the exe file path to the package graph parameter. 

Also fix xml parsing to look for 'name' on ActivatableClass tag instead of 'clsid'.