### PR TITLE
Fix a bug with upper case DLL extension and added Embedded Manifest Test in c#

### DIFF
--- a/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/EmbeddedManifestManagedTest.csproj
+++ b/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/EmbeddedManifestManagedTest.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Platforms>x64;x86</Platforms>
+    <ApplicationIcon />
+    <Win32Resource></Win32Resource>
+    <ApplicationManifest>EmbeddedManifestManagedTest.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EmbeddedTestComponent\EmbeddedTestComponent.vcxproj" />
+    <ProjectReference Include="..\mwinrtact\mwinrtact.csproj" />
+    <ProjectReference Include="..\TestComponent\TestComponent.vcxproj" />
+    <ProjectReference Include="..\UndockedRegFreeWinRT\UndockedRegFreeWinRT.vcxproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="TestComponent">
+      <HintPath>..\_build\x86\Debug\TestComponent.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/EmbeddedManifestManagedTest.manifest
+++ b/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/EmbeddedManifestManagedTest.manifest
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+      type="win32"
+      name="EmbeddedManifestTest"
+      version="1.0.0.0" />
+  <file name="TestComponent.dll">
+    <activatableClass
+        name="TestComponent.ClassBoth"
+        threadingModel="Both"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+        name="TestComponent.ClassSta"
+        threadingModel="sta"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+    <activatableClass
+        name="TestComponent.ClassMta"
+        threadingModel="mta"
+        xmlns="urn:schemas-microsoft-com:winrt.v1" />
+  </file>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type='win32' name="EmbeddedTestComponent" version="1.0.0.0" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/EmbeddedManifestManagedTest.manifest
+++ b/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/EmbeddedManifestManagedTest.manifest
@@ -2,7 +2,7 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
       type="win32"
-      name="EmbeddedManifestTest"
+      name="EmbeddedManifestManagedTest"
       version="1.0.0.0" />
   <file name="TestComponent.dll">
     <activatableClass

--- a/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/Program.cs
+++ b/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/Program.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using TestComponent;
+using EmbeddedTestComponent;
+using Microsoft.Windows;
+
+namespace EmbeddedManifestManagedTest
+{
+    class Program
+    {
+        public static bool succeeded;
+        private static int testsRan;
+        private static int testsFailed;
+
+        static void TestComponentClassBoth(int expected)
+        {
+            try
+            {
+                TestComponent.ClassBoth c = new TestComponent.ClassBoth();
+                succeeded = (expected == c.Apartment);
+            }
+            catch
+            {
+                succeeded = false;
+            }
+        }
+
+        static void TestComponentClassMta(int expected)
+        {
+            try
+            {
+                TestComponent.ClassMta c = new TestComponent.ClassMta();
+                succeeded = (expected == c.Apartment);
+            }
+            catch
+            {
+                succeeded = false;
+            }
+        }
+
+        static void TestComponentClassSta(int expected)
+        {
+            try
+            {
+                TestComponent.ClassSta c = new TestComponent.ClassSta();
+                succeeded = (expected == c.Apartment);
+            }
+            catch
+            {
+                succeeded = false;
+            }
+        }
+
+        static void EmbeddedTestComponentClassBoth(int expected)
+        {
+            try
+            {
+                EmbeddedTestComponent.ClassBoth c = new EmbeddedTestComponent.ClassBoth();
+                succeeded = (expected == c.Apartment);
+            }
+            catch
+            {
+                succeeded = false;
+            }
+        }
+
+        static void EmbeddedTestComponentClassMta(int expected)
+        {
+            try
+            {
+                EmbeddedTestComponent.ClassMta c = new EmbeddedTestComponent.ClassMta();
+                succeeded = (expected == c.Apartment);
+            }
+            catch
+            {
+                succeeded = false;
+            }
+        }
+
+        static void EmbeddedTestComponentClassSta(int expected)
+        {
+            try
+            {
+                EmbeddedTestComponent.ClassSta c = new EmbeddedTestComponent.ClassSta();
+                succeeded = (expected == c.Apartment);
+            }
+            catch
+            {
+                succeeded = false;
+            }
+        }
+
+        static bool RunTest(System.Threading.ThreadStart testThreadStart, System.Threading.ApartmentState apartmentState)
+        {
+            testsRan++;
+            System.Threading.Thread testThread = new System.Threading.Thread(testThreadStart);
+            succeeded = false;
+            testThread.SetApartmentState(apartmentState);
+            testThread.Start();
+            testThread.Join();
+            return succeeded;
+        }
+
+        static int Main(string[] args)
+        {
+            UndockedRegFreeWinrt.Initialize();
+            Console.WriteLine("Undocked RegFree Embedded Manifest Managed Test - Starting");
+
+            if (!RunTest(new System.Threading.ThreadStart(() => TestComponentClassBoth(3)), System.Threading.ApartmentState.STA))
+            {
+                Console.WriteLine("TestComponent Both to STA test failed");
+                testsFailed++;
+            }
+            if (!RunTest(new System.Threading.ThreadStart(() => TestComponentClassBoth(1)), System.Threading.ApartmentState.MTA))
+            {
+                Console.WriteLine("TestComponent Both to MTA test failed");
+                testsFailed++;
+            }
+            if (!RunTest(new System.Threading.ThreadStart(() => TestComponentClassMta(1)), System.Threading.ApartmentState.STA))
+            {
+                Console.WriteLine("TestComponent MTA to STA test failed");
+                testsFailed++;
+            }
+            if (RunTest(new System.Threading.ThreadStart(() => TestComponentClassSta(1)), System.Threading.ApartmentState.MTA))
+            {
+                Console.WriteLine("TestComponent STA to MTA should failed");
+                testsFailed++;
+            }
+
+            if (!RunTest(new System.Threading.ThreadStart(() => EmbeddedTestComponentClassBoth(3)), System.Threading.ApartmentState.STA))
+            {
+                Console.WriteLine("EmbeddedTestComponent Both to STA test failed");
+                testsFailed++;
+            }
+            if (!RunTest(new System.Threading.ThreadStart(() => EmbeddedTestComponentClassBoth(1)), System.Threading.ApartmentState.MTA))
+            {
+                Console.WriteLine("EmbeddedTestComponent Both to MTA test failed");
+                testsFailed++;
+            }
+            if (!RunTest(new System.Threading.ThreadStart(() => EmbeddedTestComponentClassMta(1)), System.Threading.ApartmentState.STA))
+            {
+                Console.WriteLine("EmbeddedTestComponent MTA to STA test failed");
+                testsFailed++;
+            }
+            if (RunTest(new System.Threading.ThreadStart(() => EmbeddedTestComponentClassSta(1)), System.Threading.ApartmentState.MTA))
+            {
+                Console.WriteLine("EmbeddedTestComponent STA to MTA should failed");
+                testsFailed++;
+            }
+
+            Console.WriteLine("Undocked RegFree Embedded Manifest Managed Test - " + (testsRan - testsFailed) + " out of " + testsRan + " tests passed");
+            return testsFailed == 0 ? 0 : 1;
+        }
+    }
+}

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT.sln
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT.sln
@@ -39,6 +39,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "mwinrtact", "mwinrtact\mwin
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ManifestParserTest", "ManifestParserTest\ManifestParserTest.vcxproj", "{7DC750DE-F43C-4A3B-9FBF-8D964458829A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmbeddedManifestManagedTest", "EmbeddedManifestManagedTest\EmbeddedManifestManagedTest.csproj", "{F92E8478-FA44-4DB0-8D86-366EBB09AA14}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -166,6 +168,18 @@ Global
 		{7DC750DE-F43C-4A3B-9FBF-8D964458829A}.Release|x64.Build.0 = Release|x64
 		{7DC750DE-F43C-4A3B-9FBF-8D964458829A}.Release|x86.ActiveCfg = Release|Win32
 		{7DC750DE-F43C-4A3B-9FBF-8D964458829A}.Release|x86.Build.0 = Release|Win32
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Debug|ARM.ActiveCfg = Debug|x86
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Debug|x64.ActiveCfg = Debug|x64
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Debug|x64.Build.0 = Debug|x64
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Debug|x86.ActiveCfg = Debug|x86
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Debug|x86.Build.0 = Debug|x86
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Release|Any CPU.ActiveCfg = Release|x86
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Release|ARM.ActiveCfg = Release|x86
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Release|x64.ActiveCfg = Release|x64
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Release|x64.Build.0 = Release|x64
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Release|x86.ActiveCfg = Release|x86
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -178,6 +192,7 @@ Global
 		{5893A945-2C61-4CF5-A433-2FD1A0D04E09} = {301A3B2F-6A25-4BCE-9656-7F36D32B8F7A}
 		{388CB1AF-5D79-4EFE-9EFF-31B48784CEAE} = {301A3B2F-6A25-4BCE-9656-7F36D32B8F7A}
 		{7DC750DE-F43C-4A3B-9FBF-8D964458829A} = {301A3B2F-6A25-4BCE-9656-7F36D32B8F7A}
+		{F92E8478-FA44-4DB0-8D86-366EBB09AA14} = {301A3B2F-6A25-4BCE-9656-7F36D32B8F7A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5F87D4F-D55E-43CD-8BE3-E2E1BF2E2A72}

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
@@ -14,6 +14,7 @@
 #include <codecvt>
 #include <locale>
 #include <RoMetadataApi.h>
+#include <algorithm>
 #include "catalog.h"
 #include "TypeResolution.h"
 
@@ -82,6 +83,13 @@ struct component
 
 static unordered_map<wstring, shared_ptr<component>> g_types;
 
+std::wstring_view wstr_tolower(std::wstring& s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+        [](unsigned char c) { return std::tolower(c); } // correct
+    );
+    return s;
+}
+
 HRESULT LoadManifestFromPath(std::wstring path)
 {
     if (path.size() < 4)
@@ -89,6 +97,8 @@ HRESULT LoadManifestFromPath(std::wstring path)
         return COR_E_ARGUMENT;
     }
     std::wstring ext(path.substr(path.size() - 4, path.size()));
+    ext = wstr_tolower(ext);
+    HRESULT hr;
     if (ext.compare(L".exe") == 0 || ext.compare(L".dll") == 0)
     {
         return LoadFromEmbeddedManifest(path.c_str());

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
@@ -98,7 +98,6 @@ HRESULT LoadManifestFromPath(std::wstring path)
     }
     std::wstring ext(path.substr(path.size() - 4, path.size()));
     ext = wstr_tolower(ext);
-    HRESULT hr;
     if (ext.compare(L".exe") == 0 || ext.compare(L".dll") == 0)
     {
         return LoadFromEmbeddedManifest(path.c_str());

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTManagedTest/Program.cs
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTManagedTest/Program.cs
@@ -90,7 +90,7 @@ namespace UndockedRegFreeWinRTManagedTest
                 testsFailed++;
             }
 
-            Console.WriteLine("Undocked RegFree Embedded Manifest Managed Test - " + (testsRan - testsFailed) + " out of " + testsRan + " tests passed");
+            Console.WriteLine("Undocked RegFree WinRT Managed Test - " + (testsRan - testsFailed) + " out of " + testsRan + " tests passed");
             return testsFailed == 0 ? 0 : 1;
         }
     }

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTManagedTest/UndockedRegFreeWinRTManagedTest.csproj
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTManagedTest/UndockedRegFreeWinRTManagedTest.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64;x86</Platforms>
+    <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">


### PR DESCRIPTION
Fix a bug with upper case DLL extension and added Embedded Manifest Test in c#.

The code looks at the extension of the path from the asmInfo but it only looks for ".dll" but the extension was in uppercase. 