### PR TITLE
python: bump sdk version to 18362

### DIFF
--- a/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-build-projection.yml
+++ b/src/package/pywinrt/projection/AzurePipelinesTemplates/steps-build-projection.yml
@@ -22,9 +22,9 @@ steps:
 - script: |
     echo %ProjectionType%
     IF %ProjectionType%==full (
-        $(Build.ArtifactStagingDirectory)/pywinrt/pywinrt.exe -input 10.0.17763.0 -output src/package/pywinrt/projection/pywinrt -verbose -include Windows. -exclude Windows.UI.Composition -exclude Windows.UI.Xaml
+        $(Build.ArtifactStagingDirectory)/pywinrt/pywinrt.exe -input 10.0.18362.0 -output src/package/pywinrt/projection/pywinrt -verbose -include Windows. -exclude Windows.UI.Composition -exclude Windows.UI.Xaml
     ) ELSE (
-        $(Build.ArtifactStagingDirectory)/pywinrt/pywinrt.exe -input 10.0.17763.0 -output src/package/pywinrt/projection/pywinrt -verbose -include Windows.Foundation -include Windows.Data.Json -include Windows.Devices.Geolocation -include Windows.Graphics.DirectX -exclude Windows.UI.Composition -exclude Windows.UI.Xaml
+        $(Build.ArtifactStagingDirectory)/pywinrt/pywinrt.exe -input 10.0.18362.0 -output src/package/pywinrt/projection/pywinrt -verbose -include Windows.Foundation -include Windows.Data.Json -include Windows.Devices.Geolocation -include Windows.Graphics.DirectX -exclude Windows.UI.Composition -exclude Windows.UI.Xaml
     )
   displayName: 'Generate $(ProjectionType) Python/WinRT Projection'
   env:
@@ -38,7 +38,7 @@ steps:
     command: custom
     arguments: 'install Microsoft.Windows.CppWinRT -ExcludeVersion -OutputDirectory _tools'
 
-- script: _tools\Microsoft.Windows.CppWinRT\bin\cppwinrt.exe -input 10.0.17763.0 -output src/package/pywinrt/projection/cppwinrt -verbose
+- script: _tools\Microsoft.Windows.CppWinRT\bin\cppwinrt.exe -input 10.0.18362.0 -output src/package/pywinrt/projection/cppwinrt -verbose
   displayName: 'Generate C++/WinRT Projection'
 
 - template: task-vsdevcmd.yml

--- a/src/package/pywinrt/projection/generate.ps1
+++ b/src/package/pywinrt/projection/generate.ps1
@@ -1,6 +1,6 @@
 param ([switch]$clean, [switch]$fullProjection)
 
-$windows_sdk = '10.0.17763.0'
+$windows_sdk = '10.0.18362.0'
 $repoRootPath = (get-item $PSScriptRoot).parent.Parent.parent.Parent.FullName
 $projectionPath = "$PSScriptRoot"
 

--- a/src/readme.md
+++ b/src/readme.md
@@ -15,7 +15,7 @@ Building xlang for Windows requires the following to be installed:
   * Visual Studio's Desktop Development with C++ workload includes CMake 3.11
 * [Ninja](https://ninja-build.org/), version 1.8 or later
   * Visual Studio's Desktop Development with C++ workload includes Ninja 1.8.2
-* [Windows 10 SDK](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk), Version 1809 or later (Build Number 10.0.17763.0)
+* [Windows 10 SDK](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk), Version 1903 or later (Build Number 10.0.18362.0)
   * Visual Studio does not install this by default with version 15.8.7 or 15.8.8. It is an optional component in Visual Studio 15.8
 * [Visual Studio SDK](https://docs.microsoft.com/en-us/visualstudio/extensibility/installing-the-visual-studio-sdk?view=vs-2017)
   * The Visual Studio SDK is an optional component installed through Visual Studio setup


### PR DESCRIPTION
This is Windows 10 1903, which gives us 2 years worth of backwards compatibility.

Fixes #727