### PR TITLE
Central package management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.VCRTForwarders.140" Version="1.0.5" />
+  </ItemGroup>
+</Project>

--- a/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/EmbeddedManifestManagedTest.csproj
+++ b/src/UndockedRegFreeWinRT/EmbeddedManifestManagedTest/EmbeddedManifestManagedTest.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.5" />
+    <PackageReference Include="Microsoft.VCRTForwarders.140" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTManagedTest/UndockedRegFreeWinRTManagedTest.csproj
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRTManagedTest/UndockedRegFreeWinRTManagedTest.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.5" />
+    <PackageReference Include="Microsoft.VCRTForwarders.140" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request introduces the NuGet [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management) feature to streamline dependency management. Key benefits and changes include:

Centralized Version Management: All NuGet package versions are now managed centrally in the Directory.Packages.props file. This ensures consistency across all projects in the repository.

Simplified Project Files: The individual project files are simplified, as they no longer need to specify version numbers for NuGet packages. This change reduces duplication and the potential for version conflicts.

Ease of Updating Dependencies: Updating a package version is now a matter of changing it in one place, making the process of keeping dependencies up-to-date more straightforward and less error-prone.