### PR TITLE
Adjust Additional Dependencies to remove windowsapp.lib so winrtact.dll can work on win8.1

### DIFF
--- a/src/UndockedRegFreeWinRT/EmbeddedManifestTest/EmbeddedManifestTest.vcxproj
+++ b/src/UndockedRegFreeWinRT/EmbeddedManifestTest/EmbeddedManifestTest.vcxproj
@@ -111,7 +111,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;Ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;kernel32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences>_winrtact_Initialize@0</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -127,7 +127,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;Ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;kernel32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences>winrtact_Initialize</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -147,7 +147,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;Ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;kernel32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences>_winrtact_Initialize@0</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -167,7 +167,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;Ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;kernel32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences>winrtact_Initialize</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>

--- a/src/UndockedRegFreeWinRT/EmbeddedManifestTest/EmbeddedManifestTest.vcxproj
+++ b/src/UndockedRegFreeWinRT/EmbeddedManifestTest/EmbeddedManifestTest.vcxproj
@@ -111,7 +111,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;Ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
       <ForceSymbolReferences>_winrtact_Initialize@0</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -127,7 +127,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;Ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
       <ForceSymbolReferences>winrtact_Initialize</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -147,7 +147,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;Ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
       <ForceSymbolReferences>_winrtact_Initialize@0</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -167,7 +167,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;runtimeobject.lib;Ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
       <ForceSymbolReferences>winrtact_Initialize</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>

--- a/src/UndockedRegFreeWinRT/EmbeddedTestComponent/EmbeddedTestComponent.vcxproj
+++ b/src/UndockedRegFreeWinRT/EmbeddedTestComponent/EmbeddedTestComponent.vcxproj
@@ -129,12 +129,18 @@
     </ClCompile>
     <Link>
       <ManifestFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">EmbeddedTestComponent.manifest</ManifestFile>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Link>
       <ManifestFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">EmbeddedTestComponent.manifest</ManifestFile>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Link>
       <ManifestFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">EmbeddedTestComponent.manifest</ManifestFile>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Manifest>
       <AdditionalManifestFiles Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-manifest EmbeddedTestComponent.manifest</AdditionalManifestFiles>
@@ -156,6 +162,12 @@
       <ManifestFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">EmbeddedTestComponent.manifest</ManifestFile>
       <ManifestFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">EmbeddedTestComponent.manifest</ManifestFile>
       <ManifestFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">EmbeddedTestComponent.manifest</ManifestFile>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|x64'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Manifest>
       <AdditionalManifestFiles Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-manifest EmbeddedTestComponent.manifest</AdditionalManifestFiles>

--- a/src/UndockedRegFreeWinRT/ManifestParserTest/ManifestParserTest.vcxproj
+++ b/src/UndockedRegFreeWinRT/ManifestParserTest/ManifestParserTest.vcxproj
@@ -99,7 +99,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -115,7 +115,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -131,7 +131,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -151,7 +151,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/UndockedRegFreeWinRT/ManifestParserTest/ManifestParserTest.vcxproj
+++ b/src/UndockedRegFreeWinRT/ManifestParserTest/ManifestParserTest.vcxproj
@@ -99,7 +99,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -115,7 +115,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -131,7 +131,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -151,7 +151,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/UndockedRegFreeWinRT/Nuget/readme.txt
+++ b/src/UndockedRegFreeWinRT/Nuget/readme.txt
@@ -47,6 +47,24 @@ Your application manifest should have the same name as, and be side by side to y
 Starting with Windows 10 19h1, the operating system has this feature by default and will use this information directly. Be sure to  target your application for windows so that the package automatically disables itself when this feature is available by default.
 https://docs.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1
 
+
+Windows 8.1 Support (10/16/2020)
+Undocked egFreeWinRT can now activate types down to Windows 8.1. However, there are some minor things to account for on Windows 8.1. 
+
+1) On Windows 8.1. you may encounter 0x8007109A (This operation is only valid in the context of an app container) error when activating your type. This is caused by the app container check that exists in windows 8.1 but not on later versions.
+This can be fixed by, setting the linker option of your component that you're activating to /APPCONTAINER:NO
+Refer to 
+https://docs.microsoft.com/en-us/cpp/build/reference/appcontainer-windows-store-app?view=vs-2019
+https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/windows-app-certification-kit-tests#appcontainercheck
+for more information. 
+
+2) MTA to STA cross apartment activation needs additional advanced manifest and dll work on Windows 8.1. This work isn't required on later versions of Windows because of a feature called metadata based marshaling. 
+For cross apartment activation to work on Windows 8.1, you'll need to author your own proxy/stub dll for the component you're activating and include a classic COM registration in the manifest to register that proxy.
+Refer to 
+https://docs.microsoft.com/en-us/windows/win32/com/building-and-registering-a-proxy-dll
+for more information.
+
+
 ========================================================================
 For more information, visit:
 https://github.com/microsoft/xlang/tree/undocked_winrt_activation

--- a/src/UndockedRegFreeWinRT/Nuget/readme.txt
+++ b/src/UndockedRegFreeWinRT/Nuget/readme.txt
@@ -51,7 +51,7 @@ https://docs.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-applicatio
 Windows 8.1 Support (10/16/2020)
 Undocked RegFreeWinRT can now activate types down to Windows 8.1. However, there are some minor things to account for on Windows 8.1. 
 
-1) On Windows 8.1. you may encounter 0x8007109A (This operation is only valid in the context of an app container) error when activating your type. This is caused by the app container check that exists in windows 8.1 but not on later versions.
+1) On Windows 8.1. you may encounter error 0x8007109A (This operation is only valid in the context of an app container) when activating your type. This is caused by the app container check that exists in windows 8.1 but not on later versions.
 This can be fixed by setting the linker option of your component that you're activating to /APPCONTAINER:NO
 Refer to 
 https://docs.microsoft.com/en-us/cpp/build/reference/appcontainer-windows-store-app?view=vs-2019

--- a/src/UndockedRegFreeWinRT/Nuget/readme.txt
+++ b/src/UndockedRegFreeWinRT/Nuget/readme.txt
@@ -49,10 +49,10 @@ https://docs.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-applicatio
 
 
 Windows 8.1 Support (10/16/2020)
-Undocked egFreeWinRT can now activate types down to Windows 8.1. However, there are some minor things to account for on Windows 8.1. 
+Undocked RegFreeWinRT can now activate types down to Windows 8.1. However, there are some minor things to account for on Windows 8.1. 
 
 1) On Windows 8.1. you may encounter 0x8007109A (This operation is only valid in the context of an app container) error when activating your type. This is caused by the app container check that exists in windows 8.1 but not on later versions.
-This can be fixed by, setting the linker option of your component that you're activating to /APPCONTAINER:NO
+This can be fixed by setting the linker option of your component that you're activating to /APPCONTAINER:NO
 Refer to 
 https://docs.microsoft.com/en-us/cpp/build/reference/appcontainer-windows-store-app?view=vs-2019
 https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/windows-app-certification-kit-tests#appcontainercheck

--- a/src/UndockedRegFreeWinRT/README.md
+++ b/src/UndockedRegFreeWinRT/README.md
@@ -48,6 +48,21 @@ Example application manifest:
 
 Starting with Windows 10 19h1, the operating system has this feature by default and will use this information directly. Be sure to use [Windows version targeting](https://docs.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1) so that the package automatically disables itself when this feature is available by default.
 
+### Windows 8.1 Support (10/16/2020)
+Undocked RegFreeWinRT can now activate types down to Windows 8.1. However, there are some minor things to account for on Windows 8.1. 
+
+1) On Windows 8.1. you may encounter 0x8007109A (This operation is only valid in the context of an app container) error when activating your type. This is caused by the app container check that exists in windows 8.1 but not on later versions.
+This can be fixed by, setting the linker option of your component that you're activating to /APPCONTAINER:NO
+Refer to 
+https://docs.microsoft.com/en-us/cpp/build/reference/appcontainer-windows-store-app?view=vs-2019
+https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/windows-app-certification-kit-tests#appcontainercheck
+for more information. 
+
+2) MTA to STA cross apartment activation needs additional advanced manifest and dll work on Windows 8.1. This work isn't required on later versions of Windows because of a feature called metadata based marshaling. 
+For cross apartment activation to work on Windows 8.1, you'll need to author your own proxy/stub dll for the component you're activating and include a classic COM registration in the manifest to register that proxy.
+Refer to 
+https://docs.microsoft.com/en-us/windows/win32/com/building-and-registering-a-proxy-dll
+for more information.
 
 ### For more information about using application manifests for Windows Runtime types, visit:
 [Enhancing Non-packaged Desktop Apps using Windows Runtime Components](https://blogs.windows.com/windowsdeveloper/2019/04/30/enhancing-non-packaged-desktop-apps-using-windows-runtime-components/)

--- a/src/UndockedRegFreeWinRT/README.md
+++ b/src/UndockedRegFreeWinRT/README.md
@@ -51,7 +51,7 @@ Starting with Windows 10 19h1, the operating system has this feature by default 
 ### Windows 8.1 Support (10/16/2020)
 Undocked RegFreeWinRT can now activate types down to Windows 8.1. However, there are some minor things to account for on Windows 8.1. 
 
-1) On Windows 8.1. you may encounter 0x8007109A (This operation is only valid in the context of an app container) error when activating your type. This is caused by the app container check that exists in windows 8.1 but not on later versions.
+1) On Windows 8.1. you may encounter error 0x8007109A (This operation is only valid in the context of an app container) when activating your type. This is caused by the app container check that exists in windows 8.1 but not on later versions.
 This can be fixed by setting the linker option of your component that you're activating to /APPCONTAINER:NO
 Refer to 
 https://docs.microsoft.com/en-us/cpp/build/reference/appcontainer-windows-store-app?view=vs-2019

--- a/src/UndockedRegFreeWinRT/README.md
+++ b/src/UndockedRegFreeWinRT/README.md
@@ -52,7 +52,7 @@ Starting with Windows 10 19h1, the operating system has this feature by default 
 Undocked RegFreeWinRT can now activate types down to Windows 8.1. However, there are some minor things to account for on Windows 8.1. 
 
 1) On Windows 8.1. you may encounter 0x8007109A (This operation is only valid in the context of an app container) error when activating your type. This is caused by the app container check that exists in windows 8.1 but not on later versions.
-This can be fixed by, setting the linker option of your component that you're activating to /APPCONTAINER:NO
+This can be fixed by setting the linker option of your component that you're activating to /APPCONTAINER:NO
 Refer to 
 https://docs.microsoft.com/en-us/cpp/build/reference/appcontainer-windows-store-app?view=vs-2019
 https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/windows-app-certification-kit-tests#appcontainercheck

--- a/src/UndockedRegFreeWinRT/TestComponent/TestComponent.vcxproj
+++ b/src/UndockedRegFreeWinRT/TestComponent/TestComponent.vcxproj
@@ -121,6 +121,18 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -129,6 +141,12 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|x64'">shlwapi.lib;runtimeobject.lib;ole32.lib;kernel32.Lib;oleaut32.lib;</AdditionalDependencies>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/APPCONTAINER:NO %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
@@ -109,7 +109,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
       <ModuleDefinitionFile>winrtact.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -128,7 +128,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
       <ModuleDefinitionFile>winrtact.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -151,7 +151,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
       <ModuleDefinitionFile>winrtact.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -174,7 +174,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;xmllite.lib;runtimeobject.lib;Pathcch.lib;</AdditionalDependencies>
       <ModuleDefinitionFile>winrtact.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
@@ -83,11 +83,10 @@ struct component
 
 static unordered_map<wstring, shared_ptr<component>> g_types;
 
-std::wstring_view wstr_tolower(std::wstring& s) {
+void wstr_tolower(std::wstring& s) {
     std::transform(s.begin(), s.end(), s.begin(),
         [](unsigned char c) { return std::tolower(c); } // correct
     );
-    return s;
 }
 
 HRESULT LoadManifestFromPath(std::wstring path)
@@ -97,7 +96,7 @@ HRESULT LoadManifestFromPath(std::wstring path)
         return COR_E_ARGUMENT;
     }
     std::wstring ext(path.substr(path.size() - 4, path.size()));
-    ext = wstr_tolower(ext);
+    wstr_tolower(ext);
     if (ext.compare(L".exe") == 0 || ext.compare(L".dll") == 0)
     {
         return LoadFromEmbeddedManifest(path.c_str());

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTTest/UndockedRegFreeWinRTTest.vcxproj
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTTest/UndockedRegFreeWinRTTest.vcxproj
@@ -111,7 +111,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences>_winrtact_Initialize@0</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -127,7 +127,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences>winrtact_Initialize</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -147,7 +147,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences>_winrtact_Initialize@0</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
@@ -167,7 +167,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>windowsapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comsuppw.lib;shlwapi.lib;runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences>winrtact_Initialize</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Adjust Additional Dependencies to remove windowsapp.lib so winrtact.dll can work on win8.1
Fixes this error
![image](https://user-images.githubusercontent.com/48363984/96175006-16538400-0edf-11eb-9275-eb1da6791346.png)

In addition, addressing:
Win8.1 currently errors with Error 0x8007109A – This operation is only valid in the context of an app container.
This is caused by the app container check that exists in windows 8.1 but not on later versions. 
To fix this, set linker option of your component to have /APPCONTAINER:NO

https://docs.microsoft.com/en-us/cpp/build/reference/appcontainer-windows-store-app?view=vs-2019
https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/windows-app-certification-kit-tests#appcontainercheck

