### PR TITLE
Onboard abi to static analysis with msbuild

### DIFF
--- a/.pipelines/AbiWinRT-Job.yml
+++ b/.pipelines/AbiWinRT-Job.yml
@@ -16,10 +16,6 @@ jobs:
       ob_nugetPublishing_enabled: ${{ parameters.OfficialBuild }}
       PackageVersion: $(Build.BuildNumber)
       
-      ob_sdl_prefast_enabled: true
-      ob_sdl_prefast_runDuring: 'Build'
-      ob_sdl_checkCompliantCompilerWarnings: true
-
     steps:
 
     - task: NuGetToolInstaller@1

--- a/.pipelines/AbiWinRT-Job.yml
+++ b/.pipelines/AbiWinRT-Job.yml
@@ -15,6 +15,10 @@ jobs:
       ob_outputDirectory: '$(Build.SourcesDirectory)\out'
       ob_nugetPublishing_enabled: ${{ parameters.OfficialBuild }}
       PackageVersion: $(Build.BuildNumber)
+      
+      ob_sdl_prefast_enabled: true
+      ob_sdl_prefast_runDuring: 'Build'
+      ob_sdl_checkCompliantCompilerWarnings: true
 
     steps:
 

--- a/.pipelines/Build-Job.yml
+++ b/.pipelines/Build-Job.yml
@@ -36,19 +36,13 @@ jobs:
     displayName: Build Tools
     inputs:
       solution: '$(Build.SourcesDirectory)\src\tool\abi\abi.sln'
-      msbuildArgs: /p:XlangBuildVersion="$(Build.BuildNumber)" /binaryLogger:$(ob_outputDirectory)\abi\abi.binlog
+      msbuildArgs: >-
+        /p:XlangBuildVersion="$(Build.BuildNumber)"
+        /p:OutDir=$(ob_outputDirectory)\abi
+        /binaryLogger:$(ob_outputDirectory)\abi\abi.binlog
       platform: ${{ parameters.BuildPlatform }}
       configuration: ${{ parameters.BuildConfiguration }}
       clean: true      
-
-  - task: CopyFiles@2
-    displayName: Stage abi.*
-    inputs:
-      SourceFolder: $(Build.SourcesDirectory)\src\tool\abi\${{ parameters.BuildConfiguration }}
-      Contents: >-
-        abi.exe
-        abi.pdb
-      TargetFolder: $(ob_outputDirectory)\abi
 
   - task: onebranch.pipeline.signing@1
     displayName: '🔒 Onebranch Signing for abi.exe'

--- a/.pipelines/Build-Job.yml
+++ b/.pipelines/Build-Job.yml
@@ -44,7 +44,7 @@ jobs:
   - task: CopyFiles@2
     displayName: Stage abi.*
     inputs:
-      SourceFolder: $(Build.SourcesDirectory)\src\tool\abi\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}
+      SourceFolder: $(Build.SourcesDirectory)\src\tool\abi\${{ parameters.BuildConfiguration }}
       Contents: >-
         abi.exe
         abi.pdb

--- a/.pipelines/Build-Job.yml
+++ b/.pipelines/Build-Job.yml
@@ -32,27 +32,21 @@ jobs:
     inputs:
       versionSpec: 6.7
 
-  - task: CmdLine@2
+  - task: VSBuild@1
     displayName: Build Tools
-    inputs: 
-      script: >
-        if "%VSCMD_VER%"=="" (
-            pushd c:
-            call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" >nul 2>&1
-            popd
-        )
-
-        build.cmd -v -b ${{ parameters.BuildConfiguration }} -f --build-version "$(Build.BuildNumber)" abi make_abiwinrt_nupkg
-      workingDirectory: $(Build.SourcesDirectory)\src\scripts\windows
-      failOnStderr: true
+    inputs:
+      solution: '$(Build.SourcesDirectory)\src\abi\abi.sln'
+      msbuildArgs: /p:XlangBuildVersion="$(Build.BuildNumber)"
+      platform: ${{ parameters.BuildPlatform }}
+      configuration: ${{ parameters.BuildConfiguration }}
+      clean: true      
 
   - task: CopyFiles@2
     displayName: Stage abi.*
     inputs:
-      SourceFolder: $(Build.SourcesDirectory)\_build\Windows\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\tool\abi
+      SourceFolder: $(Build.SourcesDirectory)\src\tool\abi\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\tool\abi
       Contents: >-
         abi.exe
-
         abi.pdb
       TargetFolder: $(ob_outputDirectory)\abi
 

--- a/.pipelines/Build-Job.yml
+++ b/.pipelines/Build-Job.yml
@@ -35,7 +35,7 @@ jobs:
   - task: VSBuild@1
     displayName: Build Tools
     inputs:
-      solution: '$(Build.SourcesDirectory)\src\abi\abi.sln'
+      solution: '$(Build.SourcesDirectory)\src\tool\abi\abi.sln'
       msbuildArgs: /p:XlangBuildVersion="$(Build.BuildNumber)"
       platform: ${{ parameters.BuildPlatform }}
       configuration: ${{ parameters.BuildConfiguration }}

--- a/.pipelines/Build-Job.yml
+++ b/.pipelines/Build-Job.yml
@@ -38,7 +38,7 @@ jobs:
       solution: '$(Build.SourcesDirectory)\src\tool\abi\abi.sln'
       msbuildArgs: >-
         /p:XlangBuildVersion="$(Build.BuildNumber)"
-        /p:OutDir=$(ob_outputDirectory)\abi
+        /p:OutDir=$(ob_outputDirectory)\abi\
         /binaryLogger:$(ob_outputDirectory)\abi\abi.binlog
       platform: ${{ parameters.BuildPlatform }}
       configuration: ${{ parameters.BuildConfiguration }}

--- a/.pipelines/Build-Job.yml
+++ b/.pipelines/Build-Job.yml
@@ -44,7 +44,7 @@ jobs:
   - task: CopyFiles@2
     displayName: Stage abi.*
     inputs:
-      SourceFolder: $(Build.SourcesDirectory)\src\tool\abi\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\tool\abi
+      SourceFolder: $(Build.SourcesDirectory)\src\tool\abi\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}
       Contents: >-
         abi.exe
         abi.pdb

--- a/.pipelines/Build-Job.yml
+++ b/.pipelines/Build-Job.yml
@@ -36,7 +36,7 @@ jobs:
     displayName: Build Tools
     inputs:
       solution: '$(Build.SourcesDirectory)\src\tool\abi\abi.sln'
-      msbuildArgs: /p:XlangBuildVersion="$(Build.BuildNumber)"
+      msbuildArgs: /p:XlangBuildVersion="$(Build.BuildNumber)" /binaryLogger:$(ob_outputDirectory)\abi\abi.binlog
       platform: ${{ parameters.BuildPlatform }}
       configuration: ${{ parameters.BuildConfiguration }}
       clean: true      

--- a/.pipelines/Build-Job.yml
+++ b/.pipelines/Build-Job.yml
@@ -19,6 +19,10 @@ jobs:
     ob_outputDirectory: '$(Build.SourcesDirectory)\out'
     ob_artifactSuffix: ${{ parameters.BuildConfiguration }}_${{ parameters.BuildPlatform }}
     StagingFolder: $(ob_outputDirectory)
+      
+    ob_sdl_prefast_enabled: true
+    ob_sdl_prefast_runDuring: 'Build'
+    ob_sdl_checkCompliantCompilerWarnings: true
 
   steps:
 

--- a/.pipelines/MidlRT-Job.yml
+++ b/.pipelines/MidlRT-Job.yml
@@ -13,6 +13,10 @@ jobs:
       ob_outputDirectory: '$(Build.SourcesDirectory)\out'
       ob_nugetPublishing_enabled: ${{ parameters.OfficialBuild }}
       PackageVersion: $(Build.BuildNumber)
+      
+      ob_sdl_prefast_enabled: true
+      ob_sdl_prefast_runDuring: 'Build'
+      ob_sdl_checkCompliantCompilerWarnings: true
 
     steps:
 

--- a/.pipelines/MidlRT-Job.yml
+++ b/.pipelines/MidlRT-Job.yml
@@ -13,10 +13,6 @@ jobs:
       ob_outputDirectory: '$(Build.SourcesDirectory)\out'
       ob_nugetPublishing_enabled: ${{ parameters.OfficialBuild }}
       PackageVersion: $(Build.BuildNumber)
-      
-      ob_sdl_prefast_enabled: true
-      ob_sdl_prefast_runDuring: 'Build'
-      ob_sdl_checkCompliantCompilerWarnings: true
 
     steps:
 

--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -47,8 +47,6 @@ extends:
         compiled:
           enabled: true
         tsaEnabled: true
-      prefast:
-        enabled: true
     
     nugetPublishing:
       feeds:

--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -37,8 +37,18 @@ extends:
       enabled: false
     
     globalSdl:
+      isNativeCode: true
+      asyncSdl:
+        enabled: true
       tsa:
-        enabled: false
+        enabled: true
+        useDynamicRouting: true
+      codeql:
+        compiled:
+          enabled: true
+        tsaEnabled: true
+      prefast:
+        enabled: true
     
     nugetPublishing:
       feeds:

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -40,8 +40,6 @@ extends:
         useDynamicRouting: true
       sbom:
         enabled: true
-      prefast:
-        enabled: true
 
     stages:
     - stage: stage

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -34,9 +34,13 @@ extends:
       product: 'build_tools'
 
     globalSdl:
+      isNativeCode: true
       tsa:
         enabled: false
+        useDynamicRouting: true
       sbom:
+        enabled: true
+      prefast:
         enabled: true
 
     stages:

--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -6,13 +6,18 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <XlangBuildVersion Condition="'$(XlangBuildVersion)'==''">0.0.0</XlangBuildVersion>
+  </PropertyGroup>
+
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PrerocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ABIWINRT_VERSION_STRING="$(XlangBuildVersion)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 

--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -6,6 +6,10 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <SpectreMitigation>Spectre</SpectreMitigation>
+  </PropertyGroup>
+
   <PropertyGroup>
     <XlangBuildVersion Condition="'$(XlangBuildVersion)'==''">0.0.0</XlangBuildVersion>
   </PropertyGroup>
@@ -32,5 +36,8 @@
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
+    <Link>
+      <CETCompat>true</CETCompat>
+    </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -1,0 +1,31 @@
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Set common MSBuild properties and item metadata for tools -->
+
+  <PropertyGroup>
+    <PlatformToolset>v143</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PrerocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/tool/Directory.Build.Targets
+++ b/src/tool/Directory.Build.Targets
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="..\Directory.Build.targets" Condition="Exists('..\Directory.Build.targets')"/>
+
+  <PropertyGroup>
+    <BeforeClCompileTargets>
+      $(BeforeClCompileTargets);CollectStringLiteralInputs;GenerateStringLiteralFiles;
+    </BeforeClCompileTargets>
+    
+    <StringLiteralOutputHeader>$(IntermediateOutputPath)strings.h</StringLiteralOutputHeader>
+    <StringLiteralOutputCode>$(IntermediateOutputPath)strings.cpp</StringLiteralOutputCode>
+
+    <!-- TEMP TESTING -->
+    <StringLiteralInputFolder>$(MSBuildProjectDirectory)\strings</StringLiteralInputFolder>
+    <StringLiteralNamespace>abi</StringLiteralNamespace>
+  </PropertyGroup>
+
+  <!-- Generate string literals into strings.h/strings.cpp -->
+  <Target Name="CollectStringLiteralInputs"
+          BeforeTargets="GenerateStringLiteralFiles">
+    <ItemGroup>
+      <StringLiteralInputs Include="$(StringLiteralInputFolder)\*.h" />
+    </ItemGroup>
+    <!--<CreateItem Include="$(StringLiteralInputFolder)\*.h">
+      <Output TaskParameter="Include" ItemName="StringLiteralInputs"/>
+    </CreateItem>-->
+  </Target>
+  
+  <Target Name="GenerateStringLiteralFiles"
+          Inputs="@(StringLiteralInputs)"
+          Outputs="$(StringLiteralOutputHeader);$(StringLiteralOutputCode)"
+          DependsOnTargets="CollectStringLiteralInputs"
+          Condition="'@(StringLiteralInputs)' != ''">
+    <Error Text="Setting StringLiteralNamespace is required when supplying StringLiteralInputs"
+           Condition="'$(StringLiteralNamespace)' == ''" />
+
+    <ReadLinesFromFile File="%(StringLiteralInputs.FullPath)">
+      <Output TaskParameter="Lines" ItemName="StringLiteralLines"/>
+    </ReadLinesFromFile>
+
+    <WriteLinesToFile File="$(StringLiteralOutputHeader)"
+                      Overwrite="true"
+                      Lines="#pragma once\n\nnamespace {"/>
+  </Target>
+</Project>

--- a/src/tool/Directory.Build.Targets
+++ b/src/tool/Directory.Build.Targets
@@ -4,29 +4,22 @@
 
   <PropertyGroup>
     <BeforeClCompileTargets>
-      $(BeforeClCompileTargets);CollectStringLiteralInputs;GenerateStringLiteralFiles;
+      $(BeforeClCompileTargets);GenerateStringLiteralFiles;
     </BeforeClCompileTargets>
     
     <StringLiteralOutputHeader>$(IntermediateOutputPath)strings.h</StringLiteralOutputHeader>
     <StringLiteralOutputCode>$(IntermediateOutputPath)strings.cpp</StringLiteralOutputCode>
-
-    <!-- TEMP TESTING -->
-    <StringLiteralInputFolder>$(MSBuildProjectDirectory)\strings</StringLiteralInputFolder>
-    <StringLiteralNamespace>strings</StringLiteralNamespace>
   </PropertyGroup>
-
-  <!-- Generate string literals into strings.h/strings.cpp -->
-  <Target Name="CollectStringLiteralInputs"
-          BeforeTargets="GenerateStringLiteralFiles">
-    <ItemGroup>
-      <StringLiteralInputs Include="$(StringLiteralInputFolder)\*.h" />
-    </ItemGroup>
+  
+  <!-- Clean string strings.h/strings.cpp -->
+  <Target Name="CleanStringLiteralFiles"
+          BeforeTargets="Clean">
+    <Delete Files="$(StringLiteralOutputHeader);$(StringLiteralOutputCode)"/>
   </Target>
   
   <Target Name="GenerateStringLiteralFiles"
           Inputs="@(StringLiteralInputs)"
           Outputs="$(StringLiteralOutputHeader);$(StringLiteralOutputCode)"
-          DependsOnTargets="CollectStringLiteralInputs"
           Condition="'@(StringLiteralInputs)' != ''">
     <Error Text="Setting StringLiteralNamespace is required when supplying StringLiteralInputs"
            Condition="'$(StringLiteralNamespace)' == ''" />
@@ -36,7 +29,7 @@
                       Overwrite="true"
                       Lines="#pragma once
 
-namespace xlang::$(StringLiteralNamespace) {
+namespace $(StringLiteralNamespace) {
 "/>
     <!-- strings.h entries-->
     <WriteLinesToFile File="$(StringLiteralOutputHeader)"
@@ -48,22 +41,13 @@ namespace xlang::$(StringLiteralNamespace) {
     <!-- strings.cpp prologue-->
     <WriteLinesToFile File="$(StringLiteralOutputCode)"
                       Overwrite="true"
-                      Lines="namespace xlang::$(StringLiteralNamespace) {
+                      Lines="namespace $(StringLiteralNamespace) {
 
 "/>
-
     <!-- strings.cpp entries-->
     <ReadLinesFromFile File="%(StringLiteralInputs.FullPath)">
       <Output TaskParameter="Lines" ItemName="StringLiteralLines"/>
     </ReadLinesFromFile>
-
-    <!--<WriteLinesToFile File="$(StringLiteralOutputCode)"
-                      Lines="
-$([System.String]::Concat(
-'extern const char %(StringLiteralInputs.FileName)[] = R&quot;xyz%28',
-$([System.IO.File]::ReadAllText('%(StringLiteralInputs.FullPath)')),
-'%29xyz&quot;%3b'))"/>-->
-
     <WriteLinesToFile File="$(StringLiteralOutputCode)"
                       Lines="%0d
 extern const char %(StringLiteralInputs.FileName)[] = R&quot;xyz%28$([System.IO.File]::ReadAllText('%(StringLiteralInputs.FullPath)'))%29xyz&quot;%3b"/>

--- a/src/tool/Directory.Build.Targets
+++ b/src/tool/Directory.Build.Targets
@@ -12,7 +12,7 @@
 
     <!-- TEMP TESTING -->
     <StringLiteralInputFolder>$(MSBuildProjectDirectory)\strings</StringLiteralInputFolder>
-    <StringLiteralNamespace>abi</StringLiteralNamespace>
+    <StringLiteralNamespace>strings</StringLiteralNamespace>
   </PropertyGroup>
 
   <!-- Generate string literals into strings.h/strings.cpp -->
@@ -21,9 +21,6 @@
     <ItemGroup>
       <StringLiteralInputs Include="$(StringLiteralInputFolder)\*.h" />
     </ItemGroup>
-    <!--<CreateItem Include="$(StringLiteralInputFolder)\*.h">
-      <Output TaskParameter="Include" ItemName="StringLiteralInputs"/>
-    </CreateItem>-->
   </Target>
   
   <Target Name="GenerateStringLiteralFiles"
@@ -34,12 +31,40 @@
     <Error Text="Setting StringLiteralNamespace is required when supplying StringLiteralInputs"
            Condition="'$(StringLiteralNamespace)' == ''" />
 
+    <!-- strings.h prologue-->
+    <WriteLinesToFile File="$(StringLiteralOutputHeader)"
+                      Overwrite="true"
+                      Lines="#pragma once
+
+namespace xlang::$(StringLiteralNamespace) {
+"/>
+    <!-- strings.h entries-->
+    <WriteLinesToFile File="$(StringLiteralOutputHeader)"
+                      Lines="extern const char %(StringLiteralInputs.FileName)[]%3b"/>
+    <!-- strings.h epilogue-->
+    <WriteLinesToFile File="$(StringLiteralOutputHeader)"
+                      Lines="}"/>
+
+    <!-- strings.cpp prologue-->
+    <WriteLinesToFile File="$(StringLiteralOutputCode)"
+                      Overwrite="true"
+                      Lines="namespace xlang::$(StringLiteralNamespace) {
+
+"/>
+
+    <!-- strings.cpp entries-->
     <ReadLinesFromFile File="%(StringLiteralInputs.FullPath)">
       <Output TaskParameter="Lines" ItemName="StringLiteralLines"/>
     </ReadLinesFromFile>
 
-    <WriteLinesToFile File="$(StringLiteralOutputHeader)"
-                      Overwrite="true"
-                      Lines="#pragma once\n\nnamespace {"/>
+    <WriteLinesToFile File="$(StringLiteralOutputCode)"
+                      Lines="
+$([System.String]::Concat(
+'extern const char %(StringLiteralInputs.FileName)[] = R&quot;xyz%28',
+$([System.IO.File]::ReadAllText('%(StringLiteralInputs.FullPath)')),
+'%29xyz&quot;%3b'))"/>
+    <!-- strings.cpp epilogue-->
+    <WriteLinesToFile File="$(StringLiteralOutputCode)"
+                      Lines="}"/>
   </Target>
 </Project>

--- a/src/tool/Directory.Build.Targets
+++ b/src/tool/Directory.Build.Targets
@@ -24,6 +24,16 @@
     <Error Text="Setting StringLiteralNamespace is required when supplying StringLiteralInputs"
            Condition="'$(StringLiteralNamespace)' == ''" />
 
+    <ItemGroup>
+      <ClInclude Include="$(StringLiteralOutputHeader)"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ClCompile Include="$(StringLiteralOutputCode)">
+        <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      </ClCompile>
+    </ItemGroup>
+
     <!-- strings.h prologue-->
     <WriteLinesToFile File="$(StringLiteralOutputHeader)"
                       Overwrite="true"

--- a/src/tool/Directory.Build.Targets
+++ b/src/tool/Directory.Build.Targets
@@ -57,12 +57,16 @@ namespace xlang::$(StringLiteralNamespace) {
       <Output TaskParameter="Lines" ItemName="StringLiteralLines"/>
     </ReadLinesFromFile>
 
-    <WriteLinesToFile File="$(StringLiteralOutputCode)"
+    <!--<WriteLinesToFile File="$(StringLiteralOutputCode)"
                       Lines="
 $([System.String]::Concat(
 'extern const char %(StringLiteralInputs.FileName)[] = R&quot;xyz%28',
 $([System.IO.File]::ReadAllText('%(StringLiteralInputs.FullPath)')),
-'%29xyz&quot;%3b'))"/>
+'%29xyz&quot;%3b'))"/>-->
+
+    <WriteLinesToFile File="$(StringLiteralOutputCode)"
+                      Lines="%0d
+extern const char %(StringLiteralInputs.FileName)[] = R&quot;xyz%28$([System.IO.File]::ReadAllText('%(StringLiteralInputs.FullPath)'))%29xyz&quot;%3b"/>
     <!-- strings.cpp epilogue-->
     <WriteLinesToFile File="$(StringLiteralOutputCode)"
                       Lines="}"/>

--- a/src/tool/abi/abi.sln
+++ b/src/tool/abi/abi.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35913.81 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "abi", "abi.vcxproj", "{F025D704-CA01-4C93-9097-D0C7BF9CCA07}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F025D704-CA01-4C93-9097-D0C7BF9CCA07}.Debug|x64.ActiveCfg = Debug|x64
+		{F025D704-CA01-4C93-9097-D0C7BF9CCA07}.Debug|x64.Build.0 = Debug|x64
+		{F025D704-CA01-4C93-9097-D0C7BF9CCA07}.Debug|x86.ActiveCfg = Debug|Win32
+		{F025D704-CA01-4C93-9097-D0C7BF9CCA07}.Debug|x86.Build.0 = Debug|Win32
+		{F025D704-CA01-4C93-9097-D0C7BF9CCA07}.Release|x64.ActiveCfg = Release|x64
+		{F025D704-CA01-4C93-9097-D0C7BF9CCA07}.Release|x64.Build.0 = Release|x64
+		{F025D704-CA01-4C93-9097-D0C7BF9CCA07}.Release|x86.ActiveCfg = Release|Win32
+		{F025D704-CA01-4C93-9097-D0C7BF9CCA07}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8D5AC3F4-11A9-461A-B4D3-B19A6C7DD36A}
+	EndGlobalSection
+EndGlobal

--- a/src/tool/abi/abi.vcxproj
+++ b/src/tool/abi/abi.vcxproj
@@ -23,6 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{f025d704-ca01-4c93-9097-d0c7bf9cca07}</ProjectGuid>
     <RootNamespace>abi</RootNamespace>
+    <StringLiteralNamespace>xlang::strings</StringLiteralNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -155,6 +156,9 @@
     <ClInclude Include="type_banners.h" />
     <ClInclude Include="type_names.h" />
     <ClInclude Include="versioning.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <StringLiteralInputs Include="strings\*.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/tool/abi/abi.vcxproj
+++ b/src/tool/abi/abi.vcxproj
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{f025d704-ca01-4c93-9097-d0c7bf9cca07}</ProjectGuid>
+    <RootNamespace>abi</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\library;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\library;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\library;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\library;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="abi_writer.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="metadata_cache.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="types.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="abi_writer.h" />
+    <ClInclude Include="code_writers.h" />
+    <ClInclude Include="common.h" />
+    <ClInclude Include="metadata_cache.h" />
+    <ClInclude Include="namespace_iterator.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="strings\constexpr_definitions.h" />
+    <ClInclude Include="strings\constexpr_end_definitions.h" />
+    <ClInclude Include="strings\deprecated_header_end.h" />
+    <ClInclude Include="strings\deprecated_header_start.h" />
+    <ClInclude Include="strings\enum_class.h" />
+    <ClInclude Include="strings\file_header.h" />
+    <ClInclude Include="strings\include_guard_end.h" />
+    <ClInclude Include="strings\include_guard_start.h" />
+    <ClInclude Include="strings\ns_prefix_always.h" />
+    <ClInclude Include="strings\ns_prefix_definitions.h" />
+    <ClInclude Include="strings\ns_prefix_never.h" />
+    <ClInclude Include="strings\ns_prefix_optional.h" />
+    <ClInclude Include="strings\optional_ns_prefix_definitions.h" />
+    <ClInclude Include="strings\optional_ns_prefix_end_definitions.h" />
+    <ClInclude Include="types.h" />
+    <ClInclude Include="type_banners.h" />
+    <ClInclude Include="type_names.h" />
+    <ClInclude Include="versioning.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/tool/abi/abi.vcxproj
+++ b/src/tool/abi/abi.vcxproj
@@ -76,6 +76,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>windowsapp.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -92,6 +93,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>windowsapp.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -104,6 +106,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>windowsapp.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -120,6 +123,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>windowsapp.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/tool/abi/abi.vcxproj.filters
+++ b/src/tool/abi/abi.vcxproj.filters
@@ -13,6 +13,9 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Header Files\strings">
+      <UniqueIdentifier>{f7c8e852-805c-4f77-8f33-800c9313304b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="abi_writer.cpp">
@@ -61,6 +64,48 @@
     </ClInclude>
     <ClInclude Include="versioning.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\constexpr_definitions.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\constexpr_end_definitions.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\deprecated_header_end.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\deprecated_header_start.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\include_guard_end.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\include_guard_start.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\enum_class.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\file_header.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\ns_prefix_always.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\ns_prefix_definitions.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\ns_prefix_never.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\ns_prefix_optional.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\optional_ns_prefix_definitions.h">
+      <Filter>Header Files\strings</Filter>
+    </ClInclude>
+    <ClInclude Include="strings\optional_ns_prefix_end_definitions.h">
+      <Filter>Header Files\strings</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/tool/abi/abi.vcxproj.filters
+++ b/src/tool/abi/abi.vcxproj.filters
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="abi_writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="metadata_cache.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="types.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="abi_writer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="code_writers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="metadata_cache.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="namespace_iterator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="type_banners.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="type_names.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="versioning.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I'm onboarding the abi package to get static analysis, prefast, TSA bug filing, and all that goodness.

Problem is, it seems like a major pain to set up prefast to run on a non-msbuild workflow (e.g. cmake) and then merge all the output sarif files into a way that our other pipeline infrastructure can digest it.

So, I decided to reverse-engineer all the cmake build options we are using to create an msbuild version.

Bonus, I've offloaded the string literal processing (scrape a folder for *.h files and turn that into strings.h/strings.cpp) into an msbuild target. This is nice as it removes the need for a separate "prebuilt" project. (Technically, I probably could have simplified the target by using a Powershell script to do the scraping, but the custom target would have remained).