### PR TITLE
adding midlrt nuget package

### DIFF
--- a/src/package/abi/LICENSE
+++ b/src/package/abi/LICENSE
@@ -1,4 +1,4 @@
-WinRT ABI Header Generation Tool
+WinRT Metadata Generation Utility Package
 
 Copyright (c) Microsoft Corporation
 All rights reserved. 

--- a/src/package/midlrt/CMakeLists.txt
+++ b/src/package/midlrt/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.9)
+
+# The Microsoft.Windows.MidlRT NuGet package is only targeted at Visual Studio (on Windows)
+if (WIN32 AND ("$ENV{VSCMD_ARG_TGT_ARCH}" STREQUAL "x86"))
+
+file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/build_tools/nuget.exe" nuget_exe)
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" midlrt_nupkg_dir)
+file(TO_NATIVE_PATH "${midlrt_nupkg_dir}/Microsoft.Windows.midlrt.${XLANG_BUILD_VERSION}.nupkg" midlrt_nupkg)
+
+file(DOWNLOAD https://dist.nuget.org/win-x86-commandline/latest/nuget.exe ${nuget_exe})
+
+add_custom_command(OUTPUT ${midlrt_nupkg}
+    COMMAND ${nuget_exe} pack ${CMAKE_CURRENT_SOURCE_DIR}/Microsoft.Windows.midlrt.nuspec -Properties -Version ${XLANG_BUILD_VERSION} -OutputDirectory ${CMAKE_CURRENT_BINARY_DIR} -NonInteractive -Verbosity Detailed
+    DEPENDS ${XLANG_BUILD_VERSION_h} ${CMAKE_CURRENT_SOURCE_DIR}/Microsoft.Windows.midlrt.nuspec
+)
+
+add_custom_target(make_midlrt_nupkg ALL DEPENDS ${midlrt_nupkg} abi)
+
+set_target_properties(make_midlrt_nupkg PROPERTIES "midlrt_nupkg_dir" ${midlrt_nupkg_dir})
+
+endif()

--- a/src/package/midlrt/LICENSE
+++ b/src/package/midlrt/LICENSE
@@ -1,0 +1,24 @@
+WinRT ABI Header Generation Tool
+
+Copyright (c) Microsoft Corporation
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/package/midlrt/Microsoft.Windows.MidlRT.IdlGen.targets
+++ b/src/package/midlrt/Microsoft.Windows.MidlRT.IdlGen.targets
@@ -1,0 +1,84 @@
+<!--
+***********************************************************************************************
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!--
+        This file contains targets for generating IDL files from winmd references. This are only
+        used when the consumer hasn't switched to Modern IDL.
+    -->
+    
+  <!--
+    If not using the newer modern idl semantics, generate the .idl for any referenced winmd files.
+    We need a special target here, because the other Get*References  depends on ResolveReferences
+    being run first. However, MIDL runs before ResolveReferences, so this target uses the References
+    item, not the ReferencePath item.
+  -->
+  <Target Name="GetMidlRTDirectWinMDReferencesForIdl"
+          BeforeTargets="Midl"
+          Returns="@(MidlRTDirectWinMDReferencesForIdl);@(MidlRTDirectWinMDReferenceDirs)">
+    <ItemGroup>
+      <_MidlRTDirectWinMDReferencesForIdl Remove="@(_MidlRTDirectWinMDReferencesForIdl)" />
+      <_MidlRTDirectWinMDReferencesForIdl Include="@(Reference)" Condition="'%(Reference.Extension)' == '.winmd' and '%(Reference.IsSystemReference)' != 'true'" />
+      <MidlRTDirectWinMDReferencesForIdl Remove="@(MidlRTDirectWinMDReferencesForIdl)"/>
+      <MidlRTDirectWinMDReferencesForIdl Include="@(_MidlRTDirectWinMDReferencesForIdl)">
+        <WinMDPath>%(FullPath)</WinMDPath>
+      </MidlRTDirectWinMDReferencesForIdl>
+
+      <!-- Generate list of reference directories to pass into winmdidl.exe -->
+      <_MidlRTDirectWinMDReferenceDirs Include="@(MidlRTDirectWinMDReferencesForIdl->'%(RootDir)%(Directory)')"/>
+    </ItemGroup>
+
+    <!-- Remove any duplicates of file paths (caused by a nuget containing mulitple .winmd files) -->
+    <RemoveDuplicates Inputs="@(_MidlRTDirectWinMDReferenceDirs)">
+      <Output TaskParameter="Filtered" ItemName="MidlRTDirectWinMDReferenceDirs"/>
+    </RemoveDuplicates>
+    <Message Text="MidlRTDirectWinMDReferencesForIdl: @(MidlRTDirectWinMDReferencesForIdl->'%(WinMDPath)')" Importance="$(MidlRTVerbosity)"/>
+  </Target>
+
+    <!-- 
+      Gather the outputs from the target if previously executed. If it hasn't been executed, then this list
+      will be empty and the target will run.
+    -->
+  <Target Name="_GatherExpectedGeneratedFiles" BeforeTargets="MidlRTMakeReferenceIdl" Returns="@(_ExpectedGeneratedIdl)">
+    <ItemGroup>
+      <_ExpectedGeneratedIdl Include="$(GeneratedFilesDir)\*.idl"/>
+    </ItemGroup>
+  </Target>
+
+  <!--Build reference IDL from WinMD project references and dynamic library project references
+      Note that Condition is evaluated before DependsOnTargets are run -->
+  <Target Name="MidlRTMakeReferenceIdl"
+          Condition="'@(MidlRTDirectWinMDReferencesForIdl)' != ''"
+          AfterTargets="GetMidlRTDirectWinMDReferencesForIdl"
+          Inputs="@(MidlRTDirectWinMDReferencesForIdl)"
+          Outputs="@(_ExpectedGeneratedIdl)">
+    <PropertyGroup>
+      <WindowsSdkToolLocation Condition="'$(WindowsSdkToolLocation)'==''">$(WDKBinRoot)\$(PreferredToolArchitecture)</WindowsSdkToolLocation>
+    </PropertyGroup>
+    <ItemGroup>
+      <_MidlRTRefInputs Remove="@(_MidlRTRefInputs)"/>
+      <_MidlRTRefInputs Include="@(MidlRTDirectWinMDReferencesForIdl)"/>
+
+      <_MidlRTMetadataDirInputs Include="$(WindowsSDK_UnionMetadataPath)"/>
+      <_MidlRTMetadataDirInputs Include="@(MidlRTDirectWinMDReferenceDirs)"/>
+    </ItemGroup>
+
+    <!-- Since the backslash is an escape character, we need to append a '.' to the end of each path so that they are properly formed -->
+    <PropertyGroup>
+      <_MidlRTWinmdIdlParams>/outdir:&quot;$(GeneratedFilesDir).&quot;</_MidlRTWinmdIdlParams>
+      <_MidlRTWinmdIdlParams>$(_MidlRTWinmdIdlParams) @(_MidlRTMetadataDirInputs->'/metadata_dir:&quot;%(Identity).&quot;', ' ')</_MidlRTWinmdIdlParams>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(GeneratedFilesDir)" />
+    <Exec Command="&quot;$(WindowsSdkToolLocation)\winmdidl.exe&quot; $(_MidlRTWinmdIdlParams) %(_MidlRTRefInputs.Identity)"
+          Condition="'@(_MidlRTRefInputs)' != ''"/>
+  </Target>
+
+  <ItemDefinitionGroup>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(GeneratedFilesDir)</AdditionalIncludeDirectories>
+    </Midl>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/package/midlrt/Microsoft.Windows.MidlRT.nuspec
+++ b/src/package/midlrt/Microsoft.Windows.MidlRT.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.5">
+    <id>Microsoft.Windows.MidlRT</id>
+    <version>1.0.0.0</version>
+    <title>MidlRT Build Support</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Provides targets for invoking MidlRT to support projects using MIDL2 and MIDL3</description>
+    <releaseNotes></releaseNotes>
+    <tags>native midl winrt nativepackage</tags>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <license type="file">LICENSE</license>
+    <projectUrl>https://github.com/microsoft/xlang/tree/master/src/package/midlrt</projectUrl>
+  </metadata>
+  <files>
+    <file src="LICENSE"/>
+    <file src="Microsoft.Windows.MidlRT.targets" target="build\native"/>
+    <file src="Microsoft.Windows.MidlRT.IdlGen.targets" target="build\native"/>
+    <file src="Microsoft.Windows.MidlRT.props" target="build\native"/>
+    <file src="readme.txt"/>
+  </files>
+</package>

--- a/src/package/midlrt/Microsoft.Windows.MidlRT.props
+++ b/src/package/midlrt/Microsoft.Windows.MidlRT.props
@@ -1,0 +1,42 @@
+<!--
+***********************************************************************************************
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <!-- Only do this for MSBuild versions below 16.0
+             as it is since done automatically, see https://github.com/microsoft/msbuild/pull/3605-->
+        <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)'  &lt;= '15'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+        
+        <UsingMidlRTPackage>true</UsingMidlRTPackage>
+    </PropertyGroup>
+
+     <PropertyGroup>
+        <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+        <CanReferenceWinRT>true</CanReferenceWinRT>
+        <IsNativeLanguage>true</IsNativeLanguage>
+        <!-- This causes VS to add the platform WinMD references for the target SDK -->
+        <WinMDAssembly>true</WinMDAssembly>
+    </PropertyGroup>
+
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <CompileAsWinRT Condition="'%(ClCompile.CompileAsWinRT)' == ''">false</CompileAsWinRT>
+        </ClCompile>
+        <Midl Condition="'$(ModernMidlRT)' != 'false'">
+            <EnableWindowsRuntime>true</EnableWindowsRuntime>
+            <MetadataFileName>$(IntDir)Unmerged\%(Filename).winmd</MetadataFileName>
+            <GenerateClientFiles Condition="'%(Midl.GenerateClientFiles)'==''">None</GenerateClientFiles>
+            <GenerateServerFiles Condition="'%(Midl.GenerateServerFiles)'==''">None</GenerateServerFiles>
+            <GenerateStublessProxies Condition="'%(Midl.GenerateStublessProxies)'==''">false</GenerateStublessProxies>
+            <GenerateTypeLibrary Condition="'%(Midl.GenerateTypeLibrary)'==''">false</GenerateTypeLibrary>
+            <HeaderFileName Condition="'%(Midl.HeaderFileName)'==''">nul</HeaderFileName>
+            <DllDataFileName Condition="'%(Midl.DllDataFileName)'==''">nul</DllDataFileName>
+            <InterfaceIdentifierFileName Condition="'%(Midl.InterfaceIdentifierFileName)'==''">nul</InterfaceIdentifierFileName>
+            <ProxyFileName Condition="'%(Midl.ProxyFileName)'==''">nul</ProxyFileName>
+            <TypeLibraryName Condition="'%(Midl.TypeLibraryName)'==''"></TypeLibraryName>
+        </Midl>
+    </ItemDefinitionGroup>
+</Project>

--- a/src/package/midlrt/Microsoft.Windows.MidlRT.targets
+++ b/src/package/midlrt/Microsoft.Windows.MidlRT.targets
@@ -1,0 +1,340 @@
+﻿<!--
+***********************************************************************************************
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <!-- Only do this for MSBuild versions below 16.0
+             as it is since done automatically, see https://github.com/microsoft/msbuild/pull/3605-->
+        <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)'  &lt;= '15'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <MidlRTProjectWinMD>$(OutDir)$(RootNamespace).winmd</MidlRTProjectWinMD>
+        <MidlRTMergedDir>$(IntDir)Merged\</MidlRTMergedDir>
+        <MidlRTUnmergedDir>$(IntDir)Unmerged\</MidlRTUnmergedDir>
+
+        <ModernMidlRT Condition="'$(ModernMidlRT)'==''">true</ModernMidlRT>
+
+        <GeneratedFilesDir Condition="'$(GeneratedFilesDir)' == ''">$(IntDir)Generated Files\</GeneratedFilesDir>
+        <!--TEMP: Override NuGet SDK's erroneous setting in uap.props -->
+        <WindowsSDK_MetadataFoundationPath Condition="('$(WindowsSDK_MetadataFoundationPath)'!='') And !Exists($(WindowsSDK_MetadataFoundationPath))">$(WindowsSDK_MetadataPathVersioned)</WindowsSDK_MetadataFoundationPath>
+        <!-- CAExcludePath is used to set an environment variable, so make sure this is defined on a single line. -->
+        <CAExcludePath>$(GeneratedFilesDir);$(CAExcludePath)</CAExcludePath>
+
+        <!-- Note: Before* targets run before Compute* targets. -->
+        <ComputeMidlInputsTargets>
+            $(ComputeMidlInputsTargets);MidlRTSetMidlReferences;
+        </ComputeMidlInputsTargets>
+        <AfterMidlTargets>
+            $(AfterMidlTargets);
+            GetMidlRTMdMergeInputs;
+            MidlRTMergeProjectWinMDInputs;
+            GetResolvedWinMD;
+            MidlRTCopyWinMDToOutputDirectory;
+        </AfterMidlTargets>
+        <ResolveAssemblyReferencesDependsOn>
+            $(ResolveAssemblyReferencesDependsOn);GetMidlRTProjectWinMDReferences;MidlRTMarkStaticLibrariesPrivate;
+        </ResolveAssemblyReferencesDependsOn>
+        <CleanDependsOn>
+            $(CleanDependsOn);MidlRTClean
+        </CleanDependsOn>
+
+    </PropertyGroup>
+
+    <!-- For a static library we don't want the winmd/lib/pdb to be packaged -->
+    <PropertyGroup Condition="'$(ConfigurationType)' == 'StaticLibrary'">
+        <IncludeCopyWinMDArtifactsOutputGroup>false</IncludeCopyWinMDArtifactsOutputGroup>
+    </PropertyGroup>
+
+    <Target Name="MidlRTClean">
+        <ItemGroup>
+            <_FilesToDelete Remove="@(_FilesToDelete)"/>
+            <_FilesToDelete Include="$(GeneratedFilesDir)*.idl"/>
+            <_FilesToDelete Include="$(OutDir)*.winmd"/>
+            <_FilesToDelete Include="$(IntDir)*.winmd"/>
+            <_FilesToDelete Include="$(IntDir)*.rsp"/>
+            <_FilesToDelete Include="$(MidlRTMergedDir)**"/>
+            <_FilesToDelete Include="$(MidlRTUnmergedDir)**"/>
+        </ItemGroup>
+        <Delete Files="@(_FilesToDelete)"/>
+    </Target>
+
+    <!-- Target used only to evaluate MidlRTGenerateWindowsMetadata if it doesn't already have a value -->
+    <Target Name="MidlRTComputeGenerateWindowsMetadata"
+            DependsOnTargets="GetMidlRTProjectWinMDReferences;$(MidlRTComputeGenerateWindowsMetadataDependsOn)">
+
+        <PropertyGroup>
+            <!-- For static libraries, only idl causes a winmd to be generated. 
+                 For exe/dll, static libraries that produce a WinMD will be merged, 
+                 so they also cause a WinMD to be generated-->
+            <MidlRTGenerateWindowsMetadata Condition="'$(ConfigurationType)' != 'StaticLibrary' AND '@(MidlRTStaticProjectWinMDReferences)@(Midl)'!= ''">true</MidlRTGenerateWindowsMetadata>
+            <MidlRTGenerateWindowsMetadata Condition="'$(ConfigurationType)' == 'StaticLibrary' AND '@(Midl)'!= ''">true</MidlRTGenerateWindowsMetadata>
+
+            <!-- At this point we checked all cases where we do generate a WinMD.
+                 The remaining option is no WinMD. -->
+            <MidlRTGenerateWindowsMetadata Condition="'$(MidlRTGenerateWindowsMetadata)'== ''">false</MidlRTGenerateWindowsMetadata>
+        </PropertyGroup>
+
+    </Target>
+
+    <Target Name="ComputeGetResolvedWinMD"
+            Condition="'$(MidlRTGenerateWindowsMetadata)' == ''">
+        <!-- If MidlRTGenerateWindowsMetadata is not defined, compute it.-->
+        <!-- We use Calltarget, so we don't run anything including DependsOnTargets
+             targets if $(MidlRTGenerateWindowsMetadata) already has a value.-->
+        <CallTarget Targets="MidlRTComputeGenerateWindowsMetadata" />
+    </Target>
+
+    <!-- This target overrides the GetResolvedWinMD target used to resolve the WinMD for native projects
+         so it is aware of the C++/WinRT generated WinMD.
+         Since not every project that consumes C++/WinRT uses it to generate a WinMD,
+         we need to keep the CX logic as well. -->
+    <Target Name="GetResolvedWinMD"
+            DependsOnTargets="ComputeGetResolvedWinMD"
+            Returns="@(WinMDFullPath)">
+
+        <!-- Copied from the CX GetResolvedWinMD target in Microsoft.CppBuild.targets -->
+        <ItemGroup>
+            <!-- To evaluate the GenerateWindowsMetadata value we need @(Link) to contains at least one element-->
+            <Link Include="tmp" Condition="'@(Link)'==''">
+                <DeleteSoon>true</DeleteSoon>
+            </Link>
+
+            <!-- Condition is modified to only do this if MidlRTGenerateWindowsMetadata is not true. -->
+            <WinMDFullPath Condition="'%(Link.GenerateWindowsMetadata)' == 'true' AND '$(MidlRTGenerateWindowsMetadata)' != 'true'"
+                           Include="@(Link->Metadata('WindowsMetadataFile')->FullPath()->Distinct()->ClearMetadata())">
+                <TargetPath>$([System.IO.Path]::GetFileName('%(Link.WindowsMetadataFile)'))</TargetPath>
+                <Primary>true</Primary>
+            </WinMDFullPath>
+
+            <WinMDFullPath>
+                <Implementation>$(WinMDImplementationPath)$(TargetName)$(TargetExt)</Implementation>
+                <FileType>winmd</FileType>
+                <WinMDFile>true</WinMDFile>
+                <ProjectType>$(ConfigurationType)</ProjectType>
+            </WinMDFullPath>
+
+            <Link Remove="@(Link)" Condition="'%(Link.DeleteSoon)' == 'true'" />
+        </ItemGroup>
+
+        <!-- Add primary WinMD to the WinMDFullPath if MidlRTGenerateWindowsMetadata is true -->
+        <ItemGroup>
+            <WinMDFullPath Include="$(MidlRTProjectWinMD)"  Condition="'$(MidlRTGenerateWindowsMetadata)' == 'true'">
+                <TargetPath>$([System.IO.Path]::GetFileName('$(MidlRTProjectWinMD)'))</TargetPath>
+                <Primary>true</Primary>
+                <Implementation Condition="'$(TargetExt)' == '.dll'">$(WinMDImplementationPath)$(TargetName)$(TargetExt)</Implementation>
+                <FileType>winmd</FileType>
+                <WinMDFile>true</WinMDFile>
+                <ProjectName>$(MSBuildProjectName)</ProjectName>
+                <ProjectType>$(ConfigurationType)</ProjectType>
+            </WinMDFullPath>
+        </ItemGroup>
+
+        <Message Text="GetResolvedWinMD: @(WinMDFullPath->'%(FullPath)')" Importance="$(MidlRTVerbosity)"/>
+    </Target>
+
+    <!-- Static library reference WinMDs are merged into the project WinMD that
+         references it and might have the same name because they often share namespace. 
+         Therefore they shouldn't be copied to the output folder
+         because they might override files in the output folder with the
+         same name, causing missing types. -->
+    <Target Name="MidlRTMarkStaticLibrariesPrivate"
+            DependsOnTargets="ResolveProjectReferences"
+            Returns="@(_ResolvedProjectReferencePaths)">
+        <ItemGroup>
+            <_ResolvedProjectReferencePaths Condition="'%(_ResolvedProjectReferencePaths.ProjectType)' == 'StaticLibrary'">
+                <Private>false</Private>
+            </_ResolvedProjectReferencePaths>
+        </ItemGroup>
+    </Target>
+
+    <!--Define platform WinMD references for modern IDL compilation-->
+    <Target Name="GetMidlRTPlatformWinMDReferences"
+            DependsOnTargets="ResolveAssemblyReferences;$(GetMidlRTPlatformWinMDReferencesDependsOn)"
+            Returns="@(MidlRTPlatformWinMDReferences)">
+        <ItemGroup>
+            <_MidlRTPlatformWinMDReferences Remove="@(_MidlRTPlatformWinMDReferences)" />
+            <_MidlRTPlatformWinMDReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.IsSystemReference)' == 'true' and '%(ReferencePath.WinMDFile)' == 'true' and '%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference'" />
+            <_MidlRTPlatformWinMDReferences Condition="'$(MidlRTOverrideSDKReferences)' != 'true'" Include="$(WindowsSDK_MetadataPathVersioned)\**\Windows.Foundation.FoundationContract.winmd" />
+            <_MidlRTPlatformWinMDReferences Condition="'$(MidlRTOverrideSDKReferences)' != 'true'" Include="$(WindowsSDK_MetadataPathVersioned)\**\Windows.Foundation.UniversalApiContract.winmd" />
+            <_MidlRTPlatformWinMDReferences Condition="'$(MidlRTOverrideSDKReferences)' != 'true'" Include="$(WindowsSDK_MetadataPathVersioned)\**\Windows.Networking.Connectivity.WwanContract.winmd" />
+            <_MidlRTPlatformWinMDReferences Include="$(MidlRTSDKReferences)" />
+            <MidlRTPlatformWinMDReferences Remove="@(MidlRTPlatformWinMDReferences)"/>
+            <MidlRTPlatformWinMDReferences Include="@(_MidlRTPlatformWinMDReferences->'%(FullPath)'->Distinct())">
+                <WinMDPath>%(FullPath)</WinMDPath>
+            </MidlRTPlatformWinMDReferences>
+        </ItemGroup>
+        <Message Text="MidlRTPlatformWinMDReferences: @(MidlRTPlatformWinMDReferences->'%(WinMDPath)')" Importance="$(MidlRTVerbosity)"/>
+    </Target>
+
+    <!--Get direct WinMD references (including Nuget packages) for projections, IDL processing, and AppX packaging-->
+    <Target Name="GetMidlRTDirectWinMDReferences"
+            DependsOnTargets="ResolveAssemblyReferences;$(GetMidlRTDirectWinMDReferencesDependsOn)"
+            Returns="@(MidlRTDirectWinMDReferences)">
+        <ItemGroup>
+            <_MidlRTDirectWinMDReferences Remove="@(_MidlRTDirectWinMDReferences)" />
+            <_MidlRTDirectWinMDReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.IsSystemReference)' != 'true' and '%(ReferencePath.WinMDFile)' == 'true' and '%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference'" />
+            <MidlRTDirectWinMDReferences Remove="@(MidlRTDirectWinMDReferences)"/>
+            <MidlRTDirectWinMDReferences Include="@(_MidlRTDirectWinMDReferences)">
+                <WinMDPath>%(FullPath)</WinMDPath>
+            </MidlRTDirectWinMDReferences>
+        </ItemGroup>
+        <Message Text="MidlRTDirectWinMDReferences: @(MidlRTDirectWinMDReferences->'%(WinMDPath)')" Importance="$(MidlRTVerbosity)"/>
+    </Target>
+
+    <!--Get direct WinMD project references for projections, IDL processing, and AppX packaging-->
+    <Target Name="GetMidlRTProjectWinMDReferences"
+            DependsOnTargets="ResolveProjectReferences;$(GetMidlRTProjectWinMDReferencesDependsOn)"
+            Returns="@(MidlRTStaticProjectWinMDReferences);@(MidlRTDynamicProjectWinMDReferences)">
+        <ItemGroup>
+            <!-- Get static library project references -->
+            <_MidlRTStaticProjectReferences Remove="@(_MidlRTStaticProjectReferences)"/>
+            <_MidlRTStaticProjectReferences Include="@(_ResolvedProjectReferencePaths)"
+                Condition= "'%(_ResolvedProjectReferencePaths.ProjectType)'=='StaticLibrary' AND 
+                    '%(_ResolvedProjectReferencePaths.WinMDFile)' == 'true'"/>
+            <!--Get dynamic library project references-->
+            <_MidlRTDynamicProjectReferences Remove="@(_MidlRTDynamicProjectReferences)"/>
+            <_MidlRTDynamicProjectReferences Include="@(_ResolvedProjectReferencePaths)"
+                Condition= "'%(_ResolvedProjectReferencePaths.ProjectType)'!='StaticLibrary' AND 
+                ('%(_ResolvedProjectReferencePaths.WinMDFile)' == 'true' OR
+                    ('%(_ResolvedProjectReferencePaths.WinMDFile)' == '' AND '%(_ResolvedProjectReferencePaths.Extension)' == '.winmd'))"/>
+        </ItemGroup>
+        <ItemGroup>
+            <MidlRTStaticProjectWinMDReferences Remove="@(MidlRTStaticProjectWinMDReferences)" />
+            <MidlRTStaticProjectWinMDReferences Include="@(_MidlRTStaticProjectReferences)">
+                <WinMDPath>%(FullPath)</WinMDPath>
+            </MidlRTStaticProjectWinMDReferences>
+            <MidlRTDynamicProjectWinMDReferences Remove="@(MidlRTDynamicProjectWinMDReferences)" />
+            <MidlRTDynamicProjectWinMDReferences Include="@(_MidlRTDynamicProjectReferences)">
+                <WinMDPath>%(FullPath)</WinMDPath>
+            </MidlRTDynamicProjectWinMDReferences>
+        </ItemGroup>
+        <Message Text="MidlRTStaticProjectWinMDReferences: @(MidlRTStaticProjectWinMDReferences->'%(WinMDPath)')" Importance="$(MidlRTVerbosity)"/>
+        <Message Text="MidlRTDynamicProjectWinMDReferences: @(MidlRTDynamicProjectWinMDReferences->'%(WinMDPath)')" Importance="$(MidlRTVerbosity)"/>
+    </Target>
+
+    <Target Name="MidlRTResolveReferences" DependsOnTargets="GetMidlRTPlatformWinMDReferences;GetMidlRTDirectWinMDReferences;GetMidlRTProjectWinMDReferences;$(MidlRTResolveReferencesDependsOn)" />
+
+    <!-- Calculates the input files and metadata directories to be passed to MdMerge -->
+    <Target Name="GetMidlRTMdMergeInputs"
+                DependsOnTargets="MidlRTResolveReferences;"
+                Returns="@(MidlRTMdMergeMetadataDirectories);@(MidlRTMdMergeInputs)">
+        <ItemGroup>
+            <_MdMergeInputs Remove="@(_MdMergeInputs)"/>
+            <_MdMergeInputs Include="@(Midl)">
+                <WinMDPath>%(Midl.OutputDirectory)%(Midl.MetadataFileName)</WinMDPath>
+                <MdMergeOutputFile>$(MidlRTProjectWinMD)</MdMergeOutputFile>
+            </_MdMergeInputs>
+            <!-- Static libraries don't mdmerge other static libraries.
+                 Instead they are passed as independent inputs for the component projection. -->
+            <_MdMergeInputs Include="@(MidlRTStaticProjectWinMDReferences)" Condition="'$(ConfigurationType)' != 'StaticLibrary'">
+                <MdMergeOutputFile>$(MidlRTProjectWinMD)</MdMergeOutputFile>
+            </_MdMergeInputs>
+            <_MdMergeReferences Remove="@(_MdMergeReferences)" />
+            <!-- Static libraries don't mdmerge other static libraries.
+                 They are however used as references so idl can reference classes from other libs. -->
+            <_MdMergeReferences Include="@(MidlRTStaticProjectWinMDReferences)" Condition="'$(ConfigurationType)' == 'StaticLibrary'" />
+            <_MdMergeReferences Include="@(MidlRTDirectWinMDReferences)" />
+            <_MdMergeReferences Include="@(MidlRTDynamicProjectWinMDReferences)" />
+            <_MdMergeReferences Include="@(MidlRTPlatformWinMDReferences)" />
+            <MidlRTMdMergeMetadataDirectories Remove="@(MidlRTMdMergeMetadataDirectories)" />
+            <MidlRTMdMergeMetadataDirectories Include="@(_MdMergeReferences->'%(RelativeDir)'->Distinct())" />
+            <MidlRTMdMergeInputs Remove="@(MidlRTMdMergeInputs)" />
+            <MidlRTMdMergeInputs Include="@(_MdMergeInputs->'%(WinMDPath)'->Distinct())" />
+        </ItemGroup>
+        <Message Text="MidlRTMdMergeInputs: @(MidlRTMdMergeInputs)" Importance="$(MidlRTVerbosity)"/>
+        <Message Text="MidlRTMdMergeMetadataDirectories: @(MidlRTMdMergeMetadataDirectories)" Importance="$(MidlRTVerbosity)"/>
+    </Target>
+
+    <!--Insert Midl /references to Platform WinMDs, library reference WinMDs, and direct reference WinMDs-->
+    <Target Name="MidlRTSetMidlReferences"
+            Condition="'$(ModernMidlRT)' != 'false'"
+            DependsOnTargets="GetMidlRTPlatformWinMDReferences;GetMidlRTDirectWinMDReferences;GetMidlRTProjectWinMDReferences;$(MidlRTSetMidlReferencesDependsOn)"
+            Inputs="$(MSBuildAllProjects);@(MidlRTDirectWinMDReferences);@(MidlRTStaticProjectWinMDReferences);@(MidlRTDynamicProjectWinMDReferences);@(MidlRTPlatformWinMDReferences)"
+            Outputs="$(IntDir)midlrt.rsp">
+        <ItemGroup>
+            <_MidlReferences Remove="@(_MidlReferences)"/>
+            <_MidlReferences Include="@(MidlRTDirectWinMDReferences)"/>
+            <_MidlReferences Include="@(MidlRTStaticProjectWinMDReferences)"/>
+            <_MidlReferences Include="@(MidlRTDynamicProjectWinMDReferences)"/>
+            <_MidlReferences Include="@(MidlRTPlatformWinMDReferences)"/>
+            <_MidlReferencesDistinct Remove="@(_MidlReferencesDistinct)" />
+            <_MidlReferencesDistinct Include="@(_MidlReferences->'%(WinMDPath)'->Distinct())" />
+            <Midl Condition="'%(Midl.DisableReferences)'==''">
+                <AdditionalOptions>%(Midl.AdditionalOptions) %40"$(IntDir)midlrt.rsp"</AdditionalOptions>
+            </Midl>
+        </ItemGroup>
+        <PropertyGroup>
+            <_MidlrtParameters>@(_MidlReferencesDistinct->'/reference &quot;%(WinMDPath)&quot;','&#x0d;&#x0a;')</_MidlrtParameters>
+        </PropertyGroup>
+        <!-- Always write the midlrt.rsp file when the target runs, because the file is used as the output of this target. -->
+        <WriteLinesToFile
+            File="$(IntDir)midlrt.rsp" Lines="$(_MidlrtParameters)"
+            ContinueOnError="true" Overwrite="true" />
+        <Message Text="MidlRTMidlReferences: @(_MidlReferences->'%(WinMDPath)')" Importance="$(MidlRTVerbosity)"/>
+    </Target>
+
+    <!--Ctrl+F7 (selected file) midl compilation support-->
+    <Target Name="MidlRTSetSelectMidlReferences" BeforeTargets="SelectMidl" DependsOnTargets="MidlRTSetMidlReferences" />
+
+    <!--Merge project-generated WinMDs and project-referenced static library WinMDs into project WinMD-->
+    <Target Name="MidlRTMergeProjectWinMDInputs"
+            DependsOnTargets="Midl;GetMidlRTMdMergeInputs;$(MidlRTMergeProjectWinMDInputsDependsOn)"
+            Inputs="$(MSBuildAllProjects);@(MidlRTMdMergeInputs)"
+            Outputs="@(_MdMergedOutput);$(IntDir)mdmerge.rsp">
+        <PropertyGroup>
+            <!--Note: MidlRTNamespaceMergeDepth supersedes MidlRTMergeDepth-->
+            <_MdMergeDepth Condition="'$(MidlRTNamespaceMergeDepth)' != ''">-n:$(MidlRTNamespaceMergeDepth)</_MdMergeDepth>
+            <_MdMergeDepth Condition="'$(_MdMergeDepth)' == ''">$(MidlRTMergeDepth)</_MdMergeDepth>
+            <_MdMergeDepth Condition="'$(_MdMergeDepth)' == '' And '$(MidlRTRootNamespaceAutoMerge)' == 'true'">-n:$(RootNamespace.Split('.').length)</_MdMergeDepth>
+            <_MdMergeDepth Condition="'$(_MdMergeDepth)' == '' And ('@(Page)' != '' Or '@(ApplicationDefinition)' != '')">-n:1</_MdMergeDepth>
+            <_MdMergeCommand>$(MdMergePath)mdmerge %40"$(IntDir)mdmerge.rsp"</_MdMergeCommand>
+        </PropertyGroup>
+        <PropertyGroup>
+            <!-- mdmerge.exe wants the folders to not have a trailing \ -->
+            <_MdMergeParameters>-v @(MidlRTMdMergeMetadataDirectories->'-metadata_dir &quot;%(RelativeDir).&quot;', '&#x0d;&#x0a;')</_MdMergeParameters>
+            <_MdMergeParameters>$(_MdMergeParameters) @(MidlRTMdMergeInputs->'-i &quot;%(Identity)&quot;', '&#x0d;&#x0a;')</_MdMergeParameters>
+            <_MdMergeParameters>$(_MdMergeParameters) -o &quot;$(MidlRTMergedDir.TrimEnd('\'))&quot; -partial $(_MdMergeDepth)</_MdMergeParameters>
+        </PropertyGroup>
+        <!-- Always write the mdmerge.rsp file when the target runs, because the file is used as the output of this target. -->
+        <WriteLinesToFile
+            File="$(IntDir)mdmerge.rsp" Lines="$(_MdMergeParameters)"
+            ContinueOnError="true" Overwrite="true" />
+        <MakeDir Directories="$(MidlRTUnmergedDir);$(MidlRTMergedDir)" />
+        <Message Text="$(_MdMergeCommand)" Importance="$(MidlRTVerbosity)" Condition="'@(MidlRTMdMergeInputs)' != ''" />
+        <!-- Only run mdmerge.exe when we actually have inputs -->
+        <Exec Command="$(_MdMergeCommand)" Condition="'@(MidlRTMdMergeInputs)' != ''" />
+        <ItemGroup>
+            <_MdMergedOutput Remove="@(_MdMergedOutput)"/>
+            <_MdMergedOutput Include="$(MidlRTMergedDir)*.winmd"/>
+        </ItemGroup>
+        <Message Text="MidlRTMdMerge output: @(MdMergeOutput)" Importance="$(MidlRTVerbosity)"/>
+    </Target>
+
+    <!-- Only copy winmd to output folder if MidlRTGenerateWindowsMetadata is true -->
+    <!-- Note that Condition is evaluated before DependsOnTargets are run -->
+    <Target Name="MidlRTCopyWinMDToOutputDirectory"
+            Condition="'$(MidlRTGenerateWindowsMetadata)' == 'true'"
+            DependsOnTargets="MidlRTMergeProjectWinMDInputs;$(MidlRTCopyWinMDToOutputDirectoryDependsOn)"
+            Inputs="@(_MdMergedOutput)"
+            Outputs="$(MidlRTProjectWinMD)">
+        <Copy UseHardlinksIfPossible="$(MidlRTUseHardlinksIfPossible)"
+            SkipUnchangedFiles="$(MidlRTSkipUnchangedFiles)"
+            SourceFiles="@(_MdMergedOutput)"
+            DestinationFiles="@(_MdMergedOutput->'$(OutDir)%(Filename)%(Extension)')" />
+    </Target>
+
+    <!--Append any additional item metadata after all default and project settings have been applied-->
+    <ItemDefinitionGroup>
+      <Midl Condition="'$(ModernMidlRT)' != 'false'">
+        <AdditionalMetadataDirectories Condition="'%(AdditionalMetadataDirectories)' == '' And '$(WindowsSDK_MetadataFoundationPath)' != ''">$(WindowsSDK_MetadataFoundationPath);%(AdditionalMetadataDirectories)</AdditionalMetadataDirectories>
+        <AdditionalMetadataDirectories Condition="'%(AdditionalMetadataDirectories)' == '' And '$(WindowsSDK_MetadataFoundationPath)' == ''">$(WindowsSDK_MetadataPath);%(AdditionalMetadataDirectories)</AdditionalMetadataDirectories>
+        <AdditionalOptions>%(AdditionalOptions) /nomidl</AdditionalOptions>
+      </Midl>
+    </ItemDefinitionGroup>
+  
+    <Import Project="Microsoft.Windows.MidlRT.IdlGen.targets" Condition="'$(ModernMidlRT)' == 'false'"/>
+</Project>

--- a/src/package/midlrt/SignConfig.xml
+++ b/src/package/midlrt/SignConfig.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?> 
+<SignConfigXML> 
+  <job configuration="Release" dest="__OUTPATHROOT__" jobname="MidlRT NuGet" approvers=""> 
+    <file src="__INPATHROOT__\Microsoft.Windows.MidlRT.*.nupkg" signType="CP-401405" dest="__OUTPATHROOT__\Microsoft.Windows.MidlRT.*.nupkg" /> 
+  </job> 
+</SignConfigXML> 

--- a/src/package/midlrt/readme.md
+++ b/src/package/midlrt/readme.md
@@ -1,0 +1,26 @@
+## The Windows Runtime (WinRT) API Genaration tool
+
+The Microsoft.Windows.MidlRT package provides targets for running the midlrt.exe tool (which ships) in the Windows SDK. This enables you to build WinRT APIs that generate a .winmd file using either the MIDL2.0 or MIDL3.0 syntax.
+
+For more information on MIDL3 and all the benefits it brings, including improved compilation times, see the official documentation: https://docs.microsoft.com/en-us/uwp/midl-3/
+
+- Nuget Package: https://www.nuget.org/packages/Microsoft.Windows.MidlRT/
+
+## Migrating from MIDL2.0 to MIDL3
+
+See the official documentation for how to migrate from MIDL2.0 syntax to MIDL3.0: https://docs.microsoft.com/en-us/uwp/midl-3/from-midlrt
+
+## Usage
+
+The MidlRT package is **production only**, which means it enables you to generate your own .winmd file. If you are producing a .winmd, it's likely that you'll need to consume other WinRT API's as well, which can be done through the consumption technology of your choice:
+
+- Microsoft.Windows.CppWinRT: https://www.nuget.org/packages/Microsoft.Windows.CppWinRT/
+- Microsoft.Windows.AbiWinRT: https://www.nuget.org/packages/Microsoft.Windows.AbiWinRT/
+  - **Note: Microsoft.Windows.AbiWinRT is only intended for legacy code bases,**
+       **and doesn't provide support for the latest C++ language features that Microsoft.Windows.CppWinRT does.**
+
+If you are using `Microsoft.Windows.CppWinRT` there is no need to reference this Nuget directly.
+
+|  Property |  Description |
+|-----------|---------------|
+| `ModernMidlRT` | Uses MIDL3.0. Defaults to `true`. |

--- a/src/package/midlrt/readme.md
+++ b/src/package/midlrt/readme.md
@@ -1,10 +1,10 @@
 ## The Windows Runtime (WinRT) API Genaration tool
 
-The Microsoft.Windows.MidlRT package provides targets for running the midlrt.exe tool (which ships) in the Windows SDK. This enables you to build WinRT APIs that generate a .winmd file using either the MIDL2.0 or MIDL3.0 syntax.
-
-For more information on MIDL3 and all the benefits it brings, including improved compilation times, see the official documentation: https://docs.microsoft.com/en-us/uwp/midl-3/
+The Microsoft.Windows.MidlRT package provides targets for running the midlrt.exe tool that ships in the Windows SDK. This enables you to build WinRT APIs that generate a .winmd file using either the MIDL2.0 or MIDL3.0 syntax.
 
 - Nuget Package: https://www.nuget.org/packages/Microsoft.Windows.MidlRT/
+
+For more information on MIDL3.0 and all the benefits it brings, including improved compilation times, see the official documentation: https://docs.microsoft.com/en-us/uwp/midl-3/
 
 ## Migrating from MIDL2.0 to MIDL3
 

--- a/src/package/midlrt/readme.txt
+++ b/src/package/midlrt/readme.txt
@@ -1,0 +1,8 @@
+========================================================================
+The Microsoft.Windows.MidlRT NuGet package provides targets
+for producing Windows Runtime APIs. 
+
+========================================================================
+For more information, including usage, visit:
+https://github.com/microsoft/xlang/tree/master/src/package/midlrt
+========================================================================


### PR DESCRIPTION
Fixes #678 

This PR takes the logic from the `Microsoft.Windows.CppWinRT` nuget package and decouples it from that package, so that other consumers, like Win2D and WinUI, can use it without having to switch all their code over to using C++/WinRT. Ideally once this package is in, the C++/WinRT package removes it's custom logic and takes a dependency on this package.

/cc @Scottj1s 