### PR TITLE
Fix a bug where the filename variable can get clobbered due to XmlReader invalidating the buffer

### DIFF
--- a/src/UndockedRegFreeWinRT/ManifestParserTest/ManifestParserTest.vcxproj
+++ b/src/UndockedRegFreeWinRT/ManifestParserTest/ManifestParserTest.vcxproj
@@ -200,6 +200,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>basicParse.negative.blankFileName.manifest</TargetPath>
     </ContentWithTargetPath>
+    <ContentWithTargetPath Include="basicParse.largefile.manifest">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>basicParse.largefile.manifest</TargetPath>
+    </ContentWithTargetPath>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/catalog.cpp
@@ -196,11 +196,18 @@ HRESULT ParseFileTag(ComPtr<IXmlReader> xmlReader)
     HRESULT hr = S_OK;
     XmlNodeType nodeType;
     PCWSTR localName = nullptr;
-    PCWSTR fileName = nullptr;
-    hr = xmlReader->MoveToAttributeByName(L"name", nullptr);
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_SXS_MANIFEST_PARSE_ERROR), hr != S_OK);
-    RETURN_IF_FAILED(xmlReader->GetValue(&fileName, nullptr));
-    RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_SXS_MANIFEST_PARSE_ERROR), fileName == nullptr || !fileName[0]);
+    wstring fileName;
+
+    {
+        PCWSTR fileNameStr = nullptr;
+        hr = xmlReader->MoveToAttributeByName(L"name", nullptr);
+        RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_SXS_MANIFEST_PARSE_ERROR), hr != S_OK);
+        RETURN_IF_FAILED(xmlReader->GetValue(&fileNameStr, nullptr));
+        RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_SXS_MANIFEST_PARSE_ERROR), fileNameStr == nullptr || !fileNameStr[0]);
+        
+        fileName = fileNameStr;
+    }
+    
     auto locale = _create_locale(LC_ALL, "C");
     while (S_OK == xmlReader->Read(&nodeType))
     {
@@ -209,7 +216,7 @@ HRESULT ParseFileTag(ComPtr<IXmlReader> xmlReader)
             RETURN_IF_FAILED(xmlReader->GetLocalName(&localName, nullptr));
             if (localName != nullptr && _wcsicmp_l(localName, L"activatableClass", locale) == 0)
             {
-                RETURN_IF_FAILED(ParseActivatableClassTag(xmlReader, fileName));
+                RETURN_IF_FAILED(ParseActivatableClassTag(xmlReader, fileName.c_str()));
             }
         }
         else if (nodeType == XmlNodeType_EndElement)

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -442,10 +442,12 @@ HRESULT ExtRoLoadCatalog()
 
 BOOL WINAPI DllMain(HINSTANCE hmodule, DWORD reason, LPVOID /*lpvReserved*/)
 {
+    /*
     if (IsWindows1019H1OrGreater())
     {
         return true;
     }
+    */
     if (reason == DLL_PROCESS_ATTACH)
     {
         DisableThreadLibraryCalls(hmodule);


### PR DESCRIPTION
The buffer returned by IXmlReader::GetValue gets invalidated after the XmlReader is used more in the future.  The fileName buffer was getting re-used in a scenario where there were lots of nodes to read.  The fix is simply to save it off to a local wstring.