### PR TITLE
Fix reference handling in Microsoft.Windows.AbiWinRT.targets

### DIFF
--- a/src/package/abi/Microsoft.Windows.AbiWinRT.targets
+++ b/src/package/abi/Microsoft.Windows.AbiWinRT.targets
@@ -132,13 +132,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <_AbiWinRTInputs Include="@(AbiWinRTProjectWinMDReferences)"/>
             <_AbiWinRTInputs Include="@(AbiWinRTPlatformWinMDReferences)"/>
 
-            <_AbiWinRTRefs Remove="@(_AbiWinRTRefRefs)"/>
+            <!-- Fix: '_AbiWinRTRefs' is used by the property group below for -ref arguments, the original '_AbiWinRTRefRefs' was never referenced. -->
+            <_AbiWinRTRefs Remove="@(_AbiWinRTRefs)"/>
             <_AbiWinRTRefs Include="@(AbiWinRTPlatformWinMDReferences)"/>
         </ItemGroup>
         <PropertyGroup>
             <_AbiWinRTParameters>$(AbiWinRTCommandVerbosity) $(AbiWinRTParameters) $(AbiWinRTCommandEnsureSDKHeaderCompat) $(AbiWinRTCommandAddAbiNamespacePrefix)</_AbiWinRTParameters>
             <_AbiWinRTParameters>$(_AbiWinRTParameters) @(_AbiWinRTInputs->'-in &quot;%(WinMDPath)&quot;', '&#x0d;&#x0a;')</_AbiWinRTParameters>
-            <_AbiWinRTParameters>$(_AbiWinRTParameters) @(_AbiWinRTRefRefs->'-ref &quot;%(WinMDPath)&quot;', '&#x0d;&#x0a;')</_AbiWinRTParameters>
+            <_AbiWinRTParameters>$(_AbiWinRTParameters) @(_AbiWinRTRefs->'-ref &quot;%(WinMDPath)&quot;', '&#x0d;&#x0a;')</_AbiWinRTParameters>
             <_AbiWinRTParameters>$(_AbiWinRTParameters) -out &quot;$(GeneratedFilesDir).&quot;</_AbiWinRTParameters>
         </PropertyGroup>
         <!-- Always write the AbiWinRT_projection.rsp file when the target runs, because the file is used as the output of this target. -->

--- a/src/package/abi/Microsoft.Windows.AbiWinRT.targets
+++ b/src/package/abi/Microsoft.Windows.AbiWinRT.targets
@@ -128,8 +128,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         </PropertyGroup>
         <ItemGroup>
             <_AbiWinRTInputs Remove="@(_AbiWinRTRefInputs)"/>
-            <_AbiWinRTInputs Include="@(AbiWinRTDirectWinMDReferences)"/>
-            <_AbiWinRTInputs Include="@(AbiWinRTProjectWinMDReferences)"/>
+            <_AbiWinRTInputs Include="@(AbiWinRTDirectWinMDReferences)" Condition="'$(AbiWinRTEnableDirectProjection)' != 'false'" />
+            <_AbiWinRTInputs Include="@(AbiWinRTProjectWinMDReferences)" Condition="'$(AbiWinRTEnableProjectProjection)' != 'false'" />
             <_AbiWinRTInputs Include="@(AbiWinRTPlatformWinMDReferences)" Condition="'$(AbiWinRTEnablePlatformProjection)' != 'false'" />
 
 

--- a/src/package/abi/Microsoft.Windows.AbiWinRT.targets
+++ b/src/package/abi/Microsoft.Windows.AbiWinRT.targets
@@ -130,7 +130,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <_AbiWinRTInputs Remove="@(_AbiWinRTRefInputs)"/>
             <_AbiWinRTInputs Include="@(AbiWinRTDirectWinMDReferences)"/>
             <_AbiWinRTInputs Include="@(AbiWinRTProjectWinMDReferences)"/>
-            <_AbiWinRTInputs Include="@(AbiWinRTPlatformWinMDReferences)"/>
+            <_AbiWinRTInputs Include="@(AbiWinRTPlatformWinMDReferences)" Condition="'$(AbiWinRTEnablePlatformProjection)' != 'false'" />
+
 
             <!-- Fix: '_AbiWinRTRefs' is used by the property group below for -ref arguments, the original '_AbiWinRTRefRefs' was never referenced. -->
             <_AbiWinRTRefs Remove="@(_AbiWinRTRefs)"/>


### PR DESCRIPTION
Updated '_AbiWinRTRefs' to remove the correct reference and adjusted parameters for WinMD paths.