### PR TITLE
Fix contract sort order and update code gen to compile with /Za

### DIFF
--- a/src/tool/abi/abi_writer.cpp
+++ b/src/tool/abi/abi_writer.cpp
@@ -136,7 +136,7 @@ void writer::push_contract_guard(contract_history vers)
     write("#if % >= %", bind<write_contract_macro>(ns, name), format_hex{ vers.current_contract.version });
     for (auto const& prev : vers.previous_contracts)
     {
-        auto [prevNs, prevName] = decompose_type(prev.type_name);
+        auto [prevNs, prevName] = decompose_type(prev.from_contract);
         write(" || \\\n    % >= % && % < %",
             bind<write_contract_macro>(prevNs, prevName), format_hex{ prev.version_introduced },
             bind<write_contract_macro>(prevNs, prevName), format_hex{ prev.version_removed });
@@ -155,7 +155,7 @@ void writer::pop_contract_guards(std::size_t count)
         write("#endif // % >= %", bind<write_contract_macro>(ns, name), format_hex{ vers.current_contract.version });
         for (auto const& prev : vers.previous_contracts)
         {
-            auto [prevNs, prevName] = decompose_type(prev.type_name);
+            auto [prevNs, prevName] = decompose_type(prev.from_contract);
             write(" || \\\n       // % >= % && % < %",
                 bind<write_contract_macro>(prevNs, prevName), format_hex{ prev.version_introduced },
                 bind<write_contract_macro>(prevNs, prevName), format_hex{ prev.version_removed });

--- a/src/tool/abi/metadata_cache.cpp
+++ b/src/tool/abi/metadata_cache.cpp
@@ -185,7 +185,7 @@ static void process_contract_dependencies(namespace_cache& target, T const& type
         target.dependent_namespaces.emplace(decompose_type(attr->current_contract.type_name).first);
         for (auto const& prevContract : attr->previous_contracts)
         {
-            target.dependent_namespaces.emplace(decompose_type(prevContract.type_name).first);
+            target.dependent_namespaces.emplace(decompose_type(prevContract.from_contract).first);
         }
     }
 

--- a/src/tool/abi/types.cpp
+++ b/src/tool/abi/types.cpp
@@ -558,7 +558,7 @@ static void write_cpp_interface_definition(writer& w, T const& type)
 
     w.write(R"^-^(%};
 
-%MIDL_CONST_ID IID& IID_% = _uuidof(%);
+%MIDL_CONST_ID IID& IID_% = __uuidof(%);
 )^-^", indent{}, indent{}, type.cpp_abi_name(), type.cpp_abi_name());
 
     w.pop_namespace();

--- a/src/tool/abi/types.h
+++ b/src/tool/abi/types.h
@@ -451,7 +451,7 @@ struct typedef_base : metadata_type
         std::size_t result = 0;
         for (auto& prev : m_contractHistory->previous_contracts)
         {
-            if ((prev.type_name == typeName) && (prev.version_introduced <= version) && (prev.version_removed > version))
+            if ((prev.from_contract == typeName) && (prev.version_introduced <= version) && (prev.version_removed > version))
             {
                 return result;
             }
@@ -480,7 +480,7 @@ struct typedef_base : metadata_type
         {
             if (index-- == 0)
             {
-                return contract_version{ prev.type_name, prev.version_introduced };
+                return contract_version{ prev.from_contract, prev.version_introduced };
             }
         }
 


### PR DESCRIPTION
When updating C++/WinRT, I realized that the sort order for the ABI tool made some incorrect assumptions, so fixing that here. Also updating the code gen to use `__uuidof` instead of `_uuidof` since the former compiles with `/Za` (disable language extensions). Will also need corresponding change to midlrt