### PR TITLE
User/benkuhn/urfw buildconfig

### DIFF
--- a/src/UndockedRegFreeWinRT/Nuget/Microsoft.Windows.UndockedRegFreeWinrt.targets
+++ b/src/UndockedRegFreeWinRT/Nuget/Microsoft.Windows.UndockedRegFreeWinrt.targets
@@ -1,5 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
+  <!-- To suport custom configruations, only test against Debug or !Debug. 
+    Any other configuration is assumed to be a release configuration -->
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\runtimes\x86\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/UndockedRegFreeWinRT/Nuget/Microsoft.Windows.UndockedRegFreeWinrt.targets
+++ b/src/UndockedRegFreeWinRT/Nuget/Microsoft.Windows.UndockedRegFreeWinrt.targets
@@ -1,5 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- If a project has custom conifigurations other tha debug or release, it can use URFW_Configuration to
+    indicate whether that configuration should use the debug or release version of RegFreeWinRT support. -->
   <PropertyGroup Condition="'$(URFW_Configuration)' == ''">
     <URFW_Configuration>$(Configuration)</URFW_Configuration>
   </PropertyGroup>

--- a/src/UndockedRegFreeWinRT/Nuget/Microsoft.Windows.UndockedRegFreeWinrt.targets
+++ b/src/UndockedRegFreeWinRT/Nuget/Microsoft.Windows.UndockedRegFreeWinrt.targets
@@ -3,11 +3,11 @@
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\runtimes\x86\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Release' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\runtimes\x86\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\runtimes\x86\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\runtimes\x64\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\runtimes\x64\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\runtimes\x64\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)..\..\runtimes\arm64\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)..\..\runtimes\arm64\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)..\..\runtimes\arm64\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences Condition="'$(Platform)' == 'Win32' Or '$(Platform)' == 'x86'">_winrtact_Initialize@0;%(ForceSymbolReferences)</ForceSymbolReferences>
       <ForceSymbolReferences Condition="'$(Platform)' == 'x64'">winrtact_Initialize;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
@@ -17,7 +17,7 @@
   <ItemGroup Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x86\debug\winrtact.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Release' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
+  <ItemGroup Condition="'$(Configuration)' != 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x86\release\winrtact.dll" />
   </ItemGroup>
 
@@ -25,7 +25,7 @@
   <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x64\debug\winrtact.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'x64'">
+  <ItemGroup Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x64\release\winrtact.dll" />
   </ItemGroup>
 
@@ -33,7 +33,7 @@
   <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'ARM64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\arm64\debug\winrtact.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Release' And '$(Platform)' == 'ARM64'">
+  <ItemGroup Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'ARM64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\arm64\release\winrtact.dll" />
   </ItemGroup>
 

--- a/src/UndockedRegFreeWinRT/Nuget/Microsoft.Windows.UndockedRegFreeWinrt.targets
+++ b/src/UndockedRegFreeWinRT/Nuget/Microsoft.Windows.UndockedRegFreeWinrt.targets
@@ -1,41 +1,43 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="'$(URFW_Configuration)' == ''">
+    <URFW_Configuration>$(Configuration)</URFW_Configuration>
+  </PropertyGroup>
   
-  <!-- To suport custom configruations, only test against Debug or !Debug. 
-    Any other configuration is assumed to be a release configuration -->
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\runtimes\x86\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\runtimes\x86\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\runtimes\x64\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\runtimes\x64\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)..\..\runtimes\arm64\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)..\..\runtimes\arm64\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(URFW_Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\runtimes\x86\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(URFW_Configuration)' == 'Release' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">$(MSBuildThisFileDirectory)..\..\runtimes\x86\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(URFW_Configuration)' == 'Debug' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\runtimes\x64\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(URFW_Configuration)' == 'Release' And '$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)..\..\runtimes\x64\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(URFW_Configuration)' == 'Debug' And '$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)..\..\runtimes\arm64\debug\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(URFW_Configuration)' == 'Release' And '$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)..\..\runtimes\arm64\release\winrtact.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ForceSymbolReferences Condition="'$(Platform)' == 'Win32' Or '$(Platform)' == 'x86'">_winrtact_Initialize@0;%(ForceSymbolReferences)</ForceSymbolReferences>
       <ForceSymbolReferences Condition="'$(Platform)' == 'x64'">winrtact_Initialize;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   
   <!-- x86 -->
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
+  <ItemGroup Condition="'$(URFW_Configuration)' == 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x86\debug\winrtact.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
+  <ItemGroup Condition="'$(URFW_Configuration)' == 'Release' And ('$(Platform)' == 'Win32' Or '$(Platform)' == 'x86')">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x86\release\winrtact.dll" />
   </ItemGroup>
 
   <!-- x64 -->
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'x64'">
+  <ItemGroup Condition="'$(URFW_Configuration)' == 'Debug' And '$(Platform)' == 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x64\debug\winrtact.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'x64'">
+  <ItemGroup Condition="'$(URFW_Configuration)' == 'Release' And '$(Platform)' == 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x64\release\winrtact.dll" />
   </ItemGroup>
 
   <!-- arm64 -->
-  <ItemGroup Condition="'$(Configuration)' == 'Debug' And '$(Platform)' == 'ARM64'">
+  <ItemGroup Condition="'$(URFW_Configuration)' == 'Debug' And '$(Platform)' == 'ARM64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\arm64\debug\winrtact.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'Debug' And '$(Platform)' == 'ARM64'">
+  <ItemGroup Condition="'$(URFW_Configuration)' == 'Release' And '$(Platform)' == 'ARM64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\arm64\release\winrtact.dll" />
   </ItemGroup>
 


### PR DESCRIPTION
Update targets to allow custom build configurations to opt-inot RegFreeWinRT support by setting the URFW_Configuration property.

E.g. if you have a config called test:
    <Configurations>Debug;Release;Test</Configurations>

You’d add this below it:
    <URFW_Configuration Condition="'$(Configuration)' == 'Test'">Release</URFW_Configuration>
