### PR TITLE
Updating build to target python 3.9

### DIFF
--- a/src/package/pywinrt/projection/AzurePipelinesTemplates/job-build-projection.yml
+++ b/src/package/pywinrt/projection/AzurePipelinesTemplates/job-build-projection.yml
@@ -17,5 +17,5 @@ jobs:
   - template: steps-build-projection.yml
     parameters:
       architecture: $(buildArchitecture)  
-      pythonVersionSpec: '3.8.x'
+      pythonVersionSpec: '3.9.x'
       projectionType: $(ProjectionType)

--- a/src/package/pywinrt/projection/AzurePipelinesTemplates/job-package-projection.yml
+++ b/src/package/pywinrt/projection/AzurePipelinesTemplates/job-package-projection.yml
@@ -18,7 +18,7 @@ jobs:
 
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8.x'
+      versionSpec: '3.9.x'
       addToPath: true 
 
   - script: pip install wheel

--- a/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-build-projection.yml
+++ b/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-build-projection.yml
@@ -1,6 +1,6 @@
 parameters: # defaults for any parameters that aren't specified
   architecture: 'x86'
-  pythonVersionSpec: '3.8.x'
+  pythonVersionSpec: '3.9.x'
   projectionType: 'partial'
 
 steps:

--- a/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-package-projection.yml
+++ b/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-package-projection.yml
@@ -21,7 +21,7 @@ steps:
     contents: 'LICENSE'
     targetFolder: $(Build.ArtifactStagingDirectory)/projection/${{ parameters.architecture }} 
 
-- script: python $(Build.SourcesDirectory)/src/package/pywinrt/projection/setup.py bdist_wheel --python-tag cp38 --plat-name $(platname)
+- script: python $(Build.SourcesDirectory)/src/package/pywinrt/projection/setup.py bdist_wheel --python-tag cp39 --plat-name $(platname)
   workingDirectory: $(Build.ArtifactStagingDirectory)/projection/${{ parameters.architecture }} 
   displayName: python setup.py bdist_wheel (${{ parameters.architecture }})
 


### PR DESCRIPTION
This is a minimal update needed to produce a PyPi package for Python 3.9, which just released a few days ago.
resolves #709