### PR TITLE
python: fix __enter__() and __exit__() methods

### DIFF
--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -1145,8 +1145,8 @@ return 0;
 
             if (implements_iclosable(type))
             {
-                w.write("{ \"__enter__\", (PyCFunction)_enter_@, METH_O, nullptr },\n", type.TypeName());
-                w.write("{ \"__exit__\",  (PyCFunction)_exit_@,  METH_O, nullptr },\n", type.TypeName());
+                w.write("{ \"__enter__\", (PyCFunction)_enter_@, METH_NOARGS, nullptr },\n", type.TypeName());
+                w.write("{ \"__exit__\",  (PyCFunction)_exit_@, METH_VARARGS, nullptr },\n", type.TypeName());
             }
 
             w.write("{ nullptr }\n");


### PR DESCRIPTION
The `__enter__()` method takes no arguments (other than self) and the `__exit__()` method takes 3 arguments (in addition to self), so `METH_O` (which indicates 1 argument in addition to self) was wrong in both cases.