### PR TITLE
python: implement buffer protocol for IBuffer

### DIFF
--- a/src/package/pywinrt/projection/readme.md
+++ b/src/package/pywinrt/projection/readme.md
@@ -109,6 +109,17 @@ async def get_current_latitude():
     return pos.coordinate.latitude
 ```
 
+### Buffer Protocol
+
+Buffers ([IBuffer](https://docs.microsoft.com/uwp/api/Windows.Storage.Streams.IBuffer)) implement
+the CPython [buffer protocol](https://docs.python.org/3/c-api/buffer.html). They can be passed
+to a [memoryview()](https://docs.python.org/3/library/stdtypes.html#typememoryview) to access
+the memory directly. The [struct](https://docs.python.org/3/library/struct.html) module can
+also use the buffer objects directly for packing and unpacking formatted binary data. Using
+native Python classes to access the memory is significantly more efficient than using the WinRT
+[IDataReader](https://docs.microsoft.com/uwp/api/Windows.Storage.Streams.IDataReader)
+or [IDataWriter](https://docs.microsoft.com/uwp/api/Windows.Storage.Streams.IDataWriter) classes.
+
 ### Collection Protocols
 
 WinRT and Python both have standard definitions of iterators, sequences and maps. Python/WinRT automatically

--- a/src/tool/python/helpers.h
+++ b/src/tool/python/helpers.h
@@ -305,6 +305,11 @@ namespace xlang
         return false;
     }
 
+    bool implements_ibuffer(TypeDef const& type)
+    {
+        return implements_interface(type, "Windows.Storage.Streams", "IBuffer");
+    }
+
     bool implements_istringable(TypeDef const& type)
     {
         return implements_interface(type, "Windows.Foundation", "IStringable");


### PR DESCRIPTION
This implements the CPython buffer protocol<sup>[1]</sup> for the `Windows.Storage.Streams.IBuffer` interface. This allows Python to access the buffer memory directly via `memoryview()`, the `struct` module and so on.

This is also a significant performance improvement for applications that just need to copy the data to/from the buffer.

[1]: https://docs.python.org/3/c-api/buffer.html