### PR TITLE
python: add _d suffix to .pyd for debug build

### DIFF
--- a/src/package/pywinrt/projection/CMakeLists.txt
+++ b/src/package/pywinrt/projection/CMakeLists.txt
@@ -51,6 +51,7 @@ project(_winrt)
 find_package (Python3 ${PYTHON_VERSION} EXACT COMPONENTS Interpreter Development)
 
 Python3_add_library (_winrt MODULE ${sources})
+set_target_properties(_winrt PROPERTIES LIBRARY_OUTPUT_NAME_DEBUG _winrt_d)
 
 target_include_directories(_winrt PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/cppwinrt" "${CMAKE_CURRENT_SOURCE_DIR}/pywinrt/winrt/src")
 target_link_libraries(_winrt PRIVATE onecore)


### PR DESCRIPTION
When debugging with `python_d.exe`, modules must be named `<module>_d.pyd` in order to be imported. Using the `LIBRARY_OUTPUT_NAME_DEBUG` property will ensure that this suffix is only added for debug builds.