### PR TITLE
python: fix leak of object pointers

### DIFF
--- a/src/tool/python/code_writers.h
+++ b/src/tool/python/code_writers.h
@@ -325,7 +325,7 @@ self->obj%;
 
             w.write(format,
                 is_ptype(type) ? "self->obj->hash()" : "std::hash<winrt::Windows::Foundation::IInspectable>{}(self->obj)",
-                is_ptype(type) ? ".release()" : " = nullptr");
+                is_ptype(type) ? ".reset()" : " = nullptr");
         }
         w.write("}\n");
     }


### PR DESCRIPTION
When a WinRT method returns a pointer, the python bindings were leaking a reference.

This solves it by deleting the pointer returned by `std::unique_ptr::release()`.

Basically, this patch changes the generated code from this:

```cpp
    static void _dealloc_IAsyncOperation(py::wrapper::Windows::Foundation::IAsyncOperation* self)
    {
        auto hash_value = self->obj->hash();
        py::wrapped_instance(hash_value, nullptr);
        self->obj.release();
    }
```

To this (just adds `delete`):

```cpp
    static void _dealloc_IAsyncOperation(py::wrapper::Windows::Foundation::IAsyncOperation* self)
    {
        auto hash_value = self->obj->hash();
        py::wrapped_instance(hash_value, nullptr);
        delete self->obj.release();
    }
```

I know enough about C++ to know this fix looks wrong but I don't know enough to know how to fix it properly.

For reference, `self->obj` is initialized here: 
https://github.com/microsoft/xlang/blob/b950b15d53cab2dddc78c65e783ef43042a2e8c9/src/tool/python/strings/pybase.h#L318-L350

Fixes #731 