### PR TITLE
Remove 'extern' from inline IID definition

### DIFF
--- a/src/tool/abi/types.cpp
+++ b/src/tool/abi/types.cpp
@@ -558,7 +558,7 @@ static void write_cpp_interface_definition(writer& w, T const& type)
 
     w.write(R"^-^(%};
 
-%extern MIDL_CONST_ID IID& IID_% = _uuidof(%);
+%MIDL_CONST_ID IID& IID_% = _uuidof(%);
 )^-^", indent{}, indent{}, type.cpp_abi_name(), type.cpp_abi_name());
 
     w.pop_namespace();


### PR DESCRIPTION
`extern` on a definition is pointless and Clang warns about it.