### PR TITLE
cppwinrt updates for pywinrt codegen

### DIFF
--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -1600,6 +1600,14 @@ struct pinterface_python_type<%<%>>
 
     void write_struct_converter_decl(writer& w, TypeDef const& type)
     {
+        auto ns = type.TypeNamespace();
+        auto name = type.TypeName();
+        if ((ns == "Windows.Foundation") && (name == "EventRegistrationToken"))
+        {
+            // The declaration for event_token is baked into pybase.h to address ordering issues.
+            return;
+        }
+        
         w.write("template<>\nstruct converter<%>\n{\n", type);
         {
             writer::indent_guard g{ w };

--- a/src/tool/python/file_writers.h
+++ b/src/tool/python/file_writers.h
@@ -156,7 +156,7 @@ namespace pywinrt
     }
 
     
-    inline void write_setup_py(stdfs::path const& folder, std::vector<std::string> const& namespaces)
+    inline void write_setup_py(stdfs::path const& folder, std::vector<std::string> const& /*namespaces*/)
     {
         writer w;
 


### PR DESCRIPTION
This updates Python WinRT support so that it can compile with the latest C++ /WinRT build, and removes references to the C++ /WinRT implementation namespace. This is a first step in attempting to enable Python 3.8 support, but additional work will probably be required.

Specifically, this pull request:
* moves the definition of event_token's converter overload in pybase.h to avoid an dependency cycle between py.Windows.Foundation.h and py.Windows.Foundation.Collections.h. This is likely due to stricter compiler validation in VS 2019. Due to the nature of the dependency, it's insufficient to just forward declare it.
* Removes the _is_struct_category_v & struct_checker templates, which were unused and had dependencies on now-removed C++ /WinRT internals
* pinterface_checker is updated to detect the presence of template type arguments to spot pinterfaces, instead of using C++ /WinRT internal traits that no longer exist.
* Changes how delegates are detected based on the presence of IUnknown, but lack of IInspectable. This should be sufficient and avoid the need to check for delegates using C++ /WinRT internal property. Again, more testing is needed. This change was also made to avoid a dependency on C++ /WinRT internals.
