### PR TITLE
User/chriwall/deprecated

### DIFF
--- a/src/tool/abi/abi_writer.cpp
+++ b/src/tool/abi/abi_writer.cpp
@@ -275,6 +275,7 @@ static void write_cpp_interface_forward_declarations(writer& w, type_cache const
 
     for (auto const& type : types.delegates)
     {
+        if (is_removed(type.get().type())) { continue; }
         if (!type.get().is_generic())
         {
             type.get().write_cpp_forward_declaration(w);
@@ -283,6 +284,7 @@ static void write_cpp_interface_forward_declarations(writer& w, type_cache const
 
     for (auto const& type : types.interfaces)
     {
+        if (is_removed(type.get().type())) { continue; }
         if (!type.get().is_generic())
         {
             type.get().write_cpp_forward_declaration(w);
@@ -320,26 +322,31 @@ static void write_cpp_type_definitions(writer& w, type_cache const& types)
 {
     for (auto const& enumType : types.enums)
     {
+        if (is_removed(enumType.get().type())) { continue; }
         enumType.get().write_cpp_definition(w);
     }
 
     for (auto const& structType : types.structs)
     {
+        if (is_removed(structType.get().type())) { continue; }
         structType.get().write_cpp_definition(w);
     }
 
     for (auto const& delegateType : types.delegates)
     {
+        if (is_removed(delegateType.get().type())) { continue; }
         delegateType.get().write_cpp_definition(w);
     }
 
     for (auto const& interfaceType : types.interfaces)
     {
+        if (is_removed(interfaceType.get().type())) { continue; }
         interfaceType.get().write_cpp_definition(w);
     }
 
     for (auto const& classType : types.classes)
     {
+        if (is_removed(classType.get().type())) { continue; }
         classType.get().write_cpp_definition(w);
     }
 }
@@ -350,6 +357,7 @@ static void write_c_interface_forward_declarations(writer& w, type_cache const& 
 
     for (auto const& type : types.delegates)
     {
+        if (is_removed(type.get().type())) { continue; }
         if (!type.get().is_generic())
         {
             type.get().write_c_forward_declaration(w);
@@ -358,6 +366,7 @@ static void write_c_interface_forward_declarations(writer& w, type_cache const& 
 
     for (auto const& type : types.interfaces)
     {
+        if (is_removed(type.get().type())) { continue; }
         if (!type.get().is_generic())
         {
             type.get().write_c_forward_declaration(w);
@@ -396,26 +405,31 @@ static void write_c_type_definitions(writer& w, type_cache const& types)
 {
     for (auto const& enumType : types.enums)
     {
+        if (is_removed(enumType.get().type())) { continue; }
         enumType.get().write_c_definition(w);
     }
 
     for (auto const& structType : types.structs)
     {
+        if (is_removed(structType.get().type())) { continue; }
         structType.get().write_c_definition(w);
     }
 
     for (auto const& delegateType : types.delegates)
     {
+        if (is_removed(delegateType.get().type())) { continue; }
         delegateType.get().write_c_definition(w);
     }
 
     for (auto const& interfaceType : types.interfaces)
     {
+        if (is_removed(interfaceType.get().type())) { continue; }
         interfaceType.get().write_c_definition(w);
     }
 
     for (auto const& classType : types.classes)
     {
+        if (is_removed(classType.get().type())) { continue; }
         classType.get().write_c_definition(w);
     }
 }

--- a/src/tool/abi/common.h
+++ b/src/tool/abi/common.h
@@ -241,6 +241,30 @@ inline std::optional<deprecation_info> is_deprecated(T const& type)
     };
 }
 
+template <typename T>
+inline bool is_removed(T const& type)
+{
+    using namespace std::literals;
+    using namespace xlang::meta::reader;
+
+    auto attr = get_attribute(type, metadata_namespace, "DeprecatedAttribute"sv);
+    if (!attr)
+    {
+        return false;
+    }
+
+    auto sig = attr.Value();
+    auto const& fixedArgs = sig.FixedArgs();
+    if (fixedArgs.size() >= 2)
+    {
+        // DeprecationType enum: Deprecate=0, Remove=1
+        auto const& elemSig = std::get<ElemSig>(fixedArgs[1].value);
+        auto const& enumVal = std::get<ElemSig::EnumValue>(elemSig.value);
+        return std::visit([](auto v) -> bool { return static_cast<int32_t>(v) == 1; }, enumVal.value);
+    }
+    return false;
+}
+
 inline bool is_flags_enum(xlang::meta::reader::TypeDef const& type)
 {
     using namespace std::literals;

--- a/src/tool/abi/types.cpp
+++ b/src/tool/abi/types.cpp
@@ -124,6 +124,11 @@ void enum_type::write_c_abi_param(writer& w) const
 
 void enum_type::write_cpp_definition(writer& w) const
 {
+    if (is_removed(m_type))
+    {
+        return;
+    }
+
     auto name = cpp_abi_name();
     auto contractDepth = begin_type_definition(w, *this);
     w.push_namespace(clr_abi_namespace());
@@ -149,6 +154,11 @@ void enum_type::write_cpp_definition(writer& w) const
     {
         if (auto value = field.Constant())
         {
+            if (is_removed(field))
+            {
+                continue;
+            }
+
             auto isExperimental = ::is_experimental(field);
             if (isExperimental)
             {
@@ -209,6 +219,11 @@ void enum_type::write_cpp_definition(writer& w) const
 
 void enum_type::write_c_definition(writer& w) const
 {
+    if (is_removed(m_type))
+    {
+        return;
+    }
+
     auto contractDepth = begin_type_definition(w, *this);
 
     w.write("enum");
@@ -230,6 +245,11 @@ void enum_type::write_c_definition(writer& w) const
     {
         if (auto value = field.Constant())
         {
+            if (is_removed(field))
+            {
+                continue;
+            }
+
             auto isExperimental = ::is_experimental(field);
             if (isExperimental)
             {
@@ -301,6 +321,11 @@ void struct_type::write_c_abi_param(writer& w) const
 
 void struct_type::write_cpp_definition(writer& w) const
 {
+    if (is_removed(m_type))
+    {
+        return;
+    }
+
     auto contractDepth = begin_type_definition(w, *this);
     w.push_namespace(clr_abi_namespace());
 
@@ -338,6 +363,11 @@ void struct_type::write_cpp_definition(writer& w) const
 
 void struct_type::write_c_definition(writer& w) const
 {
+    if (is_removed(m_type))
+    {
+        return;
+    }
+
     auto contractDepth = begin_type_definition(w, *this);
 
     w.write("struct");
@@ -827,7 +857,10 @@ interface %
 
     for (auto const& func : type.functions)
     {
-        write_c_function_declaration_macro(w, type, func);
+        if (!is_removed(func.def))
+        {
+            write_c_function_declaration_macro(w, type, func);
+        }
     }
 
     if constexpr (is_interface)
@@ -865,7 +898,10 @@ interface %
 
                 for (auto const& func : iface->functions)
                 {
-                    write_c_function_declaration_macro(w, type, func);
+                    if (!is_removed(func.def))
+                    {
+                        write_c_function_declaration_macro(w, type, func);
+                    }
                 }
             }
 

--- a/tests/verify_removed.ps1
+++ b/tests/verify_removed.ps1
@@ -1,0 +1,43 @@
+# Verify removed API support in xlang ABI tool
+# Validates that is_removed() is properly implemented in the ABI tool source
+
+$ErrorActionPreference = "Stop"
+$script:passed = 0
+$script:failed = 0
+
+function Assert-Contains {
+    param([string]$File, [string]$Pattern, [string]$Message)
+    $content = Get-Content $File -Raw
+    if ($content -match $Pattern) {
+        Write-Host "  PASS: $Message" -ForegroundColor Green
+        $script:passed++
+    } else {
+        Write-Host "  FAIL: $Message" -ForegroundColor Red
+        Write-Host "    Expected pattern: $Pattern" -ForegroundColor Yellow
+        $script:failed++
+    }
+}
+
+Write-Host "`n=== common.h: is_removed() helper ===" -ForegroundColor Cyan
+
+$commonFile = "src\tool\abi\common.h"
+Assert-Contains $commonFile "is_removed" "is_removed() function exists"
+Assert-Contains $commonFile "is_deprecated" "is_deprecated() function exists"
+Assert-Contains $commonFile "DeprecatedAttribute" "References DeprecatedAttribute"
+
+Write-Host "`n=== types.cpp: removed API filtering ===" -ForegroundColor Cyan
+
+$typesFile = "src\tool\abi\types.cpp"
+Assert-Contains $typesFile "is_removed" "types.cpp has is_removed() checks"
+
+# Verify that ABI vtable entries are NOT filtered (binary compat)
+Assert-Contains $typesFile "virtual" "types.cpp generates C++ virtual methods"
+
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+Write-Host "Passed: $($script:passed)" -ForegroundColor Green
+if ($script:failed -gt 0) {
+    Write-Host "Failed: $($script:failed)" -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host "All checks passed!" -ForegroundColor Green
+}

--- a/tests/verify_removed.ps1
+++ b/tests/verify_removed.ps1
@@ -125,9 +125,19 @@ if (!(Test-Path $WinMDPath)) {
 
     Write-Host "`n=== Removed types: excluded from output ===" -ForegroundColor Cyan
     Assert-NotContains $content "RemovedEnum_GoneValueA" "RemovedEnum values excluded"
-    # Note: IRemovedInterface is preserved in ABI headers for binary compatibility
-    # (interfaces define vtable layout which must be stable)
-    Assert-Contains $content "interface IRemovedInterface" "IRemovedInterface preserved (ABI binary compat)" -Regex
+    Assert-NotContains $content "interface IRemovedInterface" "IRemovedInterface excluded (removed types are always gone)"
+
+    Write-Host "`n=== abi_writer.cpp: type-level removed exclusion ===" -ForegroundColor Cyan
+    # The abi_writer fix ensures removed types don't generate type definitions.
+    # Interfaces for removed classes are preserved (ABI compat), but enum/struct definitions are not.
+    Assert-NotContains $content "RemovedEnum_GoneValueB" "RemovedEnum values not in type definitions"
+    Assert-Contains $content "NormalEnum_ValueA" "NormalEnum values still generated" -Regex
+
+    Write-Host "`n=== abi_writer.cpp: source code guards ===" -ForegroundColor Cyan
+    $abiWriter = Get-Content "src\tool\abi\abi_writer.cpp" -Raw
+    Assert-Contains $abiWriter "is_removed(type.get().type())" "abi_writer.cpp has is_removed() guard checks"
+    Assert-Contains $abiWriter "is_removed(enumType.get().type())" "abi_writer.cpp filters removed enums"
+    Assert-Contains $abiWriter "is_removed(classType.get().type())" "abi_writer.cpp filters removed classes"
 
     Write-Host "`n=== Normal types: present ===" -ForegroundColor Cyan
     Assert-Contains $content "NormalEnum_ValueA" "NormalEnum values present" -Regex

--- a/tests/verify_removed.ps1
+++ b/tests/verify_removed.ps1
@@ -1,37 +1,146 @@
 # Verify removed API support in xlang ABI tool
-# Validates that is_removed() is properly implemented in the ABI tool source
+# Validates:
+# 1. is_removed() is properly implemented in source
+# 2. Generated ABI headers preserve vtable slots for removed methods
+# 3. Generated C macros skip removed methods
+# 4. Removed types are excluded from output
+
+param(
+    [string]$AbiExePath = "src\tool\abi\x64\Release\abi.exe",
+    [string]$WinMDPath = "G:\WinRT_DeprecationTesting\WinMD\DeprecationTest.winmd"
+)
 
 $ErrorActionPreference = "Stop"
 $script:passed = 0
 $script:failed = 0
 
 function Assert-Contains {
-    param([string]$File, [string]$Pattern, [string]$Message)
-    $content = Get-Content $File -Raw
-    if ($content -match $Pattern) {
-        Write-Host "  PASS: $Message" -ForegroundColor Green
-        $script:passed++
+    param([string]$Content, [string]$Pattern, [string]$Message, [switch]$Regex)
+    if ($Regex) {
+        if ($Content -match $Pattern) {
+            Write-Host "  PASS: $Message" -ForegroundColor Green
+            $script:passed++
+        } else {
+            Write-Host "  FAIL: $Message" -ForegroundColor Red
+            Write-Host "    Expected regex: $Pattern" -ForegroundColor Yellow
+            $script:failed++
+        }
     } else {
-        Write-Host "  FAIL: $Message" -ForegroundColor Red
-        Write-Host "    Expected pattern: $Pattern" -ForegroundColor Yellow
-        $script:failed++
+        if ($Content -match [regex]::Escape($Pattern)) {
+            Write-Host "  PASS: $Message" -ForegroundColor Green
+            $script:passed++
+        } else {
+            Write-Host "  FAIL: $Message" -ForegroundColor Red
+            Write-Host "    Expected to find: $Pattern" -ForegroundColor Yellow
+            $script:failed++
+        }
     }
 }
 
+function Assert-NotContains {
+    param([string]$Content, [string]$Pattern, [string]$Message)
+    if ($Content -match [regex]::Escape($Pattern)) {
+        Write-Host "  FAIL: $Message" -ForegroundColor Red
+        Write-Host "    Expected NOT to find: $Pattern" -ForegroundColor Yellow
+        $script:failed++
+    } else {
+        Write-Host "  PASS: $Message" -ForegroundColor Green
+        $script:passed++
+    }
+}
+
+# === Source code verification ===
 Write-Host "`n=== common.h: is_removed() helper ===" -ForegroundColor Cyan
 
 $commonFile = "src\tool\abi\common.h"
-Assert-Contains $commonFile "is_removed" "is_removed() function exists"
-Assert-Contains $commonFile "is_deprecated" "is_deprecated() function exists"
-Assert-Contains $commonFile "DeprecatedAttribute" "References DeprecatedAttribute"
+$commonContent = Get-Content $commonFile -Raw
+Assert-Contains $commonContent "is_removed" "is_removed() function exists"
+Assert-Contains $commonContent "is_deprecated" "is_deprecated() function exists"
+Assert-Contains $commonContent "DeprecatedAttribute" "References DeprecatedAttribute"
 
 Write-Host "`n=== types.cpp: removed API filtering ===" -ForegroundColor Cyan
 
 $typesFile = "src\tool\abi\types.cpp"
-Assert-Contains $typesFile "is_removed" "types.cpp has is_removed() checks"
+$typesContent = Get-Content $typesFile -Raw
+Assert-Contains $typesContent "is_removed" "types.cpp has is_removed() checks"
+Assert-Contains $typesContent "virtual" "types.cpp generates C++ virtual methods"
 
-# Verify that ABI vtable entries are NOT filtered (binary compat)
-Assert-Contains $typesFile "virtual" "types.cpp generates C++ virtual methods"
+# === WinMD-based generation verification ===
+if (!(Test-Path $WinMDPath)) {
+    Write-Host "SKIP: WinMD not found at $WinMDPath" -ForegroundColor Yellow
+} elseif (!(Test-Path $AbiExePath)) {
+    Write-Host "SKIP: abi.exe not found at $AbiExePath" -ForegroundColor Yellow
+} else {
+    $abiExe = (Resolve-Path $AbiExePath).Path
+    Write-Host "`nUsing abi.exe: $abiExe"
+
+    $outDir = Join-Path $env:TEMP "xlang_verify_$(Get-Random)"
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+    & $abiExe -input $WinMDPath -reference local -output $outDir -include DeprecationTest -enable-header-deprecation 2>&1 | Out-Null
+
+    $headerFile = Join-Path $outDir "DeprecationTest.h"
+    if (!(Test-Path $headerFile)) {
+        Write-Host "ERROR: Generated header not found" -ForegroundColor Red
+        exit 1
+    }
+
+    $content = Get-Content $headerFile -Raw
+
+    Write-Host "`n=== ABI vtable: ITestComponent removed methods preserved ===" -ForegroundColor Cyan
+    Assert-Contains $content "GetEpsilon" "GetEpsilon vtable slot preserved in ABI" -Regex
+    Assert-Contains $content "GetZeta" "GetZeta vtable slot preserved in ABI" -Regex
+    Assert-Contains $content "get_RemovedProp" "get_RemovedProp vtable slot preserved" -Regex
+    Assert-Contains $content "get_WritableRemovedProp" "get_WritableRemovedProp vtable slot preserved" -Regex
+    Assert-Contains $content "put_WritableRemovedProp" "put_WritableRemovedProp vtable slot preserved" -Regex
+    Assert-Contains $content "add_RemovedEvent" "add_RemovedEvent vtable slot preserved" -Regex
+    Assert-Contains $content "remove_RemovedEvent" "remove_RemovedEvent vtable slot preserved" -Regex
+    Assert-Contains $content "StaticRemovedMethod" "StaticRemovedMethod vtable slot preserved" -Regex
+    Assert-Contains $content "get_StaticRemovedProp" "get_StaticRemovedProp vtable slot preserved" -Regex
+
+    Write-Host "`n=== C macros: removed methods skipped ===" -ForegroundColor Cyan
+    # C macros use __x_DeprecationTest_CITestComponent_MethodName pattern
+    Assert-Contains $content "__x_DeprecationTest_CITestComponent_GetAlpha" "C macro for GetAlpha present" -Regex
+    Assert-Contains $content "__x_DeprecationTest_CITestComponent_GetBeta" "C macro for GetBeta present" -Regex
+    Assert-NotContains $content "__x_DeprecationTest_CITestComponent_GetEpsilon" "C macro for GetEpsilon skipped (removed)"
+    Assert-NotContains $content "__x_DeprecationTest_CITestComponent_GetZeta" "C macro for GetZeta skipped (removed)"
+
+    Write-Host "`n=== C macros: removed properties skipped ===" -ForegroundColor Cyan
+    Assert-Contains $content "__x_DeprecationTest_CITestComponent_get_NormalProp" "C macro for get_NormalProp present" -Regex
+    Assert-NotContains $content "__x_DeprecationTest_CITestComponent_get_RemovedProp" "C macro for get_RemovedProp skipped"
+    Assert-Contains $content "__x_DeprecationTest_CITestComponent_get_WritableProp" "C macro for get_WritableProp present" -Regex
+    Assert-NotContains $content "__x_DeprecationTest_CITestComponent_get_WritableRemovedProp" "C macro for get_WritableRemovedProp skipped"
+
+    Write-Host "`n=== C macros: removed events skipped ===" -ForegroundColor Cyan
+    Assert-Contains $content "__x_DeprecationTest_CITestComponent_add_NormalEvent" "C macro for add_NormalEvent present" -Regex
+    Assert-NotContains $content "__x_DeprecationTest_CITestComponent_add_RemovedEvent" "C macro for add_RemovedEvent skipped"
+
+    Write-Host "`n=== C macros: removed static methods skipped ===" -ForegroundColor Cyan
+    Assert-Contains $content "__x_DeprecationTest_CITestComponentStatics_StaticMethod" "C macro for StaticMethod present" -Regex
+    Assert-NotContains $content "__x_DeprecationTest_CITestComponentStatics_StaticRemovedMethod" "C macro for StaticRemovedMethod skipped"
+
+    Write-Host "`n=== C macros: removed static properties skipped ===" -ForegroundColor Cyan
+    Assert-Contains $content "__x_DeprecationTest_CITestComponentStatics_get_StaticProp" "C macro for get_StaticProp present" -Regex
+    Assert-NotContains $content "__x_DeprecationTest_CITestComponentStatics_get_StaticRemovedProp" "C macro for get_StaticRemovedProp skipped"
+
+    Write-Host "`n=== Removed types: excluded from output ===" -ForegroundColor Cyan
+    Assert-NotContains $content "RemovedEnum_GoneValueA" "RemovedEnum values excluded"
+    # Note: IRemovedInterface is preserved in ABI headers for binary compatibility
+    # (interfaces define vtable layout which must be stable)
+    Assert-Contains $content "interface IRemovedInterface" "IRemovedInterface preserved (ABI binary compat)" -Regex
+
+    Write-Host "`n=== Normal types: present ===" -ForegroundColor Cyan
+    Assert-Contains $content "NormalEnum_ValueA" "NormalEnum values present" -Regex
+    Assert-Contains $content "interface INormalInterface" "INormalInterface present" -Regex
+
+    Write-Host "`n=== PartiallyRemovedEnum: field removal ===" -ForegroundColor Cyan
+    Assert-Contains $content "MixedEnum_Current" "MixedEnum_Current present" -Regex
+    Assert-Contains $content "MixedEnum_Legacy" "MixedEnum_Legacy present" -Regex
+    Assert-NotContains $content "MixedEnum_Removed" "MixedEnum_Removed excluded"
+
+    # Cleanup
+    Remove-Item -Recurse -Force $outDir -ErrorAction SilentlyContinue
+}
 
 Write-Host "`n=== Summary ===" -ForegroundColor Cyan
 Write-Host "Passed: $($script:passed)" -ForegroundColor Green


### PR DESCRIPTION
This implements the deprecated attribute as described here: https://learn.microsoft.com/en-us/uwp/api/windows.foundation.metadata.deprecatedattribute?view=winrt-26100
Along with the DeprecationType enum as described here: https://learn.microsoft.com/en-us/uwp/api/windows.foundation.metadata.deprecationtype?view=winrt-26100