### PR TITLE
Handle failures in InstallHooks and fix a random COMException when P/Invoking winrtact_Initialize 

### DIFF
--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -464,7 +464,7 @@ BOOL WINAPI DllMain(HINSTANCE hmodule, DWORD reason, LPVOID /*lpvReserved*/)
 
         try
         {
-            if (!SUCCEEDED(ExtRoLoadCatalog()))
+            if (!SUCCEEDED(InstallHooks()) || !SUCCEEDED(ExtRoLoadCatalog()))
                 return false;
         }
         catch (...)

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -321,7 +321,7 @@ HRESULT WINAPI RoResolveNamespaceDetour(
     return hr;
 }
 
-void InstallHooks()
+HRESULT InstallHooks()
 {
     // If this is loaded in a Detours helper process and not the actual process
     // to be hooked, just return without performing any other operations.

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -330,13 +330,14 @@ HRESULT InstallHooks()
 
     DetourRestoreAfterWith();
 
-    THROW_IF_FAILED(HRESULT_FROM_WIN32(DetourTransactionBegin()));
-    THROW_IF_FAILED(HRESULT_FROM_WIN32(DetourUpdateThread(GetCurrentThread())));
-    THROW_IF_FAILED(HRESULT_FROM_WIN32(DetourAttach(&(PVOID&)TrueRoActivateInstance, RoActivateInstanceDetour)));
-    THROW_IF_FAILED(HRESULT_FROM_WIN32(DetourAttach(&(PVOID&)TrueRoGetActivationFactory, RoGetActivationFactoryDetour)));
-    THROW_IF_FAILED(HRESULT_FROM_WIN32(DetourAttach(&(PVOID&)TrueRoGetMetaDataFile, RoGetMetaDataFileDetour)));
-    THROW_IF_FAILED(HRESULT_FROM_WIN32(DetourAttach(&(PVOID&)TrueRoResolveNamespace, RoResolveNamespaceDetour)));
-    THROW_IF_FAILED(HRESULT_FROM_WIN32(DetourTransactionCommit()));
+    RETURN_IF_WIN32_ERROR(DetourTransactionBegin());
+    RETURN_IF_WIN32_ERROR(DetourUpdateThread(GetCurrentThread()));
+    RETURN_IF_WIN32_ERROR(DetourAttach(&(PVOID&)TrueRoActivateInstance, RoActivateInstanceDetour));
+    RETURN_IF_WIN32_ERROR(DetourAttach(&(PVOID&)TrueRoGetActivationFactory, RoGetActivationFactoryDetour));
+    RETURN_IF_WIN32_ERROR(DetourAttach(&(PVOID&)TrueRoGetMetaDataFile, RoGetMetaDataFileDetour));
+    RETURN_IF_WIN32_ERROR(DetourAttach(&(PVOID&)TrueRoResolveNamespace, RoResolveNamespaceDetour));
+    RETURN_IF_WIN32_ERROR(DetourTransactionCommit());
+    return S_OK;
 }
 
 void RemoveHooks()

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -326,7 +326,7 @@ HRESULT InstallHooks()
     // If this is loaded in a Detours helper process and not the actual process
     // to be hooked, just return without performing any other operations.
     if (DetourIsHelperProcess())
-        return;
+        return S_OK;
 
     DetourRestoreAfterWith();
 

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/dllmain.cpp
@@ -454,16 +454,6 @@ BOOL WINAPI DllMain(HINSTANCE hmodule, DWORD reason, LPVOID /*lpvReserved*/)
 
         try
         {
-            InstallHooks();
-        }
-        catch (...)
-        {
-            LOG_CAUGHT_EXCEPTION();
-            return false;
-        }
-
-        try
-        {
             if (!SUCCEEDED(InstallHooks()) || !SUCCEEDED(ExtRoLoadCatalog()))
                 return false;
         }

--- a/src/UndockedRegFreeWinRT/mwinrtact/mwinrtact.cs
+++ b/src/UndockedRegFreeWinRT/mwinrtact/mwinrtact.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Windows
 {
     public static class UndockedRegFreeWinrt
     {
-        [DllImport("winrtact.dll", PreserveSig=true)]
+        [DllImport("winrtact.dll")]
         static extern void winrtact_Initialize();
 
         public static void Initialize()


### PR DESCRIPTION
@scottj1s, this PR primarily aims at resolving #782. It also removes "PreserveSig=true" from the P/Invoke signature of winrtact_Initialize. This function doesn't return HResult and this was causing a random COMException in caller in Release x64. 