### PR TITLE
Fix python version reference from native code DLLs

### DIFF
--- a/src/package/pywinrt/projection/AzurePipelinesTemplates/job-build-projection.yml
+++ b/src/package/pywinrt/projection/AzurePipelinesTemplates/job-build-projection.yml
@@ -10,32 +10,32 @@ jobs:
       Release_x86_py37:
         buildArchitecture: 'x86'
         buildConfiguration: 'Release'
-        pythonVersion: '3.7.x'
+        pythonVersion: '3.7'
         pythonArchitecture: 'x86'
       Release_x64_py37:
         buildArchitecture: 'amd64'
         buildConfiguration: 'Release'
-        pythonVersion: '3.7.x'
+        pythonVersion: '3.7'
         pythonArchitecture: 'x64'
       Release_x86_py38:
         buildArchitecture: 'x86'
         buildConfiguration: 'Release'
-        pythonVersion: '3.8.x'
+        pythonVersion: '3.8'
         pythonArchitecture: 'x86'
       Release_x64_py38:
         buildArchitecture: 'amd64'
         buildConfiguration: 'Release'
-        pythonVersion: '3.8.x'
+        pythonVersion: '3.8'
         pythonArchitecture: 'x64'
       Release_x86_py39:
         buildArchitecture: 'x86'
         buildConfiguration: 'Release'
-        pythonVersion: '3.9.x'
+        pythonVersion: '3.9'
         pythonArchitecture: 'x86'
       Release_x64_py39:
         buildArchitecture: 'amd64'
         buildConfiguration: 'Release'
-        pythonVersion: '3.9.x'
+        pythonVersion: '3.9'
         pythonArchitecture: 'x64'
   steps:
   - template: steps-build-projection.yml

--- a/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-build-projection.yml
+++ b/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-build-projection.yml
@@ -1,6 +1,6 @@
 parameters: # defaults for any parameters that aren't specified
   architecture: 'x86'
-  pythonVersionSpec: '3.9.x'
+  pythonVersionSpec: '3.9'
   projectionType: 'partial'
   pythonArchSpec: 'x86'
 
@@ -48,7 +48,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: ${{ parameters.pythonVersionSpec }}
+    versionSpec: ${{ parameters.pythonVersionSpec }}.x
     addToPath: true 
     architecture: ${{ parameters.pythonArchSpec }}
 
@@ -56,7 +56,7 @@ steps:
   displayName: 'Generate python projection build files via cmake'
   inputs:
     cwd: '.'
-    cmakeArgs: '-S src/package/pywinrt/projection/ -B_build -GNinja -DCMAKE_BUILD_TYPE=$(buildConfiguration) -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl'
+    cmakeArgs: '-S src/package/pywinrt/projection/ -B_build -GNinja -DCMAKE_BUILD_TYPE=$(buildConfiguration) -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DPYTHON_VERSION=${{parameters.pythonVersionSpec}}'
 
 - task: CMake@1
   displayName: 'build python projection'
@@ -74,7 +74,7 @@ steps:
   inputs:
     sourceFolder: src/package/pywinrt/projection/pywinrt/
     contents: '**'
-    targetFolder: $(Build.ArtifactStagingDirectory)/projection/${{ parameters.pythonVersionSpec }}/$(buildArchitecture)
+    targetFolder: $(Build.ArtifactStagingDirectory)/projection/${{ parameters.pythonVersionSpec }}.x/$(buildArchitecture)
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifact: projection'

--- a/src/package/pywinrt/projection/CMakeLists.txt
+++ b/src/package/pywinrt/projection/CMakeLists.txt
@@ -48,7 +48,7 @@ add_compile_options(/await /bigobj /GR- /permissive-)
 
 project(_winrt)
 
-find_package (Python3 ${PYTHON_VERSION} COMPONENTS Interpreter Development)
+find_package (Python3 ${PYTHON_VERSION} EXACT COMPONENTS Interpreter Development)
 
 Python3_add_library (_winrt MODULE ${sources})
 

--- a/src/package/pywinrt/projection/CMakeLists.txt
+++ b/src/package/pywinrt/projection/CMakeLists.txt
@@ -48,7 +48,7 @@ add_compile_options(/await /bigobj /GR- /permissive-)
 
 project(_winrt)
 
-find_package (Python3 COMPONENTS Interpreter Development)
+find_package (Python3 ${PYTHON_VERSION} COMPONENTS Interpreter Development)
 
 Python3_add_library (_winrt MODULE ${sources})
 


### PR DESCRIPTION
CMake selection of python version uses "latest" that it can find by default, and isn't impacted by the pipeline task that configures the preferred python version. This changes the CMake build of the native code DLL to use specific versions for the binaries.

fixes #717
